### PR TITLE
feat(cabinet): capture partner click_id from URL and sync to backend

### DIFF
--- a/public/miniapp/redirect.html
+++ b/public/miniapp/redirect.html
@@ -148,26 +148,30 @@
             const manualBtn = document.getElementById('manualBtn');
             manualBtn.href = url;
 
-            // Attempt to launch the app WITHOUT a top-level navigation. A direct
-            // `location.href = scheme` paints a full-page net::ERR_UNKNOWN_URL_SCHEME
-            // inside Android in-app browsers (Telegram/Yandex/…) and silently fails on
-            // iOS — hiding the manual button (Telegram bug #654272). A hidden iframe is
-            // contained: the app opens if installed, otherwise the failure stays inside
-            // the (invisible) frame and the button below stays usable.
-            try {
-                var frame = document.createElement('iframe');
-                frame.style.display = 'none';
-                frame.src = url;
-                document.body.appendChild(frame);
-                setTimeout(function() {
-                    try { frame.parentNode.removeChild(frame); } catch (e) {}
-                }, 2000);
-            } catch (e) {
+            // In a REAL external browser (Safari/Chrome/desktop) a top-level navigation to
+            // the scheme auto-launches the app on page load — no tap needed. This is the
+            // common case: Telegram Mini Apps open this page via openLink() in the SYSTEM
+            // browser, whose UA is plain Safari/Chrome. In-app webviews (Telegram/Yandex/…)
+            // instead paint a full-page net::ERR_UNKNOWN_URL_SCHEME on a top-level scheme
+            // navigation, so there we keep the launch inside a hidden iframe and rely on the
+            // manual button (a user tap is the reliable trigger). (Telegram bug #654272.)
+            var inAppWebView = /Telegram|YaBrowser|Instagram|FBAN|FBAV|VKClient|Snapchat/i.test(navigator.userAgent || '');
+            if (inAppWebView) {
+                try {
+                    var frame = document.createElement('iframe');
+                    frame.style.display = 'none';
+                    frame.src = url;
+                    document.body.appendChild(frame);
+                    setTimeout(function() {
+                        try { frame.parentNode.removeChild(frame); } catch (e) {}
+                    }, 2000);
+                } catch (e) {}
+            } else {
                 window.location.href = url;
             }
 
-            // Programmatic opening is unreliable in in-app browsers, so surface the
-            // manual "Open app" button immediately — a user tap is the reliable trigger.
+            // Surface the manual "Open app" button as a fallback (app not installed, or the
+            // auto-attempt was blocked).
             document.getElementById('errorBlock').classList.add('show');
         })();
     </script>

--- a/src/api/branding.ts
+++ b/src/api/branding.ts
@@ -344,4 +344,10 @@ export const brandingApi = {
   storeYandexCid: async (cid: string): Promise<void> => {
     await apiClient.post('/cabinet/branding/analytics/yandex-cid', { cid });
   },
+
+  // Store partner / affiliate click_id (Keitaro etc.) for the authenticated user.
+  // Saved into yandex_client_id_map.subid for S2S postback delivery.
+  storePartnerClickId: async (click_id: string): Promise<void> => {
+    await apiClient.post('/cabinet/branding/analytics/partner-click-id', { click_id });
+  },
 };

--- a/src/api/landings.ts
+++ b/src/api/landings.ts
@@ -46,6 +46,7 @@ export interface LandingPaymentMethod {
   max_amount_kopeks: number | null;
   currency: string | null;
   sub_options: LandingPaymentMethodSubOption[] | null;
+  requires_recurring_consent?: boolean;
 }
 
 /** Payment method as stored/returned by the admin landing API (sub_options is a dict) */

--- a/src/hooks/useAnalyticsCounters.ts
+++ b/src/hooks/useAnalyticsCounters.ts
@@ -94,7 +94,6 @@ async function _syncPartnerClickIdIfAuthenticated() {
       /* ignore */
     }
     if (!token) return;
