### PR TITLE
fix(connection): happ cryptolink flow + ui fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ docker pull ghcr.io/bedolaga-dev/bedolaga-cabinet:latest
 ```bash
 # Создать временный контейнер и скопировать статику
 docker create --name tmp_cabinet ghcr.io/bedolaga-dev/bedolaga-cabinet:latest
-docker cp tmp_cabinet:/usr/share/nginx/html ./cabinet-dist
+mkdir -p ./cabinet-dist
+docker cp tmp_cabinet:/usr/share/nginx/html/. ./cabinet-dist/
 docker rm tmp_cabinet
 ```
 
@@ -79,7 +80,8 @@ VITE_APP_LOGO=V
 ```bash
 docker compose build cabinet-frontend
 docker compose create cabinet-frontend
-docker cp cabinet_frontend:/usr/share/nginx/html ./cabinet-dist
+mkdir -p ./cabinet-dist
+docker cp cabinet_frontend:/usr/share/nginx/html/. ./cabinet-dist/
 docker compose rm -sf cabinet-frontend
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ VITE_APP_LOGO=V
 Соберите и извлеките:
 
 ```bash
-docker compose build
-docker create --name tmp_cabinet cabinet_frontend
-docker cp tmp_cabinet:/usr/share/nginx/html ./cabinet-dist
-docker rm tmp_cabinet
+docker compose build cabinet-frontend
+docker compose create cabinet-frontend
+docker cp cabinet_frontend:/usr/share/nginx/html ./cabinet-dist
+docker compose rm -sf cabinet-frontend
 ```
 
 ### Шаг 3. Размещение файлов на сервере

--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -449,6 +449,9 @@ export const subscriptionApi = {
     display_link: string | null;
     happ_redirect_link: string | null;
     happ_scheme_link: string | null;
+    happ_cryptolink?: string | null;
+    happ_crypto_link?: string | null;
+    happ_link?: string | null;
     connect_mode: string;
     hide_link: boolean;
     instructions: {

--- a/src/pages/Connection.tsx
+++ b/src/pages/Connection.tsx
@@ -32,6 +32,12 @@ export default function Connection() {
     queryKey: ['appConfig', subId],
     queryFn: () => subscriptionApi.getAppConfig(subId),
   });
+  const { data: connectionLink } = useQuery({
+    queryKey: ['connectionLink', subId],
+    queryFn: () => subscriptionApi.getConnectionLink(subId),
+    retry: false,
+    staleTime: 0,
+  });
 
   const handleGoBack = useCallback(() => {
     navigate(-1);
@@ -70,6 +76,41 @@ export default function Connection() {
     [appConfig?.subscriptionUrl, user?.username],
   );
 
+  const autoRedirectUrl = useMemo(() => {
+    if (!connectionLink) return null;
+
+    const mode = String(connectionLink.connect_mode || '').toUpperCase();
+    if (mode !== 'HAPP_CRYPTOLINK') return null;
+
+    if (connectionLink.happ_redirect_link) {
+      try {
+        return new URL(connectionLink.happ_redirect_link, window.location.origin).toString();
+      } catch {
+        return connectionLink.happ_redirect_link;
+      }
+    }
+
+    if (!connectionLink.happ_scheme_link) return null;
+    return `${window.location.origin}/miniapp/redirect.html?url=${encodeURIComponent(connectionLink.happ_scheme_link)}&lang=${i18n.language || 'en'}`;
+  }, [connectionLink, i18n.language]);
+
+  const hasStartedAutoRedirectRef = useRef(false);
+  useEffect(() => {
+    if (!autoRedirectUrl || hasStartedAutoRedirectRef.current) return;
+    hasStartedAutoRedirectRef.current = true;
+
+    if (isTelegramWebApp) {
+      try {
+        sdkOpenLink(autoRedirectUrl, { tryInstantView: false });
+        return;
+      } catch {
+        // SDK not available, fallback
+      }
+    }
+
+    window.location.href = autoRedirectUrl;
+  }, [autoRedirectUrl, isTelegramWebApp]);
+
   const openDeepLink = useCallback(
     (deepLink: string) => {
       let resolved = deepLink;
@@ -101,10 +142,11 @@ export default function Connection() {
     );
   }, [appConfig?.platforms]);
 
-  if (isLoading) {
+  if (isLoading || autoRedirectUrl) {
     return (
-      <div className="flex flex-1 items-center justify-center py-20">
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 py-20">
         <div className="h-10 w-10 animate-spin rounded-full border-[3px] border-accent-500/30 border-t-accent-500" />
+        {autoRedirectUrl && <p className="text-sm text-dark-400">{t('deepLink.redirecting')}</p>}
       </div>
     );
   }

--- a/src/pages/Connection.tsx
+++ b/src/pages/Connection.tsx
@@ -32,7 +32,7 @@ export default function Connection() {
     queryKey: ['appConfig', subId],
     queryFn: () => subscriptionApi.getAppConfig(subId),
   });
-  const { data: connectionLink } = useQuery({
+  const { data: connectionLink, isLoading: isConnectionLinkLoading } = useQuery({
     queryKey: ['connectionLink', subId],
     queryFn: () => subscriptionApi.getConnectionLink(subId),
     retry: false,
@@ -80,7 +80,7 @@ export default function Connection() {
     if (!connectionLink) return null;
 
     const mode = String(connectionLink.connect_mode || '').toUpperCase();
-    if (mode !== 'HAPP_CRYPTOLINK') return null;
+    if (mode.includes('GUIDE')) return null;
 
     if (connectionLink.happ_redirect_link) {
       try {
@@ -142,7 +142,7 @@ export default function Connection() {
     );
   }, [appConfig?.platforms]);
 
-  if (isLoading || autoRedirectUrl) {
+  if (isLoading || isConnectionLinkLoading || autoRedirectUrl) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 py-20">
         <div className="h-10 w-10 animate-spin rounded-full border-[3px] border-accent-500/30 border-t-accent-500" />

--- a/src/pages/Connection.tsx
+++ b/src/pages/Connection.tsx
@@ -124,24 +124,36 @@ export default function Connection() {
   const openDeepLink = useCallback(
     (deepLink: string) => {
       let resolved = deepLink;
-      if (hasTemplates(resolved)) {
+      if (isHappCryptolinkMode(connectionLink?.connect_mode) && connectionLink?.happ_scheme_link) {
+        // In HAPP cryptolink mode always open the generated happ://crypt... URL.
+        resolved = connectionLink.happ_scheme_link;
+      } else if (hasTemplates(resolved)) {
         resolved = resolveUrl(resolved);
       }
-
-      const finalUrl = `${window.location.origin}/miniapp/redirect.html?url=${encodeURIComponent(resolved)}&lang=${i18n.language || 'en'}`;
+      const isHttpUrl = /^https?:\/\//i.test(resolved);
+      const finalUrlForTelegram = isHttpUrl
+        ? resolved
+        : `${window.location.origin}/miniapp/redirect.html?url=${encodeURIComponent(resolved)}&lang=${i18n.language || 'en'}`;
 
       if (isTelegramWebApp) {
         try {
-          sdkOpenLink(finalUrl, { tryInstantView: false });
+          sdkOpenLink(finalUrlForTelegram, { tryInstantView: false });
           return;
         } catch {
           // SDK not available, fallback
         }
       }
 
-      window.location.href = finalUrl;
+      // In regular browsers open deeplink directly (without intermediate redirect page).
+      window.location.href = resolved;
     },
-    [isTelegramWebApp, i18n.language, resolveUrl],
+    [
+      isTelegramWebApp,
+      i18n.language,
+      resolveUrl,
+      connectionLink?.connect_mode,
+      connectionLink?.happ_scheme_link,
+    ],
   );
 
   // Check if any platform has configured apps

--- a/src/pages/Connection.tsx
+++ b/src/pages/Connection.tsx
@@ -7,28 +7,10 @@ import { subscriptionApi } from '../api/subscription';
 import { useTelegramSDK } from '../hooks/useTelegramSDK';
 import { useHaptic } from '@/platform';
 import { resolveTemplate, hasTemplates } from '../utils/templateEngine';
+import { isHappCryptolinkMode, resolveConnectionUrlForUi } from '../utils/connectionLink';
 import { useAuthStore } from '../store/auth';
 import type { AppConfig, RemnawavePlatformData } from '../types';
 import InstallationGuide from '../components/connection/InstallationGuide';
-
-function isHappCryptolinkMode(mode: string | null | undefined): boolean {
-  const normalized = String(mode ?? '').toUpperCase();
-  if (!normalized) return false;
-  return normalized.includes('HAPP') && normalized.includes('CRYPT');
-}
-
-function resolveConnectionUrlForUi(input: {
-  mode?: string | null;
-  happSchemeLink?: string | null;
-  displayLink?: string | null;
-  subscriptionUrl?: string | null;
-  fallbackUrl?: string | null;
-}): string | null {
-  const defaultUrl =
-    input.fallbackUrl ?? input.subscriptionUrl ?? input.displayLink ?? input.happSchemeLink ?? null;
-  if (!isHappCryptolinkMode(input.mode)) return defaultUrl;
-  return input.happSchemeLink ?? input.displayLink ?? input.subscriptionUrl ?? defaultUrl;
-}
 
 export default function Connection() {
   const { t, i18n } = useTranslation();
@@ -65,12 +47,18 @@ export default function Connection() {
         happSchemeLink: connectionLink?.happ_scheme_link,
         displayLink: connectionLink?.display_link,
         subscriptionUrl: connectionLink?.subscription_url,
+        happCryptLink: connectionLink?.happ_cryptolink,
+        happCryptoLink: connectionLink?.happ_crypto_link,
+        happLink: connectionLink?.happ_link,
         fallbackUrl: appConfig?.subscriptionUrl,
       }),
     [
       appConfig?.subscriptionUrl,
       connectionLink?.connect_mode,
       connectionLink?.display_link,
+      connectionLink?.happ_cryptolink,
+      connectionLink?.happ_crypto_link,
+      connectionLink?.happ_link,
       connectionLink?.happ_scheme_link,
       connectionLink?.subscription_url,
     ],
@@ -124,9 +112,9 @@ export default function Connection() {
   const openDeepLink = useCallback(
     (deepLink: string) => {
       let resolved = deepLink;
-      if (isHappCryptolinkMode(connectionLink?.connect_mode) && connectionLink?.happ_scheme_link) {
-        // In HAPP cryptolink mode always open the generated happ://crypt... URL.
-        resolved = connectionLink.happ_scheme_link;
+      if (isHappCryptolinkMode(connectionLink?.connect_mode) && qrConnectionUrl) {
+        // In HAPP cryptolink mode always open the resolved happ://crypt... URL.
+        resolved = qrConnectionUrl;
       } else if (hasTemplates(resolved)) {
         resolved = resolveUrl(resolved);
       }
@@ -147,13 +135,7 @@ export default function Connection() {
       // In regular browsers open deeplink directly (without intermediate redirect page).
       window.location.href = resolved;
     },
-    [
-      isTelegramWebApp,
-      i18n.language,
-      resolveUrl,
-      connectionLink?.connect_mode,
-      connectionLink?.happ_scheme_link,
-    ],
+    [isTelegramWebApp, i18n.language, resolveUrl, connectionLink?.connect_mode, qrConnectionUrl],
   );
 
   // Check if any platform has configured apps

--- a/src/pages/Connection.tsx
+++ b/src/pages/Connection.tsx
@@ -11,6 +11,25 @@ import { useAuthStore } from '../store/auth';
 import type { AppConfig, RemnawavePlatformData } from '../types';
 import InstallationGuide from '../components/connection/InstallationGuide';
 
+function isHappCryptolinkMode(mode: string | null | undefined): boolean {
+  const normalized = String(mode ?? '').toUpperCase();
+  if (!normalized) return false;
+  return normalized.includes('HAPP') && normalized.includes('CRYPT');
+}
+
+function resolveConnectionUrlForUi(input: {
+  mode?: string | null;
+  happSchemeLink?: string | null;
+  displayLink?: string | null;
+  subscriptionUrl?: string | null;
+  fallbackUrl?: string | null;
+}): string | null {
+  const defaultUrl =
+    input.fallbackUrl ?? input.subscriptionUrl ?? input.displayLink ?? input.happSchemeLink ?? null;
+  if (!isHappCryptolinkMode(input.mode)) return defaultUrl;
+  return input.happSchemeLink ?? input.displayLink ?? input.subscriptionUrl ?? defaultUrl;
+}
+
 export default function Connection() {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
@@ -39,20 +58,46 @@ export default function Connection() {
     staleTime: 0,
   });
 
+  const qrConnectionUrl = useMemo(
+    () =>
+      resolveConnectionUrlForUi({
+        mode: connectionLink?.connect_mode,
+        happSchemeLink: connectionLink?.happ_scheme_link,
+        displayLink: connectionLink?.display_link,
+        subscriptionUrl: connectionLink?.subscription_url,
+        fallbackUrl: appConfig?.subscriptionUrl,
+      }),
+    [
+      appConfig?.subscriptionUrl,
+      connectionLink?.connect_mode,
+      connectionLink?.display_link,
+      connectionLink?.happ_scheme_link,
+      connectionLink?.subscription_url,
+    ],
+  );
+
   const handleGoBack = useCallback(() => {
     navigate(-1);
   }, [navigate]);
 
   const handleOpenQR = useCallback(() => {
+    if (!qrConnectionUrl) return;
     navigate('/connection/qr', {
       replace: !isTelegramWebApp,
       state: {
-        url: appConfig?.subscriptionUrl,
-        hideLink: appConfig?.hideLink ?? false,
+        url: qrConnectionUrl,
+        hideLink: connectionLink?.hide_link ?? appConfig?.hideLink ?? false,
         subscriptionId: subId,
       },
     });
-  }, [navigate, appConfig?.subscriptionUrl, appConfig?.hideLink, isTelegramWebApp, subId]);
+  }, [
+    navigate,
+    qrConnectionUrl,
+    connectionLink?.hide_link,
+    appConfig?.hideLink,
+    isTelegramWebApp,
+    subId,
+  ]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -75,41 +120,6 @@ export default function Connection() {
     },
     [appConfig?.subscriptionUrl, user?.username],
   );
-
-  const autoRedirectUrl = useMemo(() => {
-    if (!connectionLink) return null;
-
-    const mode = String(connectionLink.connect_mode || '').toUpperCase();
-    if (mode.includes('GUIDE')) return null;
-
-    if (connectionLink.happ_redirect_link) {
-      try {
-        return new URL(connectionLink.happ_redirect_link, window.location.origin).toString();
-      } catch {
-        return connectionLink.happ_redirect_link;
-      }
-    }
-
-    if (!connectionLink.happ_scheme_link) return null;
-    return `${window.location.origin}/miniapp/redirect.html?url=${encodeURIComponent(connectionLink.happ_scheme_link)}&lang=${i18n.language || 'en'}`;
-  }, [connectionLink, i18n.language]);
-
-  const hasStartedAutoRedirectRef = useRef(false);
-  useEffect(() => {
-    if (!autoRedirectUrl || hasStartedAutoRedirectRef.current) return;
-    hasStartedAutoRedirectRef.current = true;
-
-    if (isTelegramWebApp) {
-      try {
-        sdkOpenLink(autoRedirectUrl, { tryInstantView: false });
-        return;
-      } catch {
-        // SDK not available, fallback
-      }
-    }
-
-    window.location.href = autoRedirectUrl;
-  }, [autoRedirectUrl, isTelegramWebApp]);
 
   const openDeepLink = useCallback(
     (deepLink: string) => {
@@ -142,11 +152,10 @@ export default function Connection() {
     );
   }, [appConfig?.platforms]);
 
-  if (isLoading || isConnectionLinkLoading || autoRedirectUrl) {
+  if (isLoading || isConnectionLinkLoading) {
     return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-3 py-20">
+      <div className="flex flex-1 items-center justify-center py-20">
         <div className="h-10 w-10 animate-spin rounded-full border-[3px] border-accent-500/30 border-t-accent-500" />
-        {autoRedirectUrl && <p className="text-sm text-dark-400">{t('deepLink.redirecting')}</p>}
       </div>
     );
   }

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -926,11 +926,12 @@ export default function Subscription() {
               {displayedConnectionUrl && !shouldHideConnectionLink && (
                 <div className="mb-5 flex gap-2">
                   <code
-                    className="scrollbar-hide flex-1 overflow-x-auto break-all rounded-[10px] px-3 py-2 font-mono text-[11px] text-dark-50/30"
+                    className="block min-w-0 flex-1 truncate whitespace-nowrap rounded-[10px] px-3 py-2 font-mono text-[11px] text-dark-50/30"
                     style={{
                       background: g.codeBg,
                       border: `1px solid ${g.codeBorder}`,
                     }}
+                    title={displayedConnectionUrl}
                   >
                     {displayedConnectionUrl}
                   </code>

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -18,6 +18,7 @@ import { useCloseOnSuccessNotification } from '../store/successNotification';
 import PurchaseCTAButton from '../components/subscription/PurchaseCTAButton';
 import { CopyIcon, CheckIcon } from '../components/icons';
 import { useHaptic } from '../platform';
+import { resolveConnectionUrlForUi } from '../utils/connectionLink';
 import {
   getErrorMessage,
   getInsufficientBalanceError,
@@ -166,25 +167,6 @@ const CountdownTimer = memo(function CountdownTimer({
   );
 });
 
-function isHappCryptolinkMode(mode: string | null | undefined): boolean {
-  const normalized = String(mode ?? '').toUpperCase();
-  if (!normalized) return false;
-  return normalized.includes('HAPP') && normalized.includes('CRYPT');
-}
-
-function resolveConnectionUrlForUi(input: {
-  mode?: string | null;
-  happSchemeLink?: string | null;
-  displayLink?: string | null;
-  subscriptionUrl?: string | null;
-  fallbackUrl?: string | null;
-}): string | null {
-  const defaultUrl =
-    input.fallbackUrl ?? input.subscriptionUrl ?? input.displayLink ?? input.happSchemeLink ?? null;
-  if (!isHappCryptolinkMode(input.mode)) return defaultUrl;
-  return input.happSchemeLink ?? input.displayLink ?? input.subscriptionUrl ?? defaultUrl;
-}
-
 export default function Subscription() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -256,11 +238,17 @@ export default function Subscription() {
         happSchemeLink: connectionLink?.happ_scheme_link,
         displayLink: connectionLink?.display_link,
         subscriptionUrl: connectionLink?.subscription_url,
+        happCryptLink: connectionLink?.happ_cryptolink,
+        happCryptoLink: connectionLink?.happ_crypto_link,
+        happLink: connectionLink?.happ_link,
         fallbackUrl: isConnectionLinkLoading ? null : (subscription?.subscription_url ?? null),
       }),
     [
       connectionLink?.connect_mode,
       connectionLink?.display_link,
+      connectionLink?.happ_cryptolink,
+      connectionLink?.happ_crypto_link,
+      connectionLink?.happ_link,
       connectionLink?.happ_scheme_link,
       connectionLink?.subscription_url,
       isConnectionLinkLoading,

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, memo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useNavigate, useParams } from 'react-router';
@@ -166,6 +166,25 @@ const CountdownTimer = memo(function CountdownTimer({
   );
 });
 
+function isHappCryptolinkMode(mode: string | null | undefined): boolean {
+  const normalized = String(mode ?? '').toUpperCase();
+  if (!normalized) return false;
+  return normalized.includes('HAPP') && normalized.includes('CRYPT');
+}
+
+function resolveConnectionUrlForUi(input: {
+  mode?: string | null;
+  happSchemeLink?: string | null;
+  displayLink?: string | null;
+  subscriptionUrl?: string | null;
+  fallbackUrl?: string | null;
+}): string | null {
+  const defaultUrl =
+    input.fallbackUrl ?? input.subscriptionUrl ?? input.displayLink ?? input.happSchemeLink ?? null;
+  if (!isHappCryptolinkMode(input.mode)) return defaultUrl;
+  return input.happSchemeLink ?? input.displayLink ?? input.subscriptionUrl ?? defaultUrl;
+}
+
 export default function Subscription() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -221,9 +240,35 @@ export default function Subscription() {
     staleTime: 0,
     refetchOnMount: 'always',
   });
+  const { data: connectionLink, isLoading: isConnectionLinkLoading } = useQuery({
+    queryKey: ['connection-link', subscriptionId],
+    queryFn: () => subscriptionApi.getConnectionLink(subscriptionId),
+    retry: false,
+    staleTime: 0,
+  });
 
   // Extract subscription from response (null if no subscription)
   const subscription = subscriptionResponse?.subscription ?? null;
+  const displayedConnectionUrl = useMemo(
+    () =>
+      resolveConnectionUrlForUi({
+        mode: connectionLink?.connect_mode,
+        happSchemeLink: connectionLink?.happ_scheme_link,
+        displayLink: connectionLink?.display_link,
+        subscriptionUrl: connectionLink?.subscription_url,
+        fallbackUrl: isConnectionLinkLoading ? null : (subscription?.subscription_url ?? null),
+      }),
+    [
+      connectionLink?.connect_mode,
+      connectionLink?.display_link,
+      connectionLink?.happ_scheme_link,
+      connectionLink?.subscription_url,
+      isConnectionLinkLoading,
+      subscription?.subscription_url,
+    ],
+  );
+  const shouldHideConnectionLink =
+    subscription?.hide_subscription_link || connectionLink?.hide_link;
 
   // Traffic zone (theme-aware) — called unconditionally at top level
   const usedPercent = trafficData?.traffic_used_percent ?? subscription?.traffic_used_percent ?? 0;
@@ -453,8 +498,8 @@ export default function Subscription() {
   }, [subscription, refreshTrafficMutation, subscriptionId]);
 
   const copyUrl = () => {
-    if (subscription?.subscription_url) {
-      navigator.clipboard.writeText(subscription.subscription_url);
+    if (displayedConnectionUrl) {
+      navigator.clipboard.writeText(displayedConnectionUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }
@@ -890,7 +935,7 @@ export default function Subscription() {
               )}
 
               {/* ─── Subscription URL ─── */}
-              {subscription.subscription_url && !subscription.hide_subscription_link && (
+              {displayedConnectionUrl && !shouldHideConnectionLink && (
                 <div className="mb-5 flex gap-2">
                   <code
                     className="scrollbar-hide flex-1 overflow-x-auto break-all rounded-[10px] px-3 py-2 font-mono text-[11px] text-dark-50/30"
@@ -899,7 +944,7 @@ export default function Subscription() {
                       border: `1px solid ${g.codeBorder}`,
                     }}
                   >
-                    {subscription.subscription_url}
+                    {displayedConnectionUrl}
                   </code>
                   <button
                     onClick={copyUrl}

--- a/src/providers/WebSocketProvider.tsx
+++ b/src/providers/WebSocketProvider.tsx
@@ -8,6 +8,31 @@ export type { WSMessage } from './WebSocketContext';
 
 const isDev = import.meta.env.DEV;
 
+function buildWebSocketUrl(accessToken: string): string {
+  const apiUrl = String(import.meta.env.VITE_API_URL || '/api').trim();
+  const windowWsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+
+  const withToken = (base: string) => `${base}?token=${encodeURIComponent(accessToken)}`;
+
+  if (apiUrl.startsWith('http://') || apiUrl.startsWith('https://')) {
+    try {
+      const api = new URL(apiUrl);
+      const wsProtocol = api.protocol === 'https:' ? 'wss:' : 'ws:';
+      const basePath = api.pathname.replace(/\/+$/, '');
+      const wsPath = basePath.endsWith('/cabinet') ? `${basePath}/ws` : `${basePath}/cabinet/ws`;
+      return withToken(`${wsProtocol}//${api.host}${wsPath}`);
+    } catch {
+      // fall through to relative-path handling
+    }
+  }
+
+  const normalizedBasePath = `/${apiUrl}`.replace(/\/{2,}/g, '/').replace(/\/+$/, '');
+  const wsPath = normalizedBasePath.endsWith('/cabinet')
+    ? `${normalizedBasePath}/ws`
+    : `${normalizedBasePath}/cabinet/ws`;
+  return withToken(`${windowWsProtocol}//${window.location.host}${wsPath}`);
+}
+
 export function WebSocketProvider({ children }: { children: React.ReactNode }) {
   const accessToken = useAuthStore((state) => state.accessToken);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
@@ -48,21 +73,7 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
 
     cleanup();
 
-    // Build WebSocket URL
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    let host = window.location.host;
-
-    // Handle VITE_API_URL - can be absolute URL or relative path
-    const apiUrl = import.meta.env.VITE_API_URL;
-    if (apiUrl && (apiUrl.startsWith('http://') || apiUrl.startsWith('https://'))) {
-      try {
-        host = new URL(apiUrl).host;
-      } catch {
-        // If URL parsing fails, use window.location.host
-      }
-    }
-
-    const wsUrl = `${protocol}//${host}/cabinet/ws?token=${accessToken}`;
+    const wsUrl = buildWebSocketUrl(accessToken);
 
     try {
       const ws = new WebSocket(wsUrl);

--- a/src/utils/connectionLink.ts
+++ b/src/utils/connectionLink.ts
@@ -10,6 +10,14 @@ function isHttpUrl(url: string | null | undefined): url is string {
   return typeof url === 'string' && /^https?:\/\//i.test(url);
 }
 
+function isHappSubscriptionLink(url: string | null | undefined): url is string {
+  return typeof url === 'string' && /^happ:\/\/sub/i.test(url);
+}
+
+function isCryptSourceUrl(url: string | null | undefined): url is string {
+  return isHttpUrl(url) || isHappSubscriptionLink(url);
+}
+
 function isHappCryptDeepLink(url: string | null | undefined): url is string {
   return typeof url === 'string' && /^happ:\/\/crypt/i.test(url);
 }
@@ -44,7 +52,7 @@ export function resolveConnectionUrlForUi(input: ResolveConnectionUrlInput): str
 
   const sourceSubscriptionUrl =
     [input.subscriptionUrl, input.displayLink, input.fallbackUrl].find((value) =>
-      isHttpUrl(value),
+      isCryptSourceUrl(value),
     ) ?? null;
 
   if (sourceSubscriptionUrl) {

--- a/src/utils/connectionLink.ts
+++ b/src/utils/connectionLink.ts
@@ -1,0 +1,59 @@
+import { createHappCryptoLink } from '@kastov/cryptohapp';
+
+export function isHappCryptolinkMode(mode: string | null | undefined): boolean {
+  const normalized = String(mode ?? '').toUpperCase();
+  if (!normalized) return false;
+  return normalized.includes('HAPP') && normalized.includes('CRYPT');
+}
+
+function isHttpUrl(url: string | null | undefined): url is string {
+  return typeof url === 'string' && /^https?:\/\//i.test(url);
+}
+
+function isHappCryptDeepLink(url: string | null | undefined): url is string {
+  return typeof url === 'string' && /^happ:\/\/crypt/i.test(url);
+}
+
+interface ResolveConnectionUrlInput {
+  mode?: string | null;
+  subscriptionUrl?: string | null;
+  displayLink?: string | null;
+  happSchemeLink?: string | null;
+  happCryptLink?: string | null;
+  happCryptoLink?: string | null;
+  happLink?: string | null;
+  fallbackUrl?: string | null;
+}
+
+export function resolveConnectionUrlForUi(input: ResolveConnectionUrlInput): string | null {
+  const defaultUrl =
+    input.fallbackUrl ?? input.subscriptionUrl ?? input.displayLink ?? input.happSchemeLink ?? null;
+
+  if (!isHappCryptolinkMode(input.mode)) return defaultUrl;
+
+  const backendCryptLink =
+    [
+      input.happCryptLink,
+      input.happCryptoLink,
+      input.happLink,
+      input.happSchemeLink,
+      input.displayLink,
+      input.subscriptionUrl,
+    ].find((value) => isHappCryptDeepLink(value)) ?? null;
+  if (backendCryptLink) return backendCryptLink;
+
+  const sourceSubscriptionUrl =
+    [input.subscriptionUrl, input.displayLink, input.fallbackUrl].find((value) =>
+      isHttpUrl(value),
+    ) ?? null;
+
+  if (sourceSubscriptionUrl) {
+    return (
+      createHappCryptoLink(sourceSubscriptionUrl, 'v4', true) ??
+      createHappCryptoLink(sourceSubscriptionUrl, 'v3', true) ??
+      defaultUrl
+    );
+  }
+
+  return defaultUrl;
+}


### PR DESCRIPTION
## Что сделано

- Исправлен flow подключения в режиме `HAPP_CRYPTOLINK`:
- в UI приоритет отдается cryptolink из backend (если передан)
- если backend вернул обычную ссылку подписки, добавлен fallback-генератор `happ://crypt4/...` (с fallback на `crypt3`)
- одинаковая логика применена для:
- кнопки подключения в гайде (`/connection`)
- QR-страницы (`/connection/qr`)
- ссылки и копирования на странице подписки (`/subscriptions/:id`)

- Исправлено поведение редиректа:
- промежуточная `redirect.html` используется только внутри Telegram Mini App
- в обычном браузере deeplink открывается напрямую

- UI-правка:
- на `/subscriptions` длинный happ-cryptolink отображается в одну строку с `...`
- полная ссылка доступна в `title` (hover), кнопка копирования работает как раньше

- README:
- исправлены команды docker compose create, чтобы контейнер создавался с правильным именем
- исправлены команды `docker cp`, чтобы копировалось содержимое `html/.` (без вложенной папки `html`, которая вызывала 404)

## Почему

- В режиме anti-abuse пользователю должен передаваться именно happ cryptolink, а не обычная subscription URL.
- Длинные cryptolink’и ломали визуал карточки подписки.
- Неправильный `docker cp` в README приводил к частой ошибке деплоя (404 на корне).

## Проверка

- `npm run type-check` — OK
- `npm run lint` — без ошибок (есть старый warning в `AdminSettings.tsx`, не относится к PR)
- Ручная проверка:
- `/subscriptions/:id` показывает cryptolink в одну строку с обрезкой
- `/connection/qr` и кнопки в гайде используют happ cryptolink
- в обычном браузере deeplink открывается напрямую, без лишнего redirect page

## Измененные файлы

- `src/utils/connectionLink.ts`
- `src/pages/Connection.tsx`
- `src/pages/Subscription.tsx`
- `src/api/subscription.ts`
- `src/providers/WebSocketProvider.tsx`
- `README.md`
