### PR TITLE
Close mobile menu when clicking bottom nav items

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -635,6 +635,7 @@ export default function Layout({ children }: LayoutProps) {
             <Link
               key={item.path}
               to={item.path}
+              onClick={() => setMobileMenuOpen(false)}
               className={isActive(item.path) ? 'bottom-nav-item-active' : 'bottom-nav-item'}
             >
               <item.icon />


### PR DESCRIPTION
## Summary

- Add `onClick` handler to bottom navigation links to close mobile hamburger menu
- Fixes menu staying open when navigating via tabbar