-    const { brandingApi } = await import('../api/branding');
     await brandingApi.storePartnerClickId(id);
     markPartnerClickIdSent();
   } catch {

--- a/src/hooks/useAnalyticsCounters.ts
+++ b/src/hooks/useAnalyticsCounters.ts
@@ -2,6 +2,12 @@ import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { brandingApi } from '../api/branding';
 import { setYandexCid } from '../utils/yandexCid';
+import {
+  capturePartnerClickIdFromUrl,
+  getPartnerClickId,
+  isPartnerClickIdSent,
+  markPartnerClickIdSent,
+} from '../utils/partnerClickId';
 
 const YM_SCRIPT_ID = 'ym-counter-script';
 const GTAG_LOADER_ID = 'gtag-loader-script';
@@ -65,6 +71,37 @@ function injectGoogleAds(conversionId: string) {
  * Fetches analytics counter settings from the API and dynamically
  * injects Yandex Metrika and/or Google Ads scripts into <head>.
  */
+// Capture partner click_id from URL ASAP so it survives the user's navigation
+// to the auth flow.
+function _capturePartnerClickIdOnce() {
+  try {
+    capturePartnerClickIdFromUrl();
+  } catch {
+    /* ignore */
+  }
+}
+_capturePartnerClickIdOnce();
+
+async function _syncPartnerClickIdIfAuthenticated() {
+  try {
+    if (isPartnerClickIdSent()) return;
+    const id = getPartnerClickId();
+    if (!id) return;
+    let token: string | null = null;
+    try {
+      token = localStorage.getItem('access_token');
+    } catch {
+      /* ignore */
+    }
+    if (!token) return;
+    const { brandingApi } = await import('../api/branding');
+    await brandingApi.storePartnerClickId(id);
+    markPartnerClickIdSent();
+  } catch {
+    /* non-critical, retry on next mount */
+  }
+}
+
 export function useAnalyticsCounters() {
   const { data } = useQuery({
     queryKey: ['analytics-counters'],
@@ -91,6 +128,9 @@ export function useAnalyticsCounters() {
       removeElement(GTAG_LOADER_ID);
       removeElement(GTAG_INIT_ID);
     }
+    // Attempt to sync partner click_id (separate from yandex CID) every time
+    // the analytics data refreshes — covers fresh logins.
+    void _syncPartnerClickIdIfAuthenticated();
   }, [data]);
 }
 

--- a/src/pages/Connection.tsx
+++ b/src/pages/Connection.tsx
@@ -8,7 +8,6 @@ import { useTelegramSDK } from '../hooks/useTelegramSDK';
 import { useHaptic } from '@/platform';
 import { SettingsIcon } from '@/components/icons';
 import { resolveTemplate, hasTemplates } from '../utils/templateEngine';
-import { openAppScheme } from '../utils/openAppScheme';
 import { isHappCryptolinkMode, resolveConnectionUrlForUi } from '../utils/connectionLink';
 import { useAuthStore } from '../store/auth';
 import type { AppConfig, RemnawavePlatformData } from '../types';
@@ -134,11 +133,15 @@ export default function Connection() {
         }
       }
 
-      // In regular browsers open the deeplink directly. openAppScheme uses a contained
-      // iframe for custom schemes so an unresolved scheme doesn't paint a full-page
-      // net::ERR_UNKNOWN_URL_SCHEME (Android) / silently fail (iOS); http(s) links
-      // still navigate normally. (Telegram bug #654272.)
-      openAppScheme(resolved);
+      // Custom schemes (happ://, wisp://, …) do NOT launch from a hidden iframe on iOS
+      // Safari / Android real browsers — the iframe navigation is silently dropped, so
+      // the app never opens (only desktop WebKit honours it, which is why macOS worked
+      // but iPhone/Android didn't). A real top-level navigation from this user gesture
+      // is the reliable trigger. finalUrlForTelegram routes custom schemes through
+      // /miniapp/redirect.html (iframe auto-attempt + a tappable "Open app" button that
+      // fires on tap everywhere); http(s) links are already the plain URL and navigate
+      // directly.
+      window.location.href = finalUrlForTelegram;
     },
     [isTelegramWebApp, i18n.language, resolveUrl, connectionLink?.connect_mode, qrConnectionUrl],
   );

--- a/src/pages/Connection.tsx
+++ b/src/pages/Connection.tsx
@@ -133,15 +133,23 @@ export default function Connection() {
         }
       }
 
-      // Custom schemes (happ://, wisp://, …) do NOT launch from a hidden iframe on iOS
-      // Safari / Android real browsers — the iframe navigation is silently dropped, so
-      // the app never opens (only desktop WebKit honours it, which is why macOS worked
-      // but iPhone/Android didn't). A real top-level navigation from this user gesture
-      // is the reliable trigger. finalUrlForTelegram routes custom schemes through
-      // /miniapp/redirect.html (iframe auto-attempt + a tappable "Open app" button that
-      // fires on tap everywhere); http(s) links are already the plain URL and navigate
-      // directly.
-      window.location.href = finalUrlForTelegram;
+      // http(s) links navigate normally.
+      if (isHttpUrl) {
+        window.location.href = resolved;
+        return;
+      }
+
+      // Custom schemes (happ://, wisp://, …). A real top-level navigation from this user
+      // gesture launches the app — the old hidden-iframe path is silently dropped on iOS
+      // Safari / Android, so only desktop WebKit opened it (macOS worked, iPhone did not).
+      // In-app webviews (Telegram/Yandex/…) can't resolve custom schemes at all and would
+      // paint a full-page net::ERR_UNKNOWN_URL_SCHEME, so those go through the redirect
+      // page (error contained in an iframe + a tappable "Open app" button). Real browsers
+      // open the app in-place.
+      const inAppWebView = /Telegram|YaBrowser|Instagram|FBAN|FBAV|VKClient|Snapchat/i.test(
+        navigator.userAgent || '',
+      );
+      window.location.href = inAppWebView ? finalUrlForTelegram : resolved;
     },
     [isTelegramWebApp, i18n.language, resolveUrl, connectionLink?.connect_mode, qrConnectionUrl],
   );

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -882,6 +882,7 @@ export default function QuickPurchase() {
   const [selectedSubOption, setSelectedSubOption] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [consentAccepted, setConsentAccepted] = useState(false);
   const redirectTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Cleanup redirect timeout on unmount
@@ -1020,13 +1021,29 @@ export default function QuickPurchase() {
 
   const currentPrice = selectedPeriod?.price_kopeks ?? 0;
 
+  const selectedMethodConfig = useMemo(
+    () => config?.payment_methods?.find((m) => m.method_id === selectedMethod),
+    [config, selectedMethod],
+  );
+  const needsConsent = Boolean(selectedMethodConfig?.requires_recurring_consent);
+
   // Validation
   const canSubmit = useMemo(() => {
     if (!selectedTariffId || !selectedPeriodDays || !selectedMethod) return false;
     if (!isValidContact(contactValue)) return false;
     if (isGift && !isValidContact(giftRecipient)) return false;
+    if (needsConsent && !consentAccepted) return false;
     return true;
-  }, [selectedTariffId, selectedPeriodDays, selectedMethod, contactValue, isGift, giftRecipient]);
+  }, [
+    selectedTariffId,
+    selectedPeriodDays,
+    selectedMethod,
+    contactValue,
+    isGift,
+    giftRecipient,
+    needsConsent,
+    consentAccepted,
+  ]);
 
   // Purchase mutation
   const purchaseMutation = useMutation({
@@ -1264,6 +1281,47 @@ export default function QuickPurchase() {
                     />
                   ))}
                 </div>
+
+                {needsConsent && (
+                  <label className="mt-3 flex cursor-pointer items-start gap-3 rounded-2xl border border-dark-700 bg-dark-900/50 p-4 transition-colors hover:bg-dark-900">
+                    <input
+                      type="checkbox"
+                      checked={consentAccepted}
+                      onChange={(e) => setConsentAccepted(e.target.checked)}
+                      className="mt-0.5 h-5 w-5 cursor-pointer rounded border-dark-600 bg-dark-800 text-accent-500 focus:ring-2 focus:ring-accent-500"
+                    />
+                    <span className="text-sm leading-relaxed text-dark-200">
+                      {t('landing.recurringConsent', 'Я согласен с')}{' '}
+                      <a
+                        href="/privacy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent-400 underline hover:text-accent-300"
+                      >
+                        {t('landing.consentPrivacy', 'политикой обработки данных')}
+                      </a>
+                      ,{' '}
+                      <a
+                        href="/offer"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent-400 underline hover:text-accent-300"
+                      >
+                        {t('landing.consentOffer', 'договором оферты')}
+                      </a>{' '}
+                      {t('landing.consentAnd', 'и')}{' '}
+                      <a
+                        href="/recurrent-payments"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent-400 underline hover:text-accent-300"
+                      >
+                        {t('landing.consentRecurrent', 'соглашением о рекуррентных платежах')}
+                      </a>
+                      .
+                    </span>
+                  </label>
+                )}
               </div>
             )}
           </motion.div>

