### PR TITLE
feat: send yandex_cid with auth requests

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,5 @@
 import apiClient from './client';
+import { getYandexCid } from '../hooks/useAnalyticsCounters';
 import type {
   AuthResponse,
   LinkCallbackResponse,
@@ -22,6 +23,7 @@ export const authApi = {
       init_data: initData,
       campaign_slug: campaignSlug || undefined,
       referral_code: referralCode || undefined,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -43,6 +45,7 @@ export const authApi = {
       ...data,
       campaign_slug: campaignSlug || undefined,
       referral_code: referralCode || undefined,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -56,6 +59,7 @@ export const authApi = {
       id_token: idToken,
       campaign_slug: campaignSlug || undefined,
       referral_code: referralCode || undefined,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -71,6 +75,7 @@ export const authApi = {
       password,
       campaign_slug: campaignSlug || undefined,
       referral_code: referralCode || undefined,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -87,6 +92,7 @@ export const authApi = {
     const response = await apiClient.post('/cabinet/auth/email/register', {
       email,
       password,
+      yandex_cid: getYandexCid() || undefined,
     });
     return response.data;
   },
@@ -100,7 +106,7 @@ export const authApi = {
   }): Promise<RegisterResponse> => {
     const response = await apiClient.post<RegisterResponse>(
       '/cabinet/auth/email/register/standalone',
-      data,
+      { ...data, yandex_cid: getYandexCid() || undefined },
     );
     return response.data;
   },

--- a/src/hooks/useAnalyticsCounters.ts
+++ b/src/hooks/useAnalyticsCounters.ts
@@ -11,6 +11,7 @@ function removeElement(id: string) {
 }
 
 function injectYandexMetrika(counterId: string) {
+  localStorage.setItem('ym_counter_id', counterId);
   if (document.getElementById(YM_SCRIPT_ID)) return;
 
   const script = document.createElement('script');
@@ -52,6 +53,75 @@ function injectGoogleAds(conversionId: string) {
   document.head.appendChild(init);
 }
 
+
+/**
+ * Fire an analytics event to all configured counters.
+ */
+export function fireAnalyticsEvent(goalName: string, params?: Record<string, unknown>) {
+  const ym = (window as any).ym;
+  if (typeof ym === 'function') {
+    try {
+      const counterId = localStorage.getItem('ym_counter_id');
+      if (counterId && /^\d{1,15}$/.test(counterId)) {
+        ym(Number(counterId), 'reachGoal', goalName, params);
+      }
+    } catch { /* silent */ }
+  }
+  const gtag = (window as any).gtag;
+  if (typeof gtag === 'function') {
+    try {
+      gtag('event', goalName, params);
+    } catch { /* silent */ }
+  }
+}
+
+function cacheYandexCid(counterId: string) {
+  const w = window as unknown as Record<string, unknown>;
+  const ym = w.ym as ((...args: unknown[]) => void) | undefined;
+  if (typeof ym !== 'function') return;
+  setTimeout(() => {
+    try {
+      (w.ym as (...args: unknown[]) => void)(Number(counterId), 'getClientID', (cid: string) => {
+        if (cid) localStorage.setItem('ym_client_id', cid);
+      });
+    } catch {}
+  }, 2000);
+}
+
+/**
+ * Get cached Yandex ClientID from localStorage.
+ * Use this in auth requests to send CID with login/register.
+ */
+export function getYandexCid(): string | null {
+  return localStorage.getItem('ym_client_id');
+}
+
+function syncYandexCid(counterId: string) {
+  const SENT_KEY = 'ym_cid_sent';
+  if (localStorage.getItem(SENT_KEY)) return;
+  const w = window as unknown as Record<string, unknown>;
+  const ym = w.ym as ((...args: unknown[]) => void) | undefined;
+  if (typeof ym !== 'function') return;
+  setTimeout(() => {
+    try {
+      (w.ym as (...args: unknown[]) => void)(Number(counterId), 'getClientID', (cid: string) => {
+        if (!cid) return;
+        localStorage.setItem('ym_client_id', cid);
+        const token = localStorage.getItem('access_token');
+        if (!token) return;
+        fetch('/api/cabinet/branding/analytics/yandex-cid', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + token,
+          },
+          body: JSON.stringify({ cid }),
+        }).then(() => localStorage.setItem(SENT_KEY, '1')).catch(() => {});
+      });
+    } catch {}
+  }, 3000);
+}
+
 /**
  * Fetches analytics counter settings from the API and dynamically
  * injects Yandex Metrika and/or Google Ads scripts into <head>.
@@ -69,6 +139,8 @@ export function useAnalyticsCounters() {
     // Yandex Metrika
     if (data.yandex_metrika_id) {
       injectYandexMetrika(data.yandex_metrika_id);
+      cacheYandexCid(data.yandex_metrika_id);
+      syncYandexCid(data.yandex_metrika_id);
     } else {
       removeElement(YM_SCRIPT_ID);
     }


### PR DESCRIPTION
## Summary
- Cache Yandex ClientID in localStorage immediately when Metrika loads (`cacheYandexCid`)
- Export `getYandexCid()` helper
- Send `yandex_cid` in all auth API calls (Telegram, Widget, OIDC, Email Login/Register)
- Fix `syncYandexCid`: skip POST if no access_token (avoids 401 for unauthenticated users)

## Problem
86% of new users from ads don't get CID captured because `syncYandexCid` requires auth token which doesn't exist yet at page load.

## Solution
CID is cached in localStorage by Metrika, then sent alongside login/register requests. Backend stores it. Works for Mini App, cabinet, all auth methods.

## Requires
Backend PR: BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#2844