### PR TITLE
Добавить поддержку v2raytun в TV Quick Connect

### DIFF
--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -480,6 +480,17 @@ export const subscriptionApi = {
     return response.data;
   },
 
+  sendTvQuickConnect: async (
+    qrData: string,
+    subscriptionId?: number,
+  ): Promise<{ status: string; provider: 'happ' | 'v2raytun' }> => {
+    const response = await apiClient.post(
+      '/cabinet/subscription/tv-quick-connect',
+      ...bodyWithSubId({ qr_data: qrData }, subscriptionId),
+    );
+    return response.data;
+  },
+
   getAppConfig: async (subscriptionId?: number): Promise<AppConfig> => {
     const response = await apiClient.get<AppConfig>(
       '/cabinet/subscription/app-config',

--- a/src/components/connection/InstallationGuide.tsx
+++ b/src/components/connection/InstallationGuide.tsx
@@ -45,6 +45,7 @@ interface Props {
   isTelegramWebApp: boolean;
   onGoBack: () => void;
   onOpenQR?: () => void;
+  subscriptionId?: number;
 }
 
 export default function InstallationGuide({
@@ -53,6 +54,7 @@ export default function InstallationGuide({
   isTelegramWebApp,
   onGoBack,
   onOpenQR,
+  subscriptionId,
 }: Props) {
   const { t, i18n } = useTranslation();
   const { isLight } = useTheme();
@@ -348,7 +350,7 @@ export default function InstallationGuide({
               renderBlockButtons={renderBlockButtons}
             />
           )}
-          <TvQuickConnect subscriptionUrl={appConfig.subscriptionUrl} isLight={isLight} />
+          <TvQuickConnect isLight={isLight} subscriptionId={subscriptionId} />
           {selectedApp.blocks.length > 1 && (
             <Renderer
               blocks={selectedApp.blocks.slice(-1)}

--- a/src/components/connection/TvQuickConnect.tsx
+++ b/src/components/connection/TvQuickConnect.tsx
@@ -5,6 +5,7 @@ import {
   isQrScannerSupported,
   retrieveLaunchParams,
 } from '@telegram-apps/sdk-react';
+import { subscriptionApi } from '@/api/subscription';
 
 const TG_MOBILE_PLATFORMS = new Set(['ios', 'android', 'android_x', 'ios_x']);
 
@@ -17,12 +18,11 @@ function isTelegramMobile(): boolean {
   }
 }
 
-const HAPP_TV_API = 'https://check.happ.su/sendtv';
 const HTML5_QRCODE_CDN = 'https://cdn.jsdelivr.net/npm/html5-qrcode@2.3.8/html5-qrcode.min.js';
 
 interface Props {
-  subscriptionUrl: string;
   isLight: boolean;
+  subscriptionId?: number;
 }
 
 interface Html5QrcodeInstance {
@@ -36,7 +36,7 @@ interface Html5QrcodeInstance {
   clear: () => void;
 }
 
-export default function TvQuickConnect({ subscriptionUrl, isLight }: Props) {
+export default function TvQuickConnect({ isLight, subscriptionId }: Props) {
   const { t } = useTranslation();
   const [code, setCode] = useState('');
   const [sending, setSending] = useState(false);
@@ -73,42 +73,36 @@ export default function TvQuickConnect({ subscriptionUrl, isLight }: Props) {
   }, []);
 
   const sendToTV = useCallback(
-    async (tvCode: string) => {
+    async (qrData: string) => {
       if (sending) return;
-      const clean = tvCode.trim().toUpperCase();
-      if (!(clean.length === 5 && /^[A-Z0-9]+$/.test(clean))) {
-        showToast(t('subscription.tvQuickConnect.badCode'), 'error');
+      const payload = qrData.trim();
+      if (!payload) {
+        showToast(t('subscription.tvQuickConnect.error'), 'error');
         return;
       }
 
       setSending(true);
       try {
-        const b64 = btoa(unescape(encodeURIComponent(subscriptionUrl)));
-        const ctrl = new AbortController();
-        const timer = setTimeout(() => ctrl.abort(), 10000);
-
-        const res = await fetch(`${HAPP_TV_API}/${encodeURIComponent(clean)}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ data: b64 }),
-          signal: ctrl.signal,
-        });
-        clearTimeout(timer);
-
-        if (res.ok) {
-          showToast(t('subscription.tvQuickConnect.sent'), 'success');
-          setCode('');
-        } else {
-          showToast(t('subscription.tvQuickConnect.error'), 'error');
-        }
+        await subscriptionApi.sendTvQuickConnect(payload, subscriptionId);
+        showToast(t('subscription.tvQuickConnect.sent'), 'success');
+        setCode('');
       } catch {
         showToast(t('subscription.tvQuickConnect.error'), 'error');
       } finally {
         setSending(false);
       }
     },
-    [sending, subscriptionUrl, showToast, t],
+    [sending, subscriptionId, showToast, t],
   );
+
+  const sendManualCode = useCallback(() => {
+    const clean = code.trim().toUpperCase();
+    if (!(clean.length === 5 && /^[A-Z0-9]+$/.test(clean))) {
+      showToast(t('subscription.tvQuickConnect.badCode'), 'error');
+      return;
+    }
+    sendToTV(clean);
+  }, [code, sendToTV, showToast, t]);
 
   const stopScan = useCallback(() => {
     if (scannerRef.current) {
@@ -125,12 +119,18 @@ export default function TvQuickConnect({ subscriptionUrl, isLight }: Props) {
 
   const onScanDecoded = useCallback(
     (decoded: string) => {
-      const parsed = parseQRCode(decoded);
-      if (!parsed) return;
+      const payload = decoded.trim();
+      if (!payload) return;
       stopScan();
-      setCode(parsed);
-      showToast(`${t('subscription.tvQuickConnect.codeFound')}: ${parsed}`, 'success');
-      setTimeout(() => sendToTV(parsed), 500);
+      const happCode = parseHappCode(payload);
+      if (happCode) setCode(happCode);
+      showToast(
+        happCode
+          ? `${t('subscription.tvQuickConnect.codeFound')}: ${happCode}`
+          : t('subscription.tvQuickConnect.codeFound'),
+        'success',
+      );
+      setTimeout(() => sendToTV(payload), 500);
     },
     [stopScan, showToast, sendToTV, t],
   );
@@ -141,15 +141,13 @@ export default function TvQuickConnect({ subscriptionUrl, isLight }: Props) {
       try {
         const qr = await openQrScanner({
           text: t('subscription.tvQuickConnect.scanDescription'),
-          capture: (s: string) => parseQRCode(s) !== null,
+          capture: (s: string) => s.trim().length > 0,
         });
         if (qr) {
-          const parsed = parseQRCode(qr);
-          if (parsed) {
-            setCode(parsed);
-            showToast(t('subscription.tvQuickConnect.codeFound'), 'success');
-            sendToTV(parsed);
-          }
+          const happCode = parseHappCode(qr);
+          if (happCode) setCode(happCode);
+          showToast(t('subscription.tvQuickConnect.codeFound'), 'success');
+          sendToTV(qr);
         }
       } catch {
         showToast(t('subscription.tvQuickConnect.error'), 'error');
@@ -238,7 +236,7 @@ export default function TvQuickConnect({ subscriptionUrl, isLight }: Props) {
                 className={inputClass}
               />
               <button
-                onClick={() => sendToTV(code)}
+                onClick={sendManualCode}
                 disabled={sending || code.length !== 5}
                 className="btn-primary w-full justify-center py-3 disabled:opacity-50"
               >
@@ -333,7 +331,7 @@ export default function TvQuickConnect({ subscriptionUrl, isLight }: Props) {
   );
 }
 
-function parseQRCode(data: string): string | null {
+function parseHappCode(data: string): string | null {
   if (data.length === 5 && /^[A-Z0-9]+$/i.test(data)) {
     return data.toUpperCase();
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -628,17 +628,17 @@
     },
     "tvQuickConnect": {
       "title": "Connect TV",
-      "description": "Enter the 5-character code from your TV screen",
+      "description": "Enter the 5-character Happ code from your TV screen",
       "sendBtn": "Send to TV",
       "badCode": "Enter a 5-character code (letters and digits)",
       "sent": "Sent to TV!",
       "error": "Failed to send to TV",
       "scanTitle": "Scan QR Code",
-      "scanDescription": "Scan the QR code from your TV screen",
+      "scanDescription": "Scan the QR code from Happ or v2raytun on your TV screen",
       "scanBtn": "Scan QR from TV",
       "stopScan": "Close camera",
       "noCamera": "Camera access denied",
-      "codeFound": "Code found"
+      "codeFound": "TV QR code found"
     }
   },
   "balance": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -656,17 +656,17 @@
     },
     "tvQuickConnect": {
       "title": "Подключить TV",
-      "description": "Введите 5-значный код с экрана телевизора",
+      "description": "Введите 5-значный код Happ с экрана телевизора",
       "sendBtn": "Отправить на TV",
       "badCode": "Введите 5-значный код (буквы и цифры)",
       "sent": "Отправлено на TV!",
       "error": "Ошибка отправки на TV",
       "scanTitle": "Сканировать QR-код",
-      "scanDescription": "Отсканируйте QR-код с экрана телевизора",
+      "scanDescription": "Отсканируйте QR-код из Happ или v2raytun на экране телевизора",
       "scanBtn": "Сканировать QR с TV",
       "stopScan": "Закрыть камеру",
       "noCamera": "Нет доступа к камере",
-      "codeFound": "Код найден"
+      "codeFound": "QR-код TV найден"
     }
   },
   "balance": {

--- a/src/pages/Connection.tsx
+++ b/src/pages/Connection.tsx
@@ -229,6 +229,7 @@ export default function Connection() {
       isTelegramWebApp={isTelegramWebApp}
       onGoBack={handleGoBack}
       onOpenQR={handleOpenQR}
+      subscriptionId={subId}
     />
   );
 }


### PR DESCRIPTION
## Что изменено

Обновлен TV Quick Connect в кабинете: теперь он поддерживает не только Happ TV-коды, но и QR-коды v2raytun с телевизора.

## Основные изменения

- Frontend больше не отправляет Happ-код напрямую на Happ API.
- Вместо этого TV Quick Connect отправляет сырой QR payload на backend: `POST /cabinet/subscription/tv-quick-connect`.
- Ручной ввод 5-символьного Happ-кода сохранен.
- QR scanner теперь принимает v2raytun TV QR payload, а не только Happ-like код.
- Прокинут `subscription_id`, чтобы при multi-tariff отправлялась выбранная подписка.
- Обновлены RU/EN тексты интерфейса.

## Зачем

Раньше сканер принимал только Happ-код, поэтому QR-код v2raytun с Android TV нельзя было использовать. Теперь frontend становится provider-agnostic: он сканирует QR и передает его backend, а backend уже решает, как отправить подписку.

## Требует

Backend/bot PR: https://github.com/BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot/pull/2931