### PR TITLE
feat(landing): support virtual trial period

### DIFF
--- a/src/api/landings.ts
+++ b/src/api/landings.ts
@@ -15,6 +15,14 @@ export interface LandingTariffPeriod {
   original_price_kopeks: number | null;
   original_price_label: string | null;
   discount_percent: number | null;
+  /**
+   * Marks a virtual period that represents a paid trial. The backend may
+   * inject this entry when a trial product is enabled. When true, the UI
+   * shows `label` verbatim (e.g. "Trial period") instead of formatting
+   * the day count, and the admin editor renders it in a distinct style.
+   * Default: false / undefined for regular periods.
+   */
+  is_trial?: boolean;
 }
 
 export interface LandingTariff {

--- a/src/api/tariffs.ts
+++ b/src/api/tariffs.ts
@@ -5,6 +5,8 @@ export interface PeriodPrice {
   days: number;
   price_kopeks: number;
   price_rubles?: number;
+  /** Marks a virtual trial-period entry (read-only on the admin tariff editor). */
+  is_trial?: boolean;
 }
 
 export interface ServerTrafficLimit {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4016,6 +4016,7 @@
       "methodSubOptions": "Payment sub-options",
       "loadingPeriods": "Loading...",
       "periodDaySuffix": "d",
+      "trialPrefix": "Trial",
       "localeTab": "Language",
       "localeHint": "Switch language to edit text in that language",
       "discount": "Discount",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -3732,6 +3732,7 @@
       "methodSubOptions": "گزینه‌های فرعی پرداخت",
       "loadingPeriods": "در حال بارگذاری...",
       "periodDaySuffix": "روز",
+      "trialPrefix": "آزمایشی",
       "localeTab": "زبان",
       "localeHint": "زبان را تغییر دهید تا متن را به آن زبان ویرایش کنید",
       "discount": "تخفیف",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -4561,6 +4561,7 @@
       "methodSubOptions": "Варианты оплаты",
       "loadingPeriods": "Загрузка...",
       "periodDaySuffix": "д",
+      "trialPrefix": "Триал",
       "localeTab": "Язык",
       "localeHint": "Переключите язык для редактирования текста на этом языке",
       "discount": "Скидка",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -3731,6 +3731,7 @@
       "methodSubOptions": "支付子选项",
       "loadingPeriods": "加载中...",
       "periodDaySuffix": "天",
+      "trialPrefix": "试用",
       "localeTab": "语言",
       "localeHint": "切换语言以编辑该语言的文本",
       "discount": "折扣",

--- a/src/pages/AdminLandingEditor.tsx
+++ b/src/pages/AdminLandingEditor.tsx
@@ -766,6 +766,20 @@ export default function AdminLandingEditor() {
                           const override = allowedPeriods[String(tariff.id)];
                           const isAllowed = !override || override.includes(period.days);
                           const isTrial = Boolean(period.is_trial);
+                          const state: 'disabled' | 'trial' | 'normal' = !isAllowed
+                            ? 'disabled'
+                            : isTrial
+                              ? 'trial'
+                              : 'normal';
+                          const stateClass = {
+                            disabled: 'bg-dark-700/50 text-dark-500 line-through',
+                            trial: 'bg-amber-500/20 text-amber-300',
+                            normal: 'bg-accent-500/20 text-accent-400',
+                          }[state];
+                          const daySuffix = t('admin.landings.periodDaySuffix');
+                          const label = isTrial
+                            ? `${t('admin.landings.trialPrefix', 'Trial')} ${period.days}${daySuffix}`
+                            : `${period.days}${daySuffix}`;
                           return (
                             <button
                               key={period.days}
@@ -778,16 +792,10 @@ export default function AdminLandingEditor() {
                               }
                               className={cn(
                                 'rounded-full px-3 py-1 text-xs font-medium transition-colors',
-                                !isAllowed
-                                  ? 'bg-dark-700/50 text-dark-500 line-through'
-                                  : isTrial
-                                    ? 'bg-amber-500/20 text-amber-300'
-                                    : 'bg-accent-500/20 text-accent-400',
+                                stateClass,
                               )}
                             >
-                              {isTrial
-                                ? `${t('admin.landings.trialPrefix', 'Trial')} ${period.days}${t('admin.landings.periodDaySuffix')}`
-                                : `${period.days}${t('admin.landings.periodDaySuffix')}`}
+                              {label}
                               {' — '}
                               {formatPrice(period.price_kopeks)}
                             </button>

--- a/src/pages/AdminLandingEditor.tsx
+++ b/src/pages/AdminLandingEditor.tsx
@@ -765,6 +765,7 @@ export default function AdminLandingEditor() {
                         {tariffPeriodsMap[tariff.id].map((period) => {
                           const override = allowedPeriods[String(tariff.id)];
                           const isAllowed = !override || override.includes(period.days);
+                          const isTrial = Boolean(period.is_trial);
                           return (
                             <button
                               key={period.days}
@@ -777,13 +778,17 @@ export default function AdminLandingEditor() {
                               }
                               className={cn(
                                 'rounded-full px-3 py-1 text-xs font-medium transition-colors',
-                                isAllowed
-                                  ? 'bg-accent-500/20 text-accent-400'
-                                  : 'bg-dark-700/50 text-dark-500 line-through',
+                                !isAllowed
+                                  ? 'bg-dark-700/50 text-dark-500 line-through'
+                                  : isTrial
+                                    ? 'bg-amber-500/20 text-amber-300'
+                                    : 'bg-accent-500/20 text-accent-400',
                               )}
                             >
-                              {period.days}
-                              {t('admin.landings.periodDaySuffix')} —{' '}
+                              {isTrial
+                                ? `${t('admin.landings.trialPrefix', 'Trial')} ${period.days}${t('admin.landings.periodDaySuffix')}`
+                                : `${period.days}${t('admin.landings.periodDaySuffix')}`}
+                              {' — '}
                               {formatPrice(period.price_kopeks)}
                             </button>
                           );

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -126,7 +126,7 @@ function PeriodTabs({
               : 'bg-dark-800/50 text-dark-300 hover:bg-dark-700/50 hover:text-dark-100',
           )}
         >
-          {formatPeriodLabel(period.days, t)}
+          {period.is_trial ? period.label : formatPeriodLabel(period.days, t)}
         </button>
       ))}
     </div>
@@ -495,7 +495,9 @@ function SummaryCard({
               {t('landing.period', 'Period')}
             </p>
             <p className="mt-1 text-sm text-dark-200">
-              {formatPeriodLabel(selectedPeriod.days, t)}
+              {selectedPeriod.is_trial
+                ? selectedPeriod.label
+                : formatPeriodLabel(selectedPeriod.days, t)}
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary

Lets the backend inject a virtual period entry that represents a paid trial offer (e.g. one-rouble "try-it" period) by marking it `is_trial: true`. Frontend then renders `period.label` verbatim instead of formatting the day count, and the admin landing editor highlights it in amber so it's visually distinct from regular paid periods.

Pairs naturally with backend setups where trial pricing isn't stored in `tariff.period_prices` but injected at landing-config time when a trial is enabled.

## Design

Backwards-compatible, opt-in:
- `LandingTariffPeriod.is_trial?: boolean` — public landing config (default false).
- `PeriodPrice.is_trial?: boolean` — admin tariff API (default false).
- `PeriodTabs` + `SummaryCard` period field: use `period.label` when `is_trial`, otherwise existing `formatPeriodLabel(days, t)`.
- `AdminLandingEditor`: amber chip styling + localized `Trial …` prefix for trial periods. Toggle still behaves like any other period (unchecking adds the override to `allowed_periods` to hide the trial on that landing).

i18n: new `admin.landings.trialPrefix` for ru / en / zh / fa.

## Backwards compatibility

`is_trial` is optional and defaults to undefined / false. Backends that don't expose trial periods see no UI change.

## Test plan

- [ ] Landing config without any `is_trial: true` period → unchanged (Period tab shows formatted day count).
- [ ] Landing config with one `is_trial: true` period at the front → tab shows `period.label`, SummaryCard "Period" field shows `period.label`.
- [ ] Admin tariff with `is_trial` period → chip is amber, prefixed `Trial`. Toggling unchecks puts an override entry; trial hides on public landing.
- [ ] All 4 locales render the trial prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)