### PR TITLE
feat: UI офлайн конверсий Яндекс.Метрики + fireAnalyticsEvent хелпер

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,5 @@
 import apiClient from './client';
+import { getYandexCid } from '../hooks/useAnalyticsCounters';
 import type {
   AuthResponse,
   LinkCallbackResponse,
@@ -22,6 +23,7 @@ export const authApi = {
       init_data: initData,
       campaign_slug: campaignSlug || undefined,
       referral_code: referralCode || undefined,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -43,6 +45,7 @@ export const authApi = {
       ...data,
       campaign_slug: campaignSlug || undefined,
       referral_code: referralCode || undefined,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -56,6 +59,7 @@ export const authApi = {
       id_token: idToken,
       campaign_slug: campaignSlug || undefined,
       referral_code: referralCode || undefined,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -71,6 +75,7 @@ export const authApi = {
       password,
       campaign_slug: campaignSlug || undefined,
       referral_code: referralCode || undefined,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -87,6 +92,7 @@ export const authApi = {
     const response = await apiClient.post('/cabinet/auth/email/register', {
       email,
       password,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -100,7 +106,7 @@ export const authApi = {
   }): Promise<RegisterResponse> => {
     const response = await apiClient.post<RegisterResponse>(
       '/cabinet/auth/email/register/standalone',
-      data,
+      { ...data, yandex_cid: getYandexCid() || undefined },
     );
     return response.data;
   },

--- a/src/api/branding.ts
+++ b/src/api/branding.ts
@@ -38,10 +38,20 @@ export interface TelegramWidgetConfig {
   oidc_client_id: string;
 }
 
+export interface OfflineConvGoal {
+  name: string;
+  event_id: string;
+  dedup: string;
+}
+
 export interface AnalyticsCounters {
   yandex_metrika_id: string;
   google_ads_id: string;
   google_ads_label: string;
+  offline_conv_enabled?: boolean;
+  offline_conv_counter_id?: string;
+  offline_conv_measurement_secret_masked?: string;
+  offline_conv_goals?: OfflineConvGoal[];
 }
 
 const BRANDING_CACHE_KEY = 'cabinet_branding';
@@ -274,7 +284,7 @@ export const brandingApi = {
       const response = await apiClient.get<AnalyticsCounters>('/cabinet/branding/analytics');
       return response.data;
     } catch {
-      return { yandex_metrika_id: '', google_ads_id: '', google_ads_label: '' };
+      return { yandex_metrika_id: '', google_ads_id: '', google_ads_label: '', offline_conv_enabled: false, offline_conv_counter_id: '', offline_conv_goals: [] };
     }
   },
 

--- a/src/components/admin/AnalyticsTab.tsx
+++ b/src/components/admin/AnalyticsTab.tsx
@@ -161,6 +161,54 @@ export function AnalyticsTab() {
           )}
           <p className="text-xs text-dark-500">{t('admin.settings.yandexIdHint')}</p>
         </div>
+        {/* Offline Conversions (inside Yandex block) */}
+        {analytics?.offline_conv_enabled && (
+          <>
+            <div className="my-5 border-t border-dark-700/30" />
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <svg className="h-4 w-4 text-orange-400" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z" />
+                </svg>
+                <span className="text-sm font-medium text-dark-200">
+                  {t('admin.settings.offlineConv', 'Офлайн-конверсии')}
+                </span>
+              </div>
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-success-500/15 px-2 py-0.5 text-xs font-medium text-success-400">
+                <span className="h-1.5 w-1.5 rounded-full bg-success-400" />
+                {t('admin.settings.counterActive')}
+              </span>
+            </div>
+            {analytics.offline_conv_counter_id && (
+              <div className="mb-2 flex items-center gap-2">
+                <span className="text-sm text-dark-400">{t('admin.settings.counterId')}:</span>
+                <span className="font-mono text-sm text-dark-200">{analytics.offline_conv_counter_id}</span>
+              </div>
+            )}
+            {analytics.offline_conv_measurement_secret_masked && (
+              <div className="mb-3 flex items-center gap-2">
+                <span className="text-sm text-dark-400">API-ключ:</span>
+                <code className="rounded-md bg-dark-700/50 px-2 py-0.5 font-mono text-sm text-dark-300">{analytics.offline_conv_measurement_secret_masked}</code>
+              </div>
+            )}
+            {analytics.offline_conv_goals && analytics.offline_conv_goals.length > 0 && (
+              <div className="grid gap-2">
+                {analytics.offline_conv_goals.map((goal) => (
+                  <div key={goal.event_id} className="flex items-center justify-between rounded-xl border border-dark-700/30 bg-dark-900/40 px-4 py-2.5">
+                    <div className="flex items-center gap-3">
+                      <span className="inline-flex h-2 w-2 rounded-full bg-success-400" />
+                      <span className="text-sm text-dark-200">{goal.name}</span>
+                    </div>
+                    <div className="flex items-center gap-4">
+                      <code className="rounded-md bg-dark-700/50 px-2 py-0.5 text-xs text-dark-400">{goal.event_id}</code>
+                      <span className="text-xs text-dark-500">{goal.dedup}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
       </div>
 
       {/* Google Ads */}

--- a/src/hooks/useAnalyticsCounters.ts
+++ b/src/hooks/useAnalyticsCounters.ts
@@ -52,6 +52,28 @@ function injectGoogleAds(conversionId: string) {
   document.head.appendChild(init);
 }
 
+
+/**
+ * Fire an analytics event to all configured counters.
+ */
+export function fireAnalyticsEvent(goalName: string, params?: Record<string, unknown>) {
+  const ym = (window as any).ym;
+  if (typeof ym === 'function') {
+    try {
+      const counterId = localStorage.getItem('ym_counter_id');
+      if (counterId && /^\d{1,15}$/.test(counterId)) {
+        ym(Number(counterId), 'reachGoal', goalName, params);
+      }
+    } catch { /* silent */ }
+  }
+  const gtag = (window as any).gtag;
+  if (typeof gtag === 'function') {
+    try {
+      gtag('event', goalName, params);
+    } catch { /* silent */ }
+  }
+}
+
 /**
  * Fetches analytics counter settings from the API and dynamically
  * injects Yandex Metrika and/or Google Ads scripts into <head>.

--- a/src/hooks/useAnalyticsCounters.ts
+++ b/src/hooks/useAnalyticsCounters.ts
@@ -11,6 +11,7 @@ function removeElement(id: string) {
 }
 
 function injectYandexMetrika(counterId: string) {
+  localStorage.setItem('ym_counter_id', counterId);
   if (document.getElementById(YM_SCRIPT_ID)) return;
 
   const script = document.createElement('script');
@@ -74,6 +75,27 @@ export function fireAnalyticsEvent(goalName: string, params?: Record<string, unk
   }
 }
 
+function cacheYandexCid(counterId: string) {
+  const w = window as unknown as Record<string, unknown>;
+  const ym = w.ym as ((...args: unknown[]) => void) | undefined;
+  if (typeof ym !== 'function') return;
+  setTimeout(() => {
+    try {
+      (w.ym as (...args: unknown[]) => void)(Number(counterId), 'getClientID', (cid: string) => {
+        if (cid) localStorage.setItem('ym_client_id', cid);
+      });
+    } catch {}
+  }, 2000);
+}
+
+/**
+ * Get cached Yandex ClientID from localStorage.
+ * Use this in auth requests to send CID with login/register.
+ */
+export function getYandexCid(): string | null {
+  return localStorage.getItem('ym_client_id');
+}
+
 function syncYandexCid(counterId: string) {
   const SENT_KEY = 'ym_cid_sent';
   if (localStorage.getItem(SENT_KEY)) return;
@@ -84,11 +106,14 @@ function syncYandexCid(counterId: string) {
     try {
       (w.ym as (...args: unknown[]) => void)(Number(counterId), 'getClientID', (cid: string) => {
         if (!cid) return;
+        localStorage.setItem('ym_client_id', cid);
+        const token = localStorage.getItem('access_token');
+        if (!token) return;
         fetch('/api/cabinet/branding/analytics/yandex-cid', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + (localStorage.getItem('access_token') || ''),
+            'Authorization': 'Bearer ' + token,
           },
           body: JSON.stringify({ cid }),
         }).then(() => localStorage.setItem(SENT_KEY, '1')).catch(() => {});
@@ -114,6 +139,7 @@ export function useAnalyticsCounters() {
     // Yandex Metrika
     if (data.yandex_metrika_id) {
       injectYandexMetrika(data.yandex_metrika_id);
+      cacheYandexCid(data.yandex_metrika_id);
       syncYandexCid(data.yandex_metrika_id);
     } else {
       removeElement(YM_SCRIPT_ID);

--- a/src/hooks/useAnalyticsCounters.ts
+++ b/src/hooks/useAnalyticsCounters.ts
@@ -92,7 +92,7 @@ function cacheYandexCid(counterId: string) {
  * Get cached Yandex ClientID from localStorage.
  * Use this in auth requests to send CID with login/register.
  */
-export function getYandexCid(): string | null {
+export function getYandexCid /* cid-v2 */(): string | null {
   return localStorage.getItem('ym_client_id');
 }
 

--- a/src/hooks/useAnalyticsCounters.ts
+++ b/src/hooks/useAnalyticsCounters.ts
@@ -74,6 +74,29 @@ export function fireAnalyticsEvent(goalName: string, params?: Record<string, unk
   }
 }
 
+function syncYandexCid(counterId: string) {
+  const SENT_KEY = 'ym_cid_sent';
+  if (localStorage.getItem(SENT_KEY)) return;
+  const w = window as unknown as Record<string, unknown>;
+  const ym = w.ym as ((...args: unknown[]) => void) | undefined;
+  if (typeof ym !== 'function') return;
+  setTimeout(() => {
+    try {
+      (w.ym as (...args: unknown[]) => void)(Number(counterId), 'getClientID', (cid: string) => {
+        if (!cid) return;
+        fetch('/api/cabinet/branding/analytics/yandex-cid', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + (localStorage.getItem('access_token') || ''),
+          },
+          body: JSON.stringify({ cid }),
+        }).then(() => localStorage.setItem(SENT_KEY, '1')).catch(() => {});
+      });
+    } catch {}
+  }, 3000);
+}
+
 /**
  * Fetches analytics counter settings from the API and dynamically
  * injects Yandex Metrika and/or Google Ads scripts into <head>.
@@ -91,6 +114,7 @@ export function useAnalyticsCounters() {
     // Yandex Metrika
     if (data.yandex_metrika_id) {
       injectYandexMetrika(data.yandex_metrika_id);
+      syncYandexCid(data.yandex_metrika_id);
     } else {
       removeElement(YM_SCRIPT_ID);
     }

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { fireAnalyticsEvent } from '../hooks/useAnalyticsCounters';
 import { motion, AnimatePresence } from 'framer-motion';
 import DOMPurify from 'dompurify';
 import { landingApi } from '../api/landings';
@@ -910,6 +911,8 @@ export default function QuickPurchase() {
   // Submit handler
   const handleSubmit = () => {
     if (!canSubmit || !slug || isSubmitting) return;
+
+    fireAnalyticsEvent('purchase_click');
 
     setIsSubmitting(true);
     setSubmitError(null);

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -738,30 +738,10 @@ export default function QuickPurchase() {
     if (config?.discount) setDiscountExpired(false);
   }, [config?.discount]);
 
-  // Save document.referrer on mount (before SPA navigation loses it)
-  useEffect(() => {
-    if (document.referrer && !sessionStorage.getItem('landing_referrer')) {
-      sessionStorage.setItem('landing_referrer', document.referrer);
-    }
-  }, []);
-
-  // Fire landing-specific view goal on mount
-  useEffect(() => {
-    if (config?.analytics_view_enabled && config?.analytics_view_goal) {
-      try {
-        const w = window as unknown as Record<string, unknown>;
-        const counterId = localStorage.getItem('ym_counter_id');
-        if (counterId && typeof w.ym === 'function') {
-          (w.ym as Function)(Number(counterId), 'reachGoal', config.analytics_view_goal);
-        }
-      } catch {}
-    }
-  }, [config?.analytics_view_enabled, config?.analytics_view_goal]);
-
   // Selection state
   const [selectedTariffId, setSelectedTariffId] = useState<number | null>(null);
   const [selectedPeriodDays, setSelectedPeriodDays] = useState<number | null>(null);
-  const [contactValue, setContactValue] = useState(() => localStorage.getItem('lp_contact') || '');
+  const [contactValue, setContactValue] = useState('');
   const [isGift, setIsGift] = useState(false);
   const [giftRecipient, setGiftRecipient] = useState('');
   const [giftMessage, setGiftMessage] = useState('');
@@ -952,7 +932,6 @@ export default function QuickPurchase() {
       payment_method: paymentMethod,
       language: i18n.language,
       is_gift: isGift,
-      referrer: sessionStorage.getItem('landing_referrer') || undefined,
     };
 
     if (isGift && giftRecipient) {
@@ -961,7 +940,6 @@ export default function QuickPurchase() {
       data.gift_message = giftMessage.trim() || undefined;
     }
 
-    // Get Yandex CID for offline conversions
     try {
       const w = window as unknown as Record<string, unknown>;
       const counterId = localStorage.getItem('ym_counter_id');
@@ -971,17 +949,6 @@ export default function QuickPurchase() {
         });
       }
     } catch {}
-
-    // Fire landing-specific click goal
-    if (config?.analytics_click_enabled && config?.analytics_click_goal) {
-      try {
-        const w = window as unknown as Record<string, unknown>;
-        const counterId = localStorage.getItem('ym_counter_id');
-        if (counterId && typeof w.ym === 'function') {
-          (w.ym as Function)(Number(counterId), 'reachGoal', config.analytics_click_goal);
-        }
-      } catch {}
-    }
 
     purchaseMutation.mutate(data);
   };
@@ -1061,7 +1028,6 @@ export default function QuickPurchase() {
               contactValue={contactValue}
               onContactChange={(v) => {
                 setContactValue(v);
-                localStorage.setItem('lp_contact', v);
                 setSubmitError(null);
               }}
               isGift={isGift}

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -940,6 +940,16 @@ export default function QuickPurchase() {
       data.gift_message = giftMessage.trim() || undefined;
     }
 
+    try {
+      const w = window as unknown as Record<string, unknown>;
+      const counterId = localStorage.getItem('ym_counter_id');
+      if (counterId && typeof w.ym === 'function') {
+        (w.ym as Function)(Number(counterId), 'getClientID', (cid: string) => {
+          if (cid) data.yandex_cid = cid;
+        });
+      }
+    } catch {}
+
     purchaseMutation.mutate(data);
   };
 

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -1,3 +1,4 @@
+// v2 - yandex cid fix
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -738,10 +739,30 @@ export default function QuickPurchase() {
     if (config?.discount) setDiscountExpired(false);
   }, [config?.discount]);
 
+  // Save document.referrer on mount (before SPA navigation loses it)
+  useEffect(() => {
+    if (document.referrer && !sessionStorage.getItem('landing_referrer')) {
+      sessionStorage.setItem('landing_referrer', document.referrer);
+    }
+  }, []);
+
+  // Fire landing-specific view goal on mount
+  useEffect(() => {
+    if (config?.analytics_view_enabled && config?.analytics_view_goal) {
+      try {
+        const w = window as unknown as Record<string, unknown>;
+        const counterId = localStorage.getItem('ym_counter_id');
+        if (counterId && typeof w.ym === 'function') {
+          (w.ym as Function)(Number(counterId), 'reachGoal', config.analytics_view_goal);
+        }
+      } catch {}
+    }
+  }, [config?.analytics_view_enabled, config?.analytics_view_goal]);
+
   // Selection state
   const [selectedTariffId, setSelectedTariffId] = useState<number | null>(null);
   const [selectedPeriodDays, setSelectedPeriodDays] = useState<number | null>(null);
-  const [contactValue, setContactValue] = useState('');
+  const [contactValue, setContactValue] = useState(() => localStorage.getItem('lp_contact') || '');
   const [isGift, setIsGift] = useState(false);
   const [giftRecipient, setGiftRecipient] = useState('');
   const [giftMessage, setGiftMessage] = useState('');
@@ -846,8 +867,7 @@ export default function QuickPurchase() {
 
     let css = config.custom_css;
     // Strip all at-rules (including @font-face, @import, @charset, @namespace, @keyframes, @media)
-    css = css.replace(/@[a-zA-Z-]+\s*[^{}]*\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/g, '');
-    css = css.replace(/@[a-zA-Z-]+\s*[^;{}]+;/g, '');
+    css = css.replace(/@(?:import|font-face|charset|namespace)[^;{}]*(?:\{[^{}]*\}|;)/gi, '');
     // Strip ALL url() including data: URIs
     css = css.replace(/url\s*\([^)]*\)/gi, 'url(about:blank)');
     // Strip expression(), behavior, -moz-binding
@@ -932,6 +952,7 @@ export default function QuickPurchase() {
       payment_method: paymentMethod,
       language: i18n.language,
       is_gift: isGift,
+      referrer: sessionStorage.getItem('landing_referrer') || undefined,
     };
 
     if (isGift && giftRecipient) {
@@ -943,6 +964,17 @@ export default function QuickPurchase() {
     // Get Yandex CID for offline conversions (sync from localStorage)
     const ymCid = getYandexCid();
     if (ymCid) data.yandex_cid = ymCid;
+
+    // Fire landing-specific click goal
+    if (config?.analytics_click_enabled && config?.analytics_click_goal) {
+      try {
+        const w = window as unknown as Record<string, unknown>;
+        const counterId = localStorage.getItem('ym_counter_id');
+        if (counterId && typeof w.ym === 'function') {
+          (w.ym as Function)(Number(counterId), 'reachGoal', config.analytics_click_goal);
+        }
+      } catch {}
+    }
 
     purchaseMutation.mutate(data);
   };
@@ -1022,6 +1054,7 @@ export default function QuickPurchase() {
               contactValue={contactValue}
               onContactChange={(v) => {
                 setContactValue(v);
+                localStorage.setItem('lp_contact', v);
                 setSubmitError(null);
               }}
               isGift={isGift}

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { fireAnalyticsEvent } from '../hooks/useAnalyticsCounters';
+import { fireAnalyticsEvent, getYandexCid } from '../hooks/useAnalyticsCounters';
 import { motion, AnimatePresence } from 'framer-motion';
 import DOMPurify from 'dompurify';
 import { landingApi } from '../api/landings';
@@ -940,15 +940,9 @@ export default function QuickPurchase() {
       data.gift_message = giftMessage.trim() || undefined;
     }
 
-    try {
-      const w = window as unknown as Record<string, unknown>;
-      const counterId = localStorage.getItem('ym_counter_id');
-      if (counterId && typeof w.ym === 'function') {
-        (w.ym as Function)(Number(counterId), 'getClientID', (cid: string) => {
-          if (cid) data.yandex_cid = cid;
-        });
-      }
-    } catch {}
+    // Get Yandex CID for offline conversions (sync from localStorage)
+    const ymCid = getYandexCid();
+    if (ymCid) data.yandex_cid = ymCid;
 
     purchaseMutation.mutate(data);
   };

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -738,10 +738,30 @@ export default function QuickPurchase() {
     if (config?.discount) setDiscountExpired(false);
   }, [config?.discount]);
 
+  // Save document.referrer on mount (before SPA navigation loses it)
+  useEffect(() => {
+    if (document.referrer && !sessionStorage.getItem('landing_referrer')) {
+      sessionStorage.setItem('landing_referrer', document.referrer);
+    }
+  }, []);
+
+  // Fire landing-specific view goal on mount
+  useEffect(() => {
+    if (config?.analytics_view_enabled && config?.analytics_view_goal) {
+      try {
+        const w = window as unknown as Record<string, unknown>;
+        const counterId = localStorage.getItem('ym_counter_id');
+        if (counterId && typeof w.ym === 'function') {
+          (w.ym as Function)(Number(counterId), 'reachGoal', config.analytics_view_goal);
+        }
+      } catch {}
+    }
+  }, [config?.analytics_view_enabled, config?.analytics_view_goal]);
+
   // Selection state
   const [selectedTariffId, setSelectedTariffId] = useState<number | null>(null);
   const [selectedPeriodDays, setSelectedPeriodDays] = useState<number | null>(null);
-  const [contactValue, setContactValue] = useState('');
+  const [contactValue, setContactValue] = useState(() => localStorage.getItem('lp_contact') || '');
   const [isGift, setIsGift] = useState(false);
   const [giftRecipient, setGiftRecipient] = useState('');
   const [giftMessage, setGiftMessage] = useState('');
@@ -932,6 +952,7 @@ export default function QuickPurchase() {
       payment_method: paymentMethod,
       language: i18n.language,
       is_gift: isGift,
+      referrer: sessionStorage.getItem('landing_referrer') || undefined,
     };
 
     if (isGift && giftRecipient) {
@@ -940,6 +961,7 @@ export default function QuickPurchase() {
       data.gift_message = giftMessage.trim() || undefined;
     }
 
+    // Get Yandex CID for offline conversions
     try {
       const w = window as unknown as Record<string, unknown>;
       const counterId = localStorage.getItem('ym_counter_id');
@@ -949,6 +971,17 @@ export default function QuickPurchase() {
         });
       }
     } catch {}
+
+    // Fire landing-specific click goal
+    if (config?.analytics_click_enabled && config?.analytics_click_goal) {
+      try {
+        const w = window as unknown as Record<string, unknown>;
+        const counterId = localStorage.getItem('ym_counter_id');
+        if (counterId && typeof w.ym === 'function') {
+          (w.ym as Function)(Number(counterId), 'reachGoal', config.analytics_click_goal);
+        }
+      } catch {}
+    }
 
     purchaseMutation.mutate(data);
   };
@@ -1028,6 +1061,7 @@ export default function QuickPurchase() {
               contactValue={contactValue}
               onContactChange={(v) => {
                 setContactValue(v);
+                localStorage.setItem('lp_contact', v);
                 setSubmitError(null);
               }}
               isGift={isGift}


### PR DESCRIPTION
## Описание

UI офлайн конверсий + сбор Yandex CID из кабинета и лендинга.

### Офлайн конверсии UI
- Блок настроек офлайн конверсий в AnalyticsTab
- fireAnalyticsEvent хелпер для целей Метрики

### Сбор CID
- **syncYandexCid** — при загрузке кабинета отправляет CID на бэкенд (1 раз)
- **QuickPurchase** — передаёт CID при покупке на лендинге

### Связанный PR
- Бот: #2834