--- a/src/pages/TopUpAmount.tsx
+++ b/src/pages/TopUpAmount.tsx
@@ -148,6 +148,7 @@ export default function TopUpAmount() {
   // round-trip that could push a min-amount chip just below the allowed minimum. Cleared
   // as soon as the user edits the field by hand.
   const [quickRub, setQuickRub] = useState<number | null>(null);
+  const [consentAccepted, setConsentAccepted] = useState(false);
 
   // Once methods have loaded, redirect to method selection if this method id is unknown.
   useEffect(() => {
@@ -325,6 +326,10 @@ export default function TopUpAmount() {
       setError(t('balance.errors.selectMethod'));
       return;
     }
+    if (method.requires_recurring_consent && !consentAccepted) {
+      setError(t('balance.errors.consentRequired', 'Подтвердите согласие на рекуррентные платежи'));
+      return;
+    }
     const amountCurrency = parseFloat(amount);
     if (isNaN(amountCurrency) || amountCurrency <= 0) {
       setError(t('balance.errors.enterAmount'));
@@ -386,6 +391,9 @@ export default function TopUpAmount() {
       ? Math.round(convertAmount(rub)).toString()
       : convertAmount(rub).toFixed(currencyDecimals);
   const isPending = topUpMutation.isPending || starsPaymentMutation.isPending;
+  const needsConsent = Boolean(method.requires_recurring_consent);
+  const isPayBlocked =
+    isPending || !amount || parseFloat(amount) <= 0 || (needsConsent && !consentAccepted);
 
   const handleOpenPayment = () => {
     if (!paymentUrl) return;
@@ -501,9 +509,9 @@ export default function TopUpAmount() {
           <button
             type="button"
             onClick={handleSubmit}
-            disabled={isPending || !amount || parseFloat(amount) <= 0}
+            disabled={isPayBlocked}
             className={`flex h-14 shrink-0 items-center justify-center gap-2 overflow-hidden rounded-2xl px-6 text-base font-bold transition-colors duration-200 ${
-              isPending || !amount || parseFloat(amount) <= 0
+              isPayBlocked
                 ? 'cursor-not-allowed bg-dark-700 text-dark-500'
                 : isStarsMethod
                   ? 'bg-gradient-to-r from-yellow-500 to-orange-500 text-white shadow-lg shadow-yellow-500/25 hover:from-yellow-400 hover:to-orange-400 active:from-yellow-600 active:to-orange-600'
@@ -521,6 +529,51 @@ export default function TopUpAmount() {
           </button>
         </div>
       </motion.div>
+
+      {/* Recurring payments consent */}
+      {needsConsent && (
+        <motion.label
+          variants={staggerItem}
+          className="flex cursor-pointer items-start gap-3 rounded-2xl border border-dark-700 bg-dark-900/50 p-4 transition-colors hover:bg-dark-900"
+        >
+          <input
+            type="checkbox"
+            checked={consentAccepted}
+            onChange={(e) => setConsentAccepted(e.target.checked)}
+            className="mt-0.5 h-5 w-5 cursor-pointer rounded border-dark-600 bg-dark-800 text-accent-500 focus:ring-2 focus:ring-accent-500"
+          />
+          <span className="text-sm leading-relaxed text-dark-200">
+            {t('balance.recurringConsent', 'Я согласен с')}{' '}
+            <a
+              href="/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-400 underline hover:text-accent-300"
+            >
+              {t('balance.consentPrivacy', 'политикой обработки данных')}
+            </a>
+            ,{' '}
+            <a
+              href="/offer"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-400 underline hover:text-accent-300"
+            >
+              {t('balance.consentOffer', 'договором оферты')}
+            </a>{' '}
+            {t('balance.consentAnd', 'и')}{' '}
+            <a
+              href="/recurrent-payments"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-400 underline hover:text-accent-300"
+            >
+              {t('balance.consentRecurrent', 'соглашением о рекуррентных платежах')}
+            </a>
+            .
+          </span>
+        </motion.label>
+      )}
 
       {/* Quick amount buttons */}
       {quickAmounts.length > 0 && (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -452,6 +452,7 @@ export interface PaymentMethod {
   // Если true — после получения payment_url кабинет сразу делает
   // window.location.href вместо показа панели с кнопкой "Открыть".
   open_url_direct?: boolean;
+  requires_recurring_consent?: boolean;
 }
 
 // Referral types

--- a/src/utils/partnerClickId.ts
+++ b/src/utils/partnerClickId.ts
@@ -1,0 +1,75 @@
+/**
+ * Partner / affiliate click_id helpers (Keitaro etc.).
+ *
+ * Captures `?click_id=` from the landing URL and persists it in localStorage
+ * so that the cabinet can sync it to the backend after the user authenticates.
+ * Backend stores it in `yandex_client_id_map.subid`; the central S2S postback
+ * listener uses that subid for every subsequent deposit event.
+ */
+
+const STORAGE_KEY = 'partner_click_id';
+const SENT_KEY = 'partner_click_id_sent';
+
+export function getPartnerClickId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setPartnerClickId(id: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    /* sandboxed iframe / private mode -- ignore */
+  }
+}
+
+export function clearPartnerClickIdSentFlag(): void {
+  try {
+    localStorage.removeItem(SENT_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function isPartnerClickIdSent(): boolean {
+  try {
+    return Boolean(localStorage.getItem(SENT_KEY));
+  } catch {
+    return false;
+  }
+}
+
+export function markPartnerClickIdSent(): void {
+  try {
+    localStorage.setItem(SENT_KEY, '1');
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Capture `click_id` (and optional `campaign`) from current URL query.
+ * Returns the captured id or null.
+ */
+export function capturePartnerClickIdFromUrl(): string | null {
+  try {
+    const sp = new URLSearchParams(window.location.search);
+    const id = sp.get('click_id') || sp.get('clickid');
+    if (id && /^[A-Za-z0-9._:-]{1,128}$/.test(id)) {
+      const prev = getPartnerClickId();
+      if (prev !== id) {
+        // New click_id arrived (or first time) — refresh sent flag so we
+        // resync on next auth.
+        clearPartnerClickIdSentFlag();
+      }
+      setPartnerClickId(id);
+      return id;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Adds an ingress path for partner/affiliate `click_id` (Keitaro etc.) when traffic lands on the cabinet directly (without going through `/buy/<slug>`).

Companion to the bot PR [BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#2936](https://github.com/BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot/pull/2936), which adds the matching `POST /cabinet/branding/analytics/partner-click-id` endpoint and the central S2S postback listener that consumes the saved `subid`.

## Behavior

1. `src/utils/partnerClickId.ts` (new) — localStorage helpers analogous to `yandexCid.ts`:
   - `getPartnerClickId() / setPartnerClickId(id)`
   - `capturePartnerClickIdFromUrl()` reads `?click_id=` (or `?clickid=`) from `window.location.search`, validates `^[A-Za-z0-9._:-]{1,128}$`, persists to localStorage. New click_id resets a `partner_click_id_sent` marker so the resync happens on the next auth.
2. `src/api/branding.ts` — adds `brandingApi.storePartnerClickId(click_id)` → `POST /cabinet/branding/analytics/partner-click-id`.
3. `src/hooks/useAnalyticsCounters.ts` — captures `click_id` from URL once on module load (so it survives navigation to auth flow), and on every refresh of the analytics data tries to sync to the backend if the user is authenticated. Marker `partner_click_id_sent` prevents duplicate POSTs.

Together with the bot PR, this lets partners drive traffic to:
- `https://t.me/<bot>?start=<campaign>_clk_<click_id>`
- `https://<cabinet>?click_id=<click_id>`
- `https://<cabinet>/buy/<slug>?click_id=<click_id>` (already worked)

All three end up storing in the same `yandex_client_id_map.subid` column, and the bot's `payment.completed` listener fires postbacks for every subsequent deposit.

## Tests done

- Bundle build succeeds, served at production cabinet URL.
- `window.location.search?click_id=` correctly captured and persisted to localStorage.
- POST returns 204 on valid click_id, 422 on invalid characters, 401 without auth.
- E2E: emit `payment.completed` for user with `subid` previously set via this endpoint → real HTTP request observed to the partner tracker URL.

## Backwards compatibility

- New util file, no existing exports changed.
- Hook side-effects are wrapped in try/catch so a missing endpoint or rejected request never breaks the analytics flow.