### PR TITLE
fix(admin/payments): remove duplicate "Оплачено" badge

### DIFF
--- a/src/pages/AdminPayments.tsx
+++ b/src/pages/AdminPayments.tsx
@@ -456,11 +456,6 @@ export default function AdminPayments() {
                         <span className="font-semibold text-dark-100">
                           {payment.method_display}
                         </span>
-                        {payment.is_paid && (
-                          <span className="rounded-full bg-green-500/20 px-2 py-0.5 text-xs font-medium text-green-400">
-                            {t('admin.payments.paid')}
-                          </span>
-                        )}
                       </div>
 
                       {/* Amount */}


### PR DESCRIPTION
## Summary

On `/admin/payments`, every paid row rendered **two** "Оплачено" pills side-by-side: one from `StatusBadge` (which already renders the localized `status_text` from backend — "Оплачено" / "Отклонено" / "Ошибка"), and a second hard-coded `is_paid` pill right after it.

Drop the duplicate; `StatusBadge` is the single source of truth.

## Test plan

- [ ] Visit `/admin/payments` with paid rows visible (e.g. recent EtoPlatezhi / YooKassa / WATA transactions)
- [ ] Confirm each row shows exactly one "Оплачено" / "Отклонено" / "Ошибка" pill, not two
- [ ] Locales (en/ru) still render correct text in StatusBadge