### PR TITLE
feat: сбор Yandex CID из кабинета

### DIFF
--- a/src/hooks/useAnalyticsCounters.ts
+++ b/src/hooks/useAnalyticsCounters.ts
@@ -28,6 +28,30 @@ function injectYandexMetrika(counterId: string) {
     });
   `;
   document.head.appendChild(script);
+  localStorage.setItem('ym_counter_id', counterId);
+}
+
+function syncYandexCid(counterId: string) {
+  const SENT_KEY = 'ym_cid_sent';
+  if (localStorage.getItem(SENT_KEY)) return;
+  const w = window as unknown as Record<string, unknown>;
+  const ym = w.ym as ((...args: unknown[]) => void) | undefined;
+  if (typeof ym !== 'function') return;
+  setTimeout(() => {
+    try {
+      (w.ym as (...args: unknown[]) => void)(Number(counterId), 'getClientID', (cid: string) => {
+        if (!cid) return;
+        fetch('/api/cabinet/branding/analytics/yandex-cid', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + (localStorage.getItem('access_token') || ''),
+          },
+          body: JSON.stringify({ cid }),
+        }).then(() => localStorage.setItem(SENT_KEY, '1')).catch(() => {});
+      });
+    } catch {}
+  }, 3000);
 }
 
 function injectGoogleAds(conversionId: string) {
@@ -69,6 +93,7 @@ export function useAnalyticsCounters() {
     // Yandex Metrika
     if (data.yandex_metrika_id) {
       injectYandexMetrika(data.yandex_metrika_id);
+      syncYandexCid(data.yandex_metrika_id);
     } else {
       removeElement(YM_SCRIPT_ID);
     }


### PR DESCRIPTION
## Описание

Сбор Yandex ClientID для офлайн конверсий из кабинета.

### Изменения

**`src/hooks/useAnalyticsCounters.ts`:**
- `syncYandexCid()` — при загрузке кабинета получает CID из Яндекс.Метрики (`ym(id, 'getClientID', cb)`) и отправляет POST на `/api/cabinet/branding/analytics/yandex-cid` (1 раз за сессию, localStorage флаг `ym_cid_sent`).
- `injectYandexMetrika()` — сохраняет counter ID в `localStorage` (`ym_counter_id`) для переиспользования другими компонентами.
- 3-секундный таймаут перед вызовом `getClientID`, чтобы Метрика успела инициализироваться.

### Как работает

1. Кабинет загружается → `useAnalyticsCounters` подтягивает настройки аналитики.
2. Если есть `yandex_metrika_id` — инжектится Метрика + вызывается `syncYandexCid`.
3. Через 3 секунды получаем CID через Metrika API и шлём на бэкенд.
4. Бэкенд сохраняет CID в `yandex_client_id_map` (user_id → cid).
5. При покупке/триале бэкенд отправляет офлайн-конверсию с этим CID.

### Связанный PR

- Бот (бэкенд): эндпоинт `/cabinet/branding/analytics/yandex-cid` — будет создан отдельным PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>