### PR TITLE
fix(Support): prevent infinite recursion in clearCreateAttachment and…

### DIFF
--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -184,7 +184,7 @@ export default function Support() {
       URL.revokeObjectURL(createPreviewRef.current);
       createPreviewRef.current = null;
     }
-    clearCreateAttachment();
+    setCreateAttachment(null);
   };
 
   const clearReplyAttachment = () => {
@@ -192,7 +192,7 @@ export default function Support() {
       URL.revokeObjectURL(replyPreviewRef.current);
       replyPreviewRef.current = null;
     }
-    clearReplyAttachment();
+    setReplyAttachment(null);
   };
 
   // Get support configuration


### PR DESCRIPTION
… clearReplyAttachment

clearCreateAttachment and clearReplyAttachment were calling themselves recursively instead of clearing state via setCreateAttachment/setReplyAttachment, causing 'Maximum call stack size exceeded' when removing media attachments.