### PR TITLE
feat(landing): capture ?ref= URL param and send as referrer_code

### DIFF
--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -833,6 +833,10 @@ export default function QuickPurchase() {
       sessionStorage.setItem('landing_referrer', document.referrer.slice(0, 500));
     }
     // Save subid from URL (also clamped to backend limit of 255)
+    const urlRef = new URLSearchParams(window.location.search).get("ref");
+    if (urlRef) {
+      sessionStorage.setItem("landing_ref", urlRef.slice(0, 64));
+    }
     const urlSubid = new URLSearchParams(window.location.search).get('subid');
     if (urlSubid) {
       sessionStorage.setItem('landing_subid', urlSubid.slice(0, 255));
@@ -1075,6 +1079,8 @@ export default function QuickPurchase() {
     if (ymCid) data.yandex_cid = ymCid;
     const subid = sessionStorage.getItem('landing_subid');
     if (subid) (data as unknown as Record<string, unknown>).subid = subid;
+    const refCode = sessionStorage.getItem('landing_ref');
+    if (refCode) (data as unknown as Record<string, unknown>).referrer_code = refCode;
 
     // Fire landing-specific click goal
     if (config?.analytics_click_enabled && config?.analytics_click_goal) {


### PR DESCRIPTION
## Summary

Companion PR to BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#2962. Adds frontend wiring so partner referral attribution works on landing pages.

When a partner shares a link like `https://cabinet.example.com/buy/telegram?ref=ref6b4c6bc4`, this PR:

1. Reads `?ref=` from `window.location.search` on landing mount (alongside the existing `?subid=` capture).
2. Stashes it in `sessionStorage` under `landing_ref` so it survives navigation within the landing.
3. Sends it as `referrer_code` in the purchase request body, where the bot resolves it to `users.referral_code` and sets `users.referred_by_id` on user creation.

No UI change. Limited to 64 chars to match the backend `VARCHAR(64)` column.

## Test plan

- [x] Open `/buy/<slug>?ref=ABC` → `sessionStorage.getItem('landing_ref') === 'ABC'`
- [x] Submit purchase → request body contains `referrer_code: 'ABC'`
- [x] Open `/buy/<slug>` (no ref) → no `referrer_code` in body
- [x] `?ref=` with 200 chars → clamped to first 64
