### PR TITLE
hotfix: переводы интерфейса (после v1.54.0)

### DIFF
--- a/src/components/subscription/purchase/TariffPickerGrid.tsx
+++ b/src/components/subscription/purchase/TariffPickerGrid.tsx
@@ -74,7 +74,7 @@ export function TariffPickerGrid({
           </div>
           <div>
             <div className="text-sm font-medium text-success-400">
-              {t('subscription.promoGroup.title', {
+              {t('subscription.promoGroup.yourGroup', {
                 name: tariffs.find((tariff) => tariff.promo_group_name)?.promo_group_name,
               })}
             </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,11 +26,19 @@
     "all": "All",
     "units": {
       "gb": "GB",
-      "perGb": "/GB"
+      "perGb": "/GB",
+      "days": "days",
+      "mo": "mo"
     },
     "retry": "Retry",
     "saving": "Saving...",
-    "understand": "Got it"
+    "understand": "Got it",
+    "balance": "Balance",
+    "copied": "Copied",
+    "no_results": "No results",
+    "ok": "OK",
+    "processing": "Processing…",
+    "rangeTo": "to"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -45,7 +53,8 @@
     "info": "Info",
     "wheel": "Fortune Wheel",
     "menu": "Menu",
-    "gift": "Gift"
+    "gift": "Gift",
+    "navigation": "Navigation"
   },
   "notifications": {
     "ticketNotifications": "Ticket Notifications",
@@ -148,7 +157,17 @@
     "tariff": "Tariff",
     "validUntil": "Valid until",
     "goToSubscription": "Go to Subscription",
-    "goToBalance": "Go to Balance"
+    "goToBalance": "Go to Balance",
+    "devicesAdded": "+{{count}} devices",
+    "devicesPurchased": {
+      "title": "Devices added"
+    },
+    "totalDevices": "Total devices: {{count}}",
+    "totalTraffic": "Total traffic: {{value}}",
+    "trafficAdded": "+{{value}} traffic",
+    "trafficPurchased": {
+      "title": "Traffic added"
+    }
   },
   "auth": {
     "login": "Login",
@@ -290,7 +309,10 @@
       "subscription": "Subscription",
       "referrals": "Referrals",
       "earnings": "Earnings"
-    }
+    },
+    "manageAll": "Manage all",
+    "showAll": "Show all",
+    "subscriptions": "Subscriptions"
   },
   "subscription": {
     "title": "Subscription",
@@ -346,7 +368,8 @@
     "cta": {
       "expiredHint": "Choose a plan and pay",
       "trialHint": "More traffic and devices",
-      "activeHint": "Renewal and plan change"
+      "activeHint": "Renewal and plan change",
+      "renewHint": "Subscription expired — renew to continue using"
     },
     "connectionInfo": "Connection Info",
     "copyLink": "Copy Link",
@@ -458,7 +481,8 @@
       "goToApps": "Go to Apps settings",
       "qrTitle": "Subscription QR Code",
       "qrScanHint": "Scan to connect",
-      "qrButton": "QR Code"
+      "qrButton": "QR Code",
+      "openQr": "Open QR code"
     },
     "myDevices": "My Devices",
     "noDevices": "No connected devices",
@@ -561,7 +585,14 @@
       "buyTrafficGb": "Buy {{gb}} GB",
       "buyUnlimited": "Buy Unlimited",
       "manageServers": "Squad management",
-      "manageServersTitle": "Squad management"
+      "manageServersTitle": "Squad management",
+      "connectedDevices": "Connected devices",
+      "currentDeviceLimit": "Current device limit",
+      "decrementDevices": "Decrease devices",
+      "disconnectDevicesFirst": "Disconnect extra devices first",
+      "incrementDevices": "Add devices",
+      "minDeviceLimit": "Minimum device limit",
+      "newDeviceLimit": "New device limit"
     },
     "serverManagement": {
       "statusLegend": "✅ — connected • ➕ — will be added (paid) • ➖ — will be disconnected",
@@ -620,7 +651,27 @@
       "stopScan": "Close camera",
       "noCamera": "Camera access denied",
       "codeFound": "Code found"
-    }
+    },
+    "allTariffsPurchased": "All tariffs already purchased",
+    "autopay": "Auto-renew",
+    "backToList": "Back to subscriptions",
+    "confirmDelete": "Delete subscription?",
+    "dailyAutoCharge": "Daily auto-charge",
+    "defaultName": "Subscription",
+    "delete": "Delete",
+    "deleteTitle": "Delete subscription",
+    "get_config": "Get config",
+    "loadError": "Failed to load subscription",
+    "newTariff": "New tariff",
+    "noOptionsAvailable": "No options available",
+    "noRenewalOptions": "No renewal options",
+    "notFound": "Subscription not found",
+    "notFoundDesc": "It may have been deleted or not yet activated",
+    "servers": "Servers",
+    "statusActive": "Active",
+    "statusExpired": "Expired",
+    "statusLimited": "Limited",
+    "statusTrial": "Trial"
   },
   "balance": {
     "title": "Balance",
@@ -738,7 +789,9 @@
         "already_used_by_user": "You have already used this promo code",
         "user_not_found": "User not found",
         "server_error": "Server error"
-      }
+      },
+      "daysLeft": "Days left: {{count}}",
+      "selectSubscription": "Select a subscription"
     },
     "minAmountError": "Minimum amount: {{amount}} ₽",
     "maxAmountError": "Maximum amount: {{amount}} ₽",
@@ -798,7 +851,8 @@
       "timeoutDesc": "Payment processing is taking longer than usual. You can try checking the status again.",
       "goToBalance": "Go to Balance",
       "tryAgain": "Try Again"
-    }
+    },
+    "top_up": "Top up balance"
   },
   "referral": {
     "title": "Referral Program",
@@ -984,7 +1038,8 @@
     "useExternalLink": "Please use the external link to get support",
     "openSupport": "Open Support",
     "contactSupport": "Please contact {{username}} for support",
-    "contactUs": "Contact Support"
+    "contactUs": "Contact Support",
+    "create_ticket": "Create ticket"
   },
   "wheel": {
     "title": "Fortune Wheel",
@@ -1017,7 +1072,8 @@
       "insufficientBalance": "Insufficient balance",
       "topUpRequired": "Top up your balance to pay for spin",
       "starsNotAvailable": "Stars payment not available. Open the app via Telegram.",
-      "noSubscription": "An active subscription is required to spin the wheel. Activate your subscription first."
+      "noSubscription": "An active subscription is required to spin the wheel. Activate your subscription first.",
+      "selectSubscription": "Select a subscription first"
     },
     "payWithStars": "Pay with Stars",
     "payWithDays": "Pay with days",
@@ -1036,7 +1092,8 @@
       "title": "Try your luck!",
       "description": "Spin the wheel and win prizes: subscription days, balance, traffic and more!",
       "button": "Go to wheel"
-    }
+    },
+    "selectSubscription": "Select subscription"
   },
   "admin": {
     "backgrounds": {
@@ -1544,7 +1601,8 @@
       "promoGroupsShort": "groups",
       "noPromoGroups": "No promo groups",
       "cancelButton": "Cancel",
-      "saveButton": "Save"
+      "saveButton": "Save",
+      "notFound": "Payment method not found"
     },
     "remnawave": {
       "title": "RemnaWave",
@@ -1611,7 +1669,8 @@
           "offline": "Offline",
           "disabled": "Disabled",
           "users": "Users"
-        }
+        },
+        "usersOnlineCount": "{{count}} online"
       },
       "squads": {
         "synced": "Synced",
@@ -1642,7 +1701,9 @@
         "localSettings": "Local Settings",
         "trialEligible": "Trial Eligible",
         "price": "Price",
-        "users": "Users"
+        "users": "Users",
+        "inboundsCount": "{{count}} inbounds",
+        "membersCount": "{{count}} members"
       },
       "sync": {
         "autoSync": "Auto Sync",
@@ -1820,7 +1881,12 @@
       "btnConnect": "Connect",
       "btnSubscription": "Subscription",
       "btnSupport": "Support",
-      "btnHome": "Home"
+      "btnHome": "Home",
+      "category": "Category",
+      "categoryNews": "News",
+      "categoryPromo": "Promo",
+      "categorySystem": "System",
+      "stopping": "Stopping…"
     },
     "pinnedMessages": {
       "title": "Pinned Messages",
@@ -2310,7 +2376,10 @@
       "remnaWaveSettings": "RemnaWave Settings",
       "remnaWaveConfigUuid": "Config UUID",
       "remnaWaveConfigUuidHint": "UUID of subscription page config from RemnaWave panel",
-      "availableConfigs": "Available configs"
+      "availableConfigs": "Available configs",
+      "noConfigs": "No configs",
+      "remnaWaveConnected": "RemnaWave connected",
+      "remnaWaveDisconnected": "RemnaWave disconnected"
     },
     "tickets": {
       "title": "Ticket Management",
@@ -2361,7 +2430,13 @@
       "userNotificationsEnabled": "User Notifications",
       "userNotificationsEnabledDesc": "Send notifications to users about admin replies",
       "adminNotificationsEnabled": "Admin Notifications",
-      "adminNotificationsEnabledDesc": "Send notifications to admins about new tickets and replies"
+      "adminNotificationsEnabledDesc": "Send notifications to admins about new tickets and replies",
+      "replyFailed": "Failed to send reply",
+      "validation": {
+        "checkIntervalRange": "Check interval must be between 1 and 1440 minutes",
+        "reminderCooldownRange": "Reminder cooldown must be between 0 and 1440 minutes",
+        "slaMinutesRange": "SLA must be between 1 and 10080 minutes"
+      }
     },
     "tariffs": {
       "title": "Tariff Management",
@@ -2588,7 +2663,8 @@
         "deactivate": "Deactivate",
         "activate": "Activate",
         "edit": "Edit",
-        "delete": "Delete"
+        "delete": "Delete",
+        "registrations": "Registrations"
       },
       "modal": {
         "editTitle": "Edit Campaign",
@@ -2658,7 +2734,9 @@
         "totalSpending": "Subscription Spending",
         "periodComparison": "Period comparison",
         "vsLastWeek": "vs last week",
-        "topRegistrations": "Top registrations"
+        "topRegistrations": "Top registrations",
+        "subscriptionsIssued": "Subscriptions issued",
+        "tariffsIssued": "Tariffs issued"
       },
       "users": {
         "title": "Campaign Users",
@@ -2682,7 +2760,10 @@
         "delete": "Delete"
       },
       "loadError": "Failed to load campaign",
-      "updateError": "Failed to save changes"
+      "updateError": "Failed to save changes",
+      "validation": {
+        "nameRequired": "Name is required"
+      }
     },
     "withdrawals": {
       "title": "Withdrawals",
@@ -2853,7 +2934,10 @@
         "createTitle": "Create Campaign",
         "createSubtitle": "Campaign will be auto-assigned to the partner",
         "autoAssignNote": "Campaign will be automatically assigned to partner {{name}}",
-        "createAndAssign": "Create & Assign"
+        "createAndAssign": "Create & Assign",
+        "earnings": "Earnings",
+        "referrals": "Referrals",
+        "registrations": "Registrations"
       },
       "dangerZone": {
         "title": "Danger Zone",
@@ -2928,7 +3012,10 @@
         "firstPurchaseOnly": "First purchase only",
         "cancel": "Cancel",
         "saving": "Saving...",
-        "save": "Save"
+        "save": "Save",
+        "defaultTrialTariff": "Default trial tariff",
+        "selectTariff": "Select tariff",
+        "tariff": "Tariff"
       },
       "stats": {
         "title": "Promo code statistics",
@@ -2958,7 +3045,8 @@
         "totalPromocodes": "Total promo codes",
         "activeCount": "Active",
         "usagesCount": "Uses",
-        "exhausted": "Exhausted"
+        "exhausted": "Exhausted",
+        "hoursValue": "{{count}}h"
       },
       "actions": {
         "stats": "Statistics",
@@ -3249,7 +3337,9 @@
           "expired": "expired",
           "daysLeft": "d left",
           "deviceLimitUpdated": "Device limit updated",
-          "invalidDays": "Please enter a valid number of days (greater than 0)"
+          "invalidDays": "Please enter a valid number of days (greater than 0)",
+          "backToList": "Back to subscriptions",
+          "createNew": "Create new"
         },
         "balance": {
           "current": "Current balance",
@@ -3333,7 +3423,9 @@
           "alreadyReferred": "already has referrer",
           "noUsersFound": "No users found"
         }
-      }
+      },
+      "notFound": "User not found",
+      "purchaseCount": "Purchases: {{count}}"
     },
     "promoOffers": {
       "title": "Promo Offers",
@@ -3342,7 +3434,8 @@
       "tabs": {
         "templates_one": "Templates ({{count}} template)",
         "templates_other": "Templates ({{count}} templates)",
-        "logs": "Logs"
+        "logs": "Logs",
+        "templates": "Templates"
       },
       "noData": {
         "templates": "No templates",
@@ -3372,7 +3465,9 @@
         "activeDiscountHours": "Discount validity (hours)",
         "discountDurationHint": "How long the discount lasts after activation",
         "templateActive": "Template active",
-        "saving": "Saving..."
+        "saving": "Saving...",
+        "noServers": "No servers",
+        "testSquads": "Test squads"
       },
       "send": {
         "title": "Send promo offer",
@@ -3398,7 +3493,10 @@
         "notificationsSent_other": "Notifications sent: {{count}}",
         "notificationsFailed_one": "(failed: {{count}})",
         "notificationsFailed_other": "(failed: {{count}})",
-        "sendError": "Failed to send offer"
+        "sendError": "Failed to send offer",
+        "notificationsSent": "Notifications sent",
+        "offersCreated": "Offers created",
+        "notificationsFailed": "(failed: {{count}})"
       },
       "notFound": "Template not found",
       "noActiveTemplates": "No active templates",
@@ -3535,7 +3633,8 @@
         "selectedPermissions_other": "{{count}} permissions selected",
         "cancel": "Cancel",
         "saving": "Saving...",
-        "save": "Save"
+        "save": "Save",
+        "selectedPermissions": "Selected permissions"
       },
       "presets": {
         "moderator": "Moderator",
@@ -3555,7 +3654,9 @@
         "updateFailed": "Failed to update role",
         "nameRequired": "Role name is required",
         "deleteFailed": "Failed to delete role"
-      }
+      },
+      "permissionsCount": "{{count}} permissions",
+      "usersCount": "{{count}} users"
     },
     "roleAssign": {
       "title": "Role Assignment",
@@ -3608,7 +3709,8 @@
         "roleRequired": "Please select a role",
         "assignFailed": "Failed to assign role",
         "revokeFailed": "Failed to revoke role"
-      }
+      },
+      "totalAssignments": "Total assignments: {{count}}"
     },
     "policies": {
       "title": "Access Policies",
@@ -3676,7 +3778,8 @@
         "day3": "Wed",
         "day4": "Thu",
         "day5": "Fri",
-        "day6": "Sat"
+        "day6": "Sat",
+        "ipCount": "IP count"
       },
       "confirm": {
         "title": "Delete policy?",
@@ -3762,7 +3865,10 @@
         "hoursAgo_one": "{{count}} hr ago",
         "hoursAgo_other": "{{count}} hrs ago",
         "daysAgo_one": "{{count}} day ago",
-        "daysAgo_other": "{{count}} days ago"
+        "daysAgo_other": "{{count}} days ago",
+        "daysAgo": "{{count}}d ago",
+        "hoursAgo": "{{count}}h ago",
+        "minutesAgo": "{{count}}m ago"
       },
       "pagination": {
         "pageSize": "Per page:",
@@ -3775,7 +3881,8 @@
       "errors": {
         "loadFailed": "Failed to load audit log",
         "retry": "Try again"
-      }
+      },
+      "totalEntries": "Total entries: {{count}}"
     },
     "landings": {
       "title": "Landing Pages",
@@ -3869,7 +3976,8 @@
         "funnel": "Funnel",
         "loadError": "Failed to load statistics",
         "noPurchases": "No purchases",
-        "paid": "paid"
+        "paid": "paid",
+        "dailyPurchases": "Purchases per day"
       },
       "purchases": {
         "title": "Purchases",
@@ -3895,7 +4003,16 @@
         "page": "Page {{current}} of {{total}}",
         "prev": "Previous",
         "next": "Next"
-      }
+      },
+      "methodCurrency": "Currency",
+      "methodDescPlaceholder": "Short description shown to the user",
+      "methodDescription": "Method description",
+      "methodDisplayName": "Display name",
+      "methodIconUrl": "Icon URL",
+      "methodMaxAmount": "Maximum amount",
+      "methodMinAmount": "Minimum amount",
+      "methodReturnUrl": "Return URL",
+      "stickyPayButton": "Sticky pay button"
     },
     "infoPages": {
       "title": "Information Pages",
@@ -4007,7 +4124,8 @@
       "disable": "Disable",
       "hide": "Hide ({{count}})",
       "showMore_one": "Show {{count}} more node",
-      "showMore_other": "Show {{count}} more nodes"
+      "showMore_other": "Show {{count}} more nodes",
+      "showMore": "Show more"
     },
     "topReferrers": {
       "title": "Top referrers",
@@ -4457,7 +4575,8 @@
         "yandex": "Yandex",
         "discord": "Discord",
         "vk": "VK"
-      }
+      },
+      "backToAccounts": "Back to accounts"
     }
   },
   "theme": {
@@ -4611,7 +4730,8 @@
       "warning": "A cancelled promo code cannot be reused. The discount will stop working immediately.",
       "confirm": "Cancel discount",
       "deactivating": "Cancelling...",
-      "error": "Failed to cancel promo code. Please try again later."
+      "error": "Failed to cancel promo code. Please try again later.",
+      "success": "Offer deactivated"
     }
   },
   "telegramRedirect": {
@@ -4788,7 +4908,9 @@
       "nDays_one": "{{count}} day",
       "nDays_other": "{{count}} days",
       "nMonths_one": "{{count}} month",
-      "nMonths_other": "{{count}} months"
+      "nMonths_other": "{{count}} months",
+      "nDays": "{{count}} days",
+      "nMonths": "{{count}} months"
     }
   },
   "gift": {
@@ -4966,5 +5088,12 @@
         "linkUrlPrompt": "URL:"
       }
     }
+  },
+  "subscriptions": {
+    "buy": "Buy subscription",
+    "buyAnother": "Buy another subscription",
+    "empty": "You have no subscriptions yet",
+    "emptyDesc": "Choose a tariff to get started",
+    "title": "My subscriptions"
   }
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -23,14 +23,22 @@
     "copy": "کپی",
     "units": {
       "gb": "GB",
-      "perGb": "/GB"
+      "perGb": "/GB",
+      "days": "روز",
+      "mo": "ماه"
     },
     "add": "افزودن",
     "refresh": "بازخوانی",
     "retry": "تلاش مجدد",
     "saving": "در حال ذخیره...",
     "understand": "متوجه شدم",
-    "collapse": "جمع کردن"
+    "collapse": "جمع کردن",
+    "balance": "موجودی",
+    "copied": "کپی شد",
+    "no_results": "نتیجه‌ای یافت نشد",
+    "ok": "تأیید",
+    "processing": "در حال پردازش…",
+    "rangeTo": "تا"
   },
   "nav": {
     "dashboard": "داشبورد",
@@ -45,7 +53,8 @@
     "info": "اطلاعات",
     "wheel": "چرخ شانس",
     "menu": "منو",
-    "gift": "هدیه"
+    "gift": "هدیه",
+    "navigation": "ناوبری"
   },
   "notifications": {
     "ticketNotifications": "اعلان‌های تیکت",
@@ -142,7 +151,17 @@
     "tariff": "تعرفه",
     "validUntil": "معتبر تا",
     "goToSubscription": "رفتن به اشتراک",
-    "goToBalance": "رفتن به موجودی"
+    "goToBalance": "رفتن به موجودی",
+    "devicesAdded": "+{{count}} دستگاه",
+    "devicesPurchased": {
+      "title": "دستگاه‌ها افزوده شدند"
+    },
+    "totalDevices": "مجموع دستگاه‌ها: {{count}}",
+    "totalTraffic": "مجموع ترافیک: {{value}}",
+    "trafficAdded": "+{{value}} ترافیک",
+    "trafficPurchased": {
+      "title": "ترافیک افزوده شد"
+    }
   },
   "auth": {
     "login": "ورود",
@@ -243,13 +262,38 @@
       "tariffs": "تعرفه‌ها",
       "traffic": "ترافیک",
       "devices": "دستگاه‌ها",
-      "expiredDate": "منقضی شده"
+      "expiredDate": "منقضی شده",
+      "activeUntil": "منقضی شده — تا {{date}}"
     },
     "deviceLimitReached": "برای افزودن دستگاه جدید، دستگاه‌های فعلی را قطع کنید",
     "suspended": {
       "title": "اشتراک معلق شده",
       "resume": "از سرگیری"
-    }
+    },
+    "manageAll": "مدیریت همه",
+    "showAll": "نمایش همه",
+    "subscriptions": "اشتراک‌ها",
+    "connectDevice": "اتصال دستگاه",
+    "devicesConnectedUnlimited": "{{count}} دستگاه متصل",
+    "devicesOfMax": "{{used}} از {{max}}",
+    "maxUsage": "حداکثر",
+    "remaining": "باقی‌مانده",
+    "stats": {
+      "balance": "موجودی",
+      "referrals": "معرفی‌شده‌ها"
+    },
+    "tariff": "تعرفه",
+    "trafficUsageTitle": "مصرف ترافیک",
+    "trialOffer": {
+      "freeDesc": "{{days}} روز رایگان آزمایش کنید — بدون پرداخت",
+      "freeTitle": "دوره آزمایشی رایگان",
+      "paidDesc": "{{days}} روز آزمایشی فقط با {{price}}",
+      "paidTitle": "دوره آزمایشی پرداختی"
+    },
+    "unlimited": "نامحدود",
+    "usageLast14Days": "مصرف ۱۴ روز اخیر",
+    "usedSuffix": "مصرف شده",
+    "validUntil": "معتبر تا {{date}}"
   },
   "subscription": {
     "title": "اشتراک",
@@ -339,7 +383,10 @@
       "devices_other": "{{count}} دستگاه",
       "price": "هزینه فعال‌سازی",
       "activate": "فعال‌سازی دوره آزمایشی",
-      "unavailable": "دوره آزمایشی در دسترس نیست"
+      "unavailable": "دوره آزمایشی در دسترس نیست",
+      "insufficientBalance": "موجودی برای فعال‌سازی دوره آزمایشی کافی نیست",
+      "payAndActivate": "پرداخت و فعال‌سازی",
+      "topUpToActivate": "برای فعال‌سازی دوره آزمایشی موجودی را افزایش دهید"
     },
     "connection": {
       "title": "اتصال VPN",
@@ -368,7 +415,8 @@
       "goToApps": "رفتن به تنظیمات برنامه‌ها",
       "qrTitle": "کد QR اشتراک",
       "qrScanHint": "برای اتصال با دوربین اسکن کنید",
-      "qrButton": "کد QR"
+      "qrButton": "کد QR",
+      "openQr": "باز کردن کد QR"
     },
     "additionalOptions": {
       "title": "گزینه‌های اضافی",
@@ -387,7 +435,20 @@
       "buyTrafficGb": "خرید {{gb}} GB",
       "buyUnlimited": "خرید نامحدود",
       "manageServers": "مدیریت اسکوادها",
-      "manageServersTitle": "مدیریت اسکوادها"
+      "manageServersTitle": "مدیریت اسکوادها",
+      "connectedDevices": "دستگاه‌های متصل",
+      "currentDeviceLimit": "محدودیت فعلی دستگاه",
+      "decrementDevices": "کاهش تعداد دستگاه‌ها",
+      "disconnectDevicesFirst": "ابتدا دستگاه‌های اضافی را قطع کنید",
+      "incrementDevices": "افزایش تعداد دستگاه‌ها",
+      "minDeviceLimit": "حداقل محدودیت دستگاه",
+      "newDeviceLimit": "محدودیت جدید دستگاه",
+      "reduce": "کاهش",
+      "reduceDevices": "کاهش تعداد دستگاه‌ها",
+      "reduceDevicesDescription": "محدودیت دستگاه‌های خود را تنظیم کنید. در صورت لزوم ابتدا دستگاه‌های اضافه را قطع کنید",
+      "reduceDevicesTitle": "کاهش تعداد دستگاه‌ها",
+      "reduceUnavailable": "در حال حاضر کاهش تعداد دستگاه‌ها امکان‌پذیر نیست",
+      "reducing": "در حال کاهش…"
     },
     "serverManagement": {
       "statusLegend": "✅ — متصل • ➕ — اضافه خواهد شد (پولی) • ➖ — قطع خواهد شد",
@@ -499,6 +560,46 @@
       "stopScan": "بستن دوربین",
       "noCamera": "دسترسی به دوربین امکان‌پذیر نیست",
       "codeFound": "کد پیدا شد"
+    },
+    "allTariffsPurchased": "همه تعرفه‌ها قبلاً خریداری شده‌اند",
+    "autopay": "تمدید خودکار",
+    "backToList": "بازگشت به فهرست اشتراک‌ها",
+    "confirmDelete": "اشتراک حذف شود؟",
+    "cta": {
+      "renewHint": "اشتراک منقضی شده — برای ادامه استفاده تمدید کنید",
+      "activeHint": "اشتراک فعال است — می‌توانید دستگاه‌ها را متصل کرده و از VPN استفاده کنید",
+      "expiredHint": "اشتراک منقضی شده — برای ادامه استفاده تمدید کنید",
+      "trialHint": "شما در دوره آزمایشی هستید — برای دسترسی به همه امکانات به تعرفه پرداختی ارتقا دهید"
+    },
+    "dailyAutoCharge": "برداشت خودکار روزانه",
+    "defaultName": "اشتراک",
+    "delete": "حذف",
+    "deleteTitle": "حذف اشتراک",
+    "get_config": "دریافت پیکربندی",
+    "loadError": "بارگذاری اشتراک ناموفق بود",
+    "newTariff": "تعرفه جدید",
+    "noOptionsAvailable": "گزینه‌ای در دسترس نیست",
+    "noRenewalOptions": "گزینه‌ای برای تمدید وجود ندارد",
+    "notFound": "اشتراک یافت نشد",
+    "notFoundDesc": "ممکن است حذف شده یا هنوز فعال نشده باشد",
+    "servers": "سرورها",
+    "statusActive": "فعال",
+    "statusExpired": "منقضی شده",
+    "statusLimited": "محدود",
+    "statusTrial": "آزمایشی",
+    "daysShort": "روز",
+    "expiredBanner": {
+      "selectTariff": "تعرفه را انتخاب کنید",
+      "title": "اشتراک منقضی شده است"
+    },
+    "trialInfo": {
+      "description": "{{days}} روز سرویس ما را رایگان امتحان کنید",
+      "remaining": "{{count}} روز باقی‌مانده",
+      "title": "دوره آزمایشی"
+    },
+    "trialUpgrade": {
+      "description": "برای دسترسی به همه امکانات و ادامه استفاده به اشتراک پرداختی ارتقا دهید",
+      "title": "ارتقای اشتراک"
     }
   },
   "balance": {
@@ -575,7 +676,9 @@
         "already_used_by_user": "شما قبلاً از این کد استفاده کرده‌اید",
         "user_not_found": "کاربر یافت نشد",
         "server_error": "خطای سرور"
-      }
+      },
+      "daysLeft": "روزهای باقی‌مانده: {{count}}",
+      "selectSubscription": "اشتراک را انتخاب کنید"
     },
     "minAmountError": "حداقل مبلغ: {{amount}}",
     "maxAmountError": "حداکثر مبلغ: {{amount}}",
@@ -633,7 +736,8 @@
       "timeoutDesc": "پردازش پرداخت بیشتر از حد معمول طول می‌کشد. می‌توانید دوباره وضعیت را بررسی کنید.",
       "goToBalance": "مشاهده موجودی",
       "tryAgain": "تلاش مجدد"
-    }
+    },
+    "top_up": "افزایش موجودی"
   },
   "referral": {
     "title": "برنامه معرفی",
@@ -817,7 +921,8 @@
     "contactUs": "تماس با پشتیبانی",
     "openSupport": "باز کردن پشتیبانی",
     "ticketsDisabled": "تیکت‌ها غیرفعال است",
-    "useExternalLink": "لطفاً از لینک خارجی برای دریافت پشتیبانی استفاده کنید"
+    "useExternalLink": "لطفاً از لینک خارجی برای دریافت پشتیبانی استفاده کنید",
+    "create_ticket": "ایجاد تیکت"
   },
   "wheel": {
     "title": "چرخ شانس",
@@ -849,7 +954,8 @@
       "insufficientBalance": "موجودی کافی نیست",
       "topUpRequired": "برای پرداخت شارژ کنید",
       "starsNotAvailable": "پرداخت Stars در دسترس نیست. برنامه را از طریق تلگرام باز کنید.",
-      "noSubscription": "برای چرخاندن گردونه نیاز به اشتراک فعال دارید. ابتدا اشتراک خود را فعال کنید."
+      "noSubscription": "برای چرخاندن گردونه نیاز به اشتراک فعال دارید. ابتدا اشتراک خود را فعال کنید.",
+      "selectSubscription": "ابتدا یک اشتراک انتخاب کنید"
     },
     "payWithStars": "پرداخت {stars} Stars",
     "processingPayment": "در حال پردازش...",
@@ -868,7 +974,8 @@
     "noPrize": "این بار شانس نیاوردید...",
     "payWithDays": "پرداخت با روز",
     "starsPaymentSuccessCheckHistory": "پرداخت موفق! تاریخچه یا تلگرام را بررسی کنید.",
-    "youWon": "شما برنده شدید"
+    "youWon": "شما برنده شدید",
+    "selectSubscription": "اشتراک را انتخاب کنید"
   },
   "admin": {
     "backgrounds": {
@@ -1422,7 +1529,32 @@
       "customButtonTypeCallback": "Callback",
       "customButtonTypeUrl": "لینک",
       "customButtonCallbackPlaceholder": "callback_data (مثلاً back_to_menu)",
-      "customButtonUrlPlaceholder": "https://example.com"
+      "customButtonUrlPlaceholder": "https://example.com",
+      "category": "دسته‌بندی",
+      "categoryNews": "اخبار",
+      "categoryPromo": "تبلیغاتی",
+      "categorySystem": "سیستمی",
+      "stopping": "در حال توقف…",
+      "btnBalance": "افزایش موجودی",
+      "btnConnect": "اتصال",
+      "btnHome": "صفحه اصلی",
+      "btnPartners": "برنامه معرفی",
+      "btnPromocode": "کد تخفیف",
+      "btnSubscription": "اشتراک",
+      "btnSupport": "پشتیبانی",
+      "emailContent": "محتوای ایمیل",
+      "emailContentHint": "پشتیبانی از HTML",
+      "emailContentPlaceholder": "<p>سلام، {{user_name}}!</p>\n<p>پیام شما اینجا...</p>",
+      "emailSection": "ارسال انبوه ایمیل",
+      "emailSubject": "موضوع ایمیل",
+      "emailSubjectPlaceholder": "موضوع ایمیل را وارد کنید...",
+      "emailVariables": "متغیرهای موجود",
+      "preview": "پیش‌نمایش",
+      "previewEmpty": "— خالی —",
+      "selectChannel": "کانال ارسال",
+      "selectEmailFilter": "مخاطبان ایمیل را انتخاب کنید",
+      "selectEmailFilterPlaceholder": "فیلتر را انتخاب کنید...",
+      "telegramSection": "ارسال انبوه تلگرام"
     },
     "pinnedMessages": {
       "title": "Pinned Messages",
@@ -1723,8 +1855,8 @@
         "telegramOidcClientId": "Client ID (شناسه ربات)",
         "telegramOidcClientSecret": "Client Secret"
       },
-      "offlineConv": "\u062a\u0628\u062f\u06cc\u0644\u200c\u0647\u0627\u06cc \u0622\u0641\u0644\u0627\u06cc\u0646",
-      "apiKey": "\u06a9\u0644\u06cc\u062f API"
+      "offlineConv": "تبدیل‌های آفلاین",
+      "apiKey": "کلید API"
     },
     "buttons": {
       "color": "رنگ دکمه",
@@ -1830,7 +1962,10 @@
       "remnaWaveConfigUuidHint": "UUID پیکربندی صفحه اشتراک از پنل RemnaWave",
       "remnaWaveMode": "نمایش برنامه‌ها از پنل RemnaWave. حالت فقط خواندنی.",
       "remnaWaveSettings": "تنظیمات RemnaWave",
-      "remnaWaveToggle": "تغییر منبع RemnaWave"
+      "remnaWaveToggle": "تغییر منبع RemnaWave",
+      "noConfigs": "هیچ تنظیماتی وجود ندارد",
+      "remnaWaveConnected": "RemnaWave متصل است",
+      "remnaWaveDisconnected": "RemnaWave قطع است"
     },
     "tickets": {
       "title": "مدیریت تیکت‌ها",
@@ -1881,7 +2016,13 @@
       "copyTelegramId": "برای کپی شناسه تلگرام کلیک کنید",
       "viewUser": "کاربر",
       "userNotificationsEnabled": "اعلان‌های کاربر",
-      "userNotificationsEnabledDesc": "ارسال اعلان به کاربران درباره پاسخ‌های مدیر"
+      "userNotificationsEnabledDesc": "ارسال اعلان به کاربران درباره پاسخ‌های مدیر",
+      "replyFailed": "ارسال پاسخ ناموفق بود",
+      "validation": {
+        "checkIntervalRange": "بازه بررسی باید بین ۱ تا ۱۴۴۰ دقیقه باشد",
+        "reminderCooldownRange": "زمان تأخیر یادآوری باید بین ۰ تا ۱۴۴۰ دقیقه باشد",
+        "slaMinutesRange": "SLA باید بین ۱ تا ۱۰۰۸۰ دقیقه باشد"
+      }
     },
     "tariffs": {
       "title": "مدیریت تعرفه‌ها",
@@ -2111,7 +2252,8 @@
       "promoGroupsShort": "گروه",
       "noPromoGroups": "هیچ گروه تبلیغاتی نیست",
       "cancelButton": "لغو",
-      "saveButton": "ذخیره"
+      "saveButton": "ذخیره",
+      "notFound": "روش پرداخت یافت نشد"
     },
     "campaigns": {
       "title": "کمپین‌های تبلیغاتی",
@@ -2139,7 +2281,8 @@
         "deactivate": "غیرفعال کردن",
         "activate": "فعال کردن",
         "edit": "ویرایش",
-        "delete": "حذف"
+        "delete": "حذف",
+        "registrations": "ثبت‌نام‌ها"
       },
       "modal": {
         "editTitle": "ویرایش کمپین",
@@ -2207,7 +2350,9 @@
         "totalSpending": "هزینه اشتراک",
         "periodComparison": "مقایسه دوره‌ها",
         "vsLastWeek": "نسبت به هفته قبل",
-        "topRegistrations": "بالاترین ثبت‌نام‌ها"
+        "topRegistrations": "بالاترین ثبت‌نام‌ها",
+        "subscriptionsIssued": "اشتراک‌های صادر شده",
+        "tariffsIssued": "تعرفه‌های صادر شده"
       },
       "users": {
         "title": "کاربران کمپین",
@@ -2231,7 +2376,11 @@
         "delete": "حذف"
       },
       "loadError": "بارگذاری کمپین ناموفق بود",
-      "updateError": "ذخیره تغییرات ناموفق بود"
+      "updateError": "ذخیره تغییرات ناموفق بود",
+      "validation": {
+        "nameRequired": "نام الزامی است"
+      },
+      "loadMore": "بارگذاری بیشتر"
     },
     "withdrawals": {
       "title": "برداشت‌ها",
@@ -2338,7 +2487,30 @@
         "description": "رد درخواست شراکت از {{name}}",
         "commentLabel": "نظر (اختیاری)",
         "commentPlaceholder": "دلیل رد..."
-      }
+      },
+      "settings": "تنظیمات",
+      "settingsFields": {
+        "cooldownDays": "فاصله بین برداشت‌ها (روز)",
+        "cooldownDaysDesc": "چند روز باید بین درخواست‌های برداشت بگذرد",
+        "minAmount": "حداقل مبلغ برداشت (کوپک)",
+        "minAmountDesc": "حداقل مبلغ برای درخواست برداشت (۱۰۰ کوپک = ۱ ₽)",
+        "partnerVisible": "بخش همکاران در کابین قابل مشاهده باشد",
+        "partnerVisibleDesc": "نمایش/مخفی کردن بخش‌های درخواست همکاری و برداشت برای کاربران",
+        "programEnabled": "برنامه معرفی فعال است",
+        "programEnabledDesc": "تمام عملکرد ارجاع را فعال می‌کند",
+        "requisitesText": "متن اطلاعات حساب",
+        "requisitesTextDesc": "در فرم درخواست همکاری به کاربر نمایش داده می‌شود",
+        "requisitesTextPlaceholder": "اطلاعات حساب خود را وارد کنید...",
+        "withdrawalEnabled": "برداشت مجاز است",
+        "withdrawalEnabledDesc": "به کاربران اجازه می‌دهد درخواست برداشت بدهند"
+      },
+      "settingsLoadError": "بارگذاری تنظیمات همکاری ناموفق بود",
+      "settingsSection": {
+        "referralProgram": "برنامه معرفی",
+        "withdrawalSettings": "تنظیمات برداشت"
+      },
+      "settingsSubtitle": "تنظیمات برنامه معرفی و برداشت همکاران",
+      "settingsUpdateError": "ذخیره تنظیمات همکاری ناموفق بود"
     },
     "partnerDetail": {
       "title": "جزئیات شریک",
@@ -2379,7 +2551,10 @@
         "createTitle": "ایجاد کمپین",
         "createSubtitle": "کمپین به‌طور خودکار به شریک اختصاص می‌یابد",
         "autoAssignNote": "کمپین به‌طور خودکار به شریک {{name}} اختصاص می‌یابد",
-        "createAndAssign": "ایجاد و اختصاص"
+        "createAndAssign": "ایجاد و اختصاص",
+        "earnings": "درآمد",
+        "referrals": "معرفی‌شده‌ها",
+        "registrations": "ثبت‌نام‌ها"
       },
       "dangerZone": {
         "title": "منطقه خطر",
@@ -2452,7 +2627,10 @@
         "firstPurchaseOnly": "فقط برای اولین خرید",
         "cancel": "لغو",
         "saving": "در حال ذخیره...",
-        "save": "ذخیره"
+        "save": "ذخیره",
+        "defaultTrialTariff": "تعرفه پیش‌فرض آزمایشی",
+        "selectTariff": "تعرفه را انتخاب کنید",
+        "tariff": "تعرفه"
       },
       "stats": {
         "title": "آمار کد تخفیف",
@@ -2481,7 +2659,8 @@
         "totalPromocodes": "کل کدهای تخفیف",
         "activeCount": "فعال",
         "usagesCount": "استفاده‌ها",
-        "exhausted": "تمام شده"
+        "exhausted": "تمام شده",
+        "hoursValue": "{{count}} ساعت"
       },
       "actions": {
         "stats": "آمار",
@@ -2736,7 +2915,9 @@
           "expired": "منقضی شده",
           "daysLeft": "روز باقیمانده",
           "deviceLimitUpdated": "محدودیت دستگاه به‌روز شد",
-          "invalidDays": "لطفاً تعداد روز معتبر وارد کنید (بیشتر از ۰)"
+          "invalidDays": "لطفاً تعداد روز معتبر وارد کنید (بیشتر از ۰)",
+          "backToList": "بازگشت به فهرست اشتراک‌ها",
+          "createNew": "ایجاد جدید"
         },
         "balance": {
           "current": "موجودی فعلی",
@@ -2819,6 +3000,26 @@
           "searchPlaceholder": "جستجو بر اساس نام، ایمیل یا شناسه تلگرام...",
           "alreadyReferred": "قبلاً معرفی شده",
           "noUsersFound": "کاربری یافت نشد"
+        },
+        "actions": {
+          "areYouSure": "آیا مطمئنید می‌خواهید ادامه دهید؟",
+          "title": "عملیات"
+        },
+        "noVpnData": "داده‌ای از VPN وجود ندارد"
+      },
+      "notFound": "کاربر یافت نشد",
+      "purchaseCount": "تعداد خرید: {{count}}",
+      "userActions": {
+        "delete": "حذف کاربر",
+        "disable": "غیرفعال‌سازی",
+        "error": "انجام عملیات ناموفق بود",
+        "resetSubscription": "بازنشانی اشتراک",
+        "resetTrial": "بازنشانی دوره آزمایشی",
+        "success": {
+          "delete": "کاربر حذف شد",
+          "disable": "کاربر غیرفعال شد",
+          "resetSubscription": "اشتراک بازنشانی شد",
+          "resetTrial": "دوره آزمایشی بازنشانی شد"
         }
       }
     },
@@ -2828,7 +3029,8 @@
       "sendButton": "ارسال",
       "tabs": {
         "templates_other": "قالب‌ها ({{count}})",
-        "logs": "گزارش‌ها"
+        "logs": "گزارش‌ها",
+        "templates": "قالب‌ها"
       },
       "noData": {
         "templates": "قالبی وجود ندارد",
@@ -2858,7 +3060,9 @@
         "activeDiscountHours": "اعتبار تخفیف (ساعت)",
         "discountDurationHint": "مدت زمان اعتبار تخفیف پس از فعال‌سازی",
         "templateActive": "قالب فعال",
-        "saving": "در حال ذخیره..."
+        "saving": "در حال ذخیره...",
+        "noServers": "هیچ سروری وجود ندارد",
+        "testSquads": "تیم‌های آزمایشی"
       },
       "send": {
         "title": "ارسال پیشنهاد تبلیغاتی",
@@ -2881,7 +3085,9 @@
         "offersCreated_other": "پیشنهادات ایجاد شده: {{count}}",
         "notificationsSent_other": "اعلان‌های ارسال شده: {{count}}",
         "notificationsFailed": "(ناموفق: {{count}})",
-        "sendError": "ارسال پیشنهاد ناموفق بود"
+        "sendError": "ارسال پیشنهاد ناموفق بود",
+        "notificationsSent": "اعلان‌های ارسال شده",
+        "offersCreated": "پیشنهادهای ایجاد شده"
       },
       "notFound": "قالب یافت نشد",
       "noActiveTemplates": "قالب فعالی وجود ندارد",
@@ -2970,7 +3176,8 @@
           "offline": "آفلاین",
           "disabled": "غیرفعال",
           "users": "کاربران"
-        }
+        },
+        "usersOnlineCount": "{{count}} آنلاین"
       },
       "overview": {
         "bandwidth": "پهنای باند لحظه‌ای",
@@ -3021,7 +3228,9 @@
         "localSettings": "تنظیمات محلی",
         "trialEligible": "واجد شرایط آزمایشی",
         "price": "قیمت",
-        "users": "کاربران"
+        "users": "کاربران",
+        "inboundsCount": "{{count}} ورودی",
+        "membersCount": "{{count}} عضو"
       },
       "sync": {
         "autoSync": "همگام‌سازی خودکار",
@@ -3146,7 +3355,8 @@
         "selectedPermissions_other": "{{count}} مجوز انتخاب شده",
         "cancel": "لغو",
         "saving": "در حال ذخیره...",
-        "save": "ذخیره"
+        "save": "ذخیره",
+        "selectedPermissions": "مجوزهای انتخاب‌شده"
       },
       "presets": {
         "moderator": "مدیر محتوا",
@@ -3166,7 +3376,9 @@
         "updateFailed": "به‌روزرسانی نقش ناموفق بود",
         "nameRequired": "نام نقش الزامی است",
         "deleteFailed": "حذف نقش ناموفق بود"
-      }
+      },
+      "permissionsCount": "{{count}} مجوز",
+      "usersCount": "{{count}} کاربر"
     },
     "roleAssign": {
       "title": "تخصیص نقش",
@@ -3218,7 +3430,8 @@
         "roleRequired": "لطفاً یک نقش انتخاب کنید",
         "assignFailed": "تخصیص نقش ناموفق بود",
         "revokeFailed": "لغو نقش ناموفق بود"
-      }
+      },
+      "totalAssignments": "مجموع انتساب‌ها: {{count}}"
     },
     "policies": {
       "title": "سیاست‌های دسترسی",
@@ -3285,7 +3498,8 @@
         "day3": "چهارشنبه",
         "day4": "پنجشنبه",
         "day5": "جمعه",
-        "day6": "شنبه"
+        "day6": "شنبه",
+        "ipCount": "تعداد آی‌پی"
       },
       "confirm": {
         "title": "حذف سیاست؟",
@@ -3367,7 +3581,10 @@
         "justNow": "همین الان",
         "minutesAgo_other": "{{count}} دقیقه پیش",
         "hoursAgo_other": "{{count}} ساعت پیش",
-        "daysAgo_other": "{{count}} روز پیش"
+        "daysAgo_other": "{{count}} روز پیش",
+        "daysAgo": "{{count}} روز پیش",
+        "hoursAgo": "{{count}} ساعت پیش",
+        "minutesAgo": "{{count}} دقیقه پیش"
       },
       "pagination": {
         "pageSize": "در هر صفحه:",
@@ -3380,7 +3597,8 @@
       "errors": {
         "loadFailed": "بارگذاری گزارش بازرسی ناموفق بود",
         "retry": "تلاش مجدد"
-      }
+      },
+      "totalEntries": "مجموع موارد: {{count}}"
     },
     "landings": {
       "title": "صفحات فرود",
@@ -3474,7 +3692,8 @@
         "funnel": "قیف",
         "loadError": "بارگذاری آمار ناموفق بود",
         "noPurchases": "خریدی وجود ندارد",
-        "paid": "پرداخت شده"
+        "paid": "پرداخت شده",
+        "dailyPurchases": "خریدهای روزانه"
       },
       "purchases": {
         "title": "خریدها",
@@ -3500,7 +3719,16 @@
         "page": "صفحه {{current}} از {{total}}",
         "prev": "قبلی",
         "next": "بعدی"
-      }
+      },
+      "methodCurrency": "ارز",
+      "methodDescPlaceholder": "توضیح کوتاه برای کاربر",
+      "methodDescription": "توضیحات روش",
+      "methodDisplayName": "نام نمایشی",
+      "methodIconUrl": "آدرس نماد",
+      "methodMaxAmount": "حداکثر مبلغ",
+      "methodMinAmount": "حداقل مبلغ",
+      "methodReturnUrl": "آدرس بازگشت",
+      "stickyPayButton": "دکمه پرداخت ثابت"
     },
     "infoPages": {
       "title": "صفحات اطلاعات",
@@ -3597,7 +3825,9 @@
       },
       "deleteSubscription": {
         "warning": "اشتراک‌های انتخاب شده برای همیشه از ربات و پنل RemnaWave حذف خواهند شد!",
-        "hint": "کاربران دسترسی VPN اشتراک‌های حذف شده را از دست خواهند داد. این عملیات قابل بازگشت نیست."
+        "hint": "کاربران دسترسی VPN اشتراک‌های حذف شده را از دست خواهند داد. این عملیات قابل بازگشت نیست.",
+        "activePaidWarning": "{{count}} از {{total}} اشتراک انتخاب‌شده اشتراک‌های فعال پرداختی هستند",
+        "forceDeleteConfirm": "حذف اشتراک‌های فعال پرداختی را تأیید می‌کنم"
       },
       "deleteUser": {
         "warning": "کاربران انتخاب شده برای همیشه از ربات حذف خواهند شد! تمام اشتراک‌ها، موجودی و داده‌های آن‌ها از بین خواهد رفت!",
@@ -3718,7 +3948,8 @@
       "enable": "فعال",
       "disable": "غیرفعال",
       "hide": "پنهان کردن ({{count}})",
-      "showMore_other": "نمایش {{count}} گره بیشتر"
+      "showMore_other": "نمایش {{count}} گره بیشتر",
+      "showMore": "نمایش بیشتر"
     },
     "revenue": {
       "title": "درآمد",
@@ -3782,6 +4013,16 @@
       "uptime": "آپتایم",
       "users": "کاربران",
       "activeSubs": "اشتراک‌ها"
+    },
+    "tariffs": {
+      "activeSubscriptions": "اشتراک‌های فعال",
+      "purchasedMonth": "فروش ماه",
+      "purchasedToday": "فروش امروز",
+      "purchasedWeek": "فروش هفته",
+      "subtitle": "آمار به تفکیک تعرفه",
+      "tariffName": "نام تعرفه",
+      "title": "آمار تعرفه‌ها",
+      "trialSubscriptions": "اشتراک‌های آزمایشی"
     }
   },
   "profile": {
@@ -3879,7 +4120,8 @@
         "yandex": "یاندکس",
         "discord": "دیسکورد",
         "vk": "VK"
-      }
+      },
+      "backToAccounts": "بازگشت به فهرست حساب‌ها"
     }
   },
   "theme": {
@@ -4030,7 +4272,8 @@
       "warning": "کد تخفیف لغو شده قابل استفاده مجدد نیست. تخفیف بلافاصله متوقف می‌شود.",
       "confirm": "لغو تخفیف",
       "deactivating": "در حال لغو...",
-      "error": "لغو کد تخفیف ناموفق بود. لطفاً بعداً دوباره امتحان کنید."
+      "error": "لغو کد تخفیف ناموفق بود. لطفاً بعداً دوباره امتحان کنید.",
+      "success": "پیشنهاد غیرفعال شد"
     }
   },
   "telegramRedirect": {
@@ -4318,6 +4561,12 @@
       "d456": "۱ سال و ۳ ماه",
       "nDays": "{{count}} روز",
       "nMonths": "{{count}} ماه"
+    },
+    "discount": {
+      "days": "روز",
+      "hours": "ساعت",
+      "minutes": "دقیقه",
+      "seconds": "ثانیه"
     }
   },
   "gift": {
@@ -4376,7 +4625,43 @@
     },
     "warning": {
       "telegram_unresolvable": "نام کاربری تلگرام قابل تأیید نبود. ممکن است گیرنده اعلان هدیه را دریافت نکند."
-    }
+    },
+    "activateButton": "فعال‌سازی",
+    "activateCodePlaceholder": "کد هدیه را وارد کنید",
+    "activatedBy": "توسط {{name}} فعال شد",
+    "activateDescription": "برای فعال‌سازی اشتراک، کد هدیه دریافتی را وارد کنید",
+    "activatedGiftsTitle": "هدایای فعال‌شده",
+    "activateError": "فعال‌سازی هدیه ناموفق بود",
+    "activateSelfError": "نمی‌توانید هدیه خودتان را فعال کنید",
+    "activateSuccess": "هدیه فعال شد!",
+    "activateSuccessDesc": "اشتراک به حساب شما افزوده شد",
+    "activateTitle": "فعال‌سازی هدیه",
+    "activeGiftsTitle": "هدایای فعال",
+    "codeLabel": "کد هدیه",
+    "codeReadyTitle": "کد هدیه شما آماده است",
+    "copyMessage": "کپی پیام",
+    "daysShort": "روز",
+    "deviceCount": "تعداد دستگاه‌ها",
+    "devicesShort": "دستگاه",
+    "gbShort": "گیگابایت",
+    "myGiftsEmpty": "هنوز هدیه‌ای ندارید",
+    "myGiftsEmptyDesc": "هدایایی که ارسال یا دریافت می‌کنید اینجا نمایش داده می‌شوند",
+    "pageTitle": "هدایا",
+    "receivedGiftsTitle": "هدایای دریافت‌شده",
+    "selectPeriod": "دوره را انتخاب کنید",
+    "selectTariff": "تعرفه را انتخاب کنید",
+    "sentTo": "به {{name}} ارسال شد",
+    "shareGift": "به اشتراک گذاشتن هدیه",
+    "shareModalActivateVia": "از طریق فعال‌سازی",
+    "shareModalActivateViaCabinet": "از طریق کابین",
+    "shareText": "برای شما هدیه‌ای از Bedolaga VPN دارم: {{code}}",
+    "shareToastCopied": "لینک کپی شد",
+    "statusActivated": "فعال شده",
+    "statusAvailable": "قابل فعال‌سازی",
+    "tabActivate": "فعال‌سازی",
+    "tabBuy": "خرید",
+    "tabMyGifts": "هدایای من",
+    "unlimitedTraffic": "ترافیک نامحدود"
   },
   "news": {
     "title": "اخبار و به‌روزرسانی‌ها",
@@ -4437,5 +4722,12 @@
         "linkUrlPrompt": "آدرس پیوند:"
       }
     }
+  },
+  "subscriptions": {
+    "buy": "خرید اشتراک",
+    "buyAnother": "خرید اشتراک دیگر",
+    "empty": "هنوز اشتراکی ندارید",
+    "emptyDesc": "برای شروع تعرفه‌ای انتخاب کنید",
+    "title": "اشتراک‌های من"
   }
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -29,8 +29,16 @@
     "understand": "Понятно",
     "units": {
       "gb": "ГБ",
-      "perGb": "/ГБ"
-    }
+      "perGb": "/ГБ",
+      "days": "дн",
+      "mo": "мес"
+    },
+    "balance": "Баланс",
+    "copied": "Скопировано",
+    "no_results": "Ничего не найдено",
+    "ok": "ОК",
+    "processing": "Обработка…",
+    "rangeTo": "до"
   },
   "nav": {
     "dashboard": "Главная",
@@ -45,7 +53,8 @@
     "info": "Информация",
     "wheel": "Колесо удачи",
     "menu": "Меню",
-    "gift": "Подарить"
+    "gift": "Подарить",
+    "navigation": "Навигация"
   },
   "notifications": {
     "ticketNotifications": "Уведомления о тикетах",
@@ -151,7 +160,17 @@
     "tariff": "Тариф",
     "validUntil": "Действует до",
     "goToSubscription": "Перейти к подписке",
-    "goToBalance": "Перейти к балансу"
+    "goToBalance": "Перейти к балансу",
+    "devicesAdded": "+{{count}} устройств",
+    "devicesPurchased": {
+      "title": "Устройства добавлены"
+    },
+    "totalDevices": "Всего устройств: {{count}}",
+    "totalTraffic": "Всего трафика: {{value}}",
+    "trafficAdded": "+{{value}} трафика",
+    "trafficPurchased": {
+      "title": "Трафик добавлен"
+    }
   },
   "auth": {
     "login": "Вход",
@@ -303,7 +322,10 @@
       "subscription": "Подписка",
       "referrals": "Рефералы",
       "earnings": "Заработок"
-    }
+    },
+    "manageAll": "Управлять всеми",
+    "showAll": "Показать все",
+    "subscriptions": "Подписки"
   },
   "subscription": {
     "title": "Подписка",
@@ -365,7 +387,8 @@
     "cta": {
       "expiredHint": "Выберите тариф и оплатите",
       "trialHint": "Больше трафика и устройств",
-      "activeHint": "Продление и смена тарифа"
+      "activeHint": "Продление и смена тарифа",
+      "renewHint": "Подписка истекла — продлите, чтобы продолжить пользоваться"
     },
     "connectionInfo": "Данные для подключения",
     "copyLink": "Копировать ссылку",
@@ -482,7 +505,8 @@
       "goToApps": "Перейти к настройке приложений",
       "qrTitle": "QR-код подписки",
       "qrScanHint": "Отсканируйте для подключения",
-      "qrButton": "QR-код"
+      "qrButton": "QR-код",
+      "openQr": "Открыть QR-код"
     },
     "myDevices": "Мои устройства",
     "noDevices": "Нет подключенных устройств",
@@ -590,7 +614,14 @@
       "buyTrafficGb": "Купить {{gb}} ГБ",
       "buyUnlimited": "Купить Безлимит",
       "manageServers": "Управление сквадами",
-      "manageServersTitle": "Управление сквадами"
+      "manageServersTitle": "Управление сквадами",
+      "connectedDevices": "Подключённые устройства",
+      "currentDeviceLimit": "Текущий лимит устройств",
+      "decrementDevices": "Уменьшить кол-во устройств",
+      "disconnectDevicesFirst": "Сначала отключите лишние устройства",
+      "incrementDevices": "Увеличить кол-во устройств",
+      "minDeviceLimit": "Минимальный лимит устройств",
+      "newDeviceLimit": "Новый лимит устройств"
     },
     "serverManagement": {
       "statusLegend": "✅ — подключено • ➕ — будет добавлено (платно) • ➖ — будет отключено",
@@ -649,7 +680,27 @@
       "stopScan": "Закрыть камеру",
       "noCamera": "Нет доступа к камере",
       "codeFound": "Код найден"
-    }
+    },
+    "allTariffsPurchased": "Все тарифы уже куплены",
+    "autopay": "Автопродление",
+    "backToList": "К списку подписок",
+    "confirmDelete": "Удалить подписку?",
+    "dailyAutoCharge": "Ежедневное списание",
+    "defaultName": "Подписка",
+    "delete": "Удалить",
+    "deleteTitle": "Удаление подписки",
+    "get_config": "Получить конфиг",
+    "loadError": "Не удалось загрузить подписку",
+    "newTariff": "Новый тариф",
+    "noOptionsAvailable": "Доступных опций нет",
+    "noRenewalOptions": "Нет вариантов продления",
+    "notFound": "Подписка не найдена",
+    "notFoundDesc": "Возможно, она была удалена или ещё не активирована",
+    "servers": "Серверы",
+    "statusActive": "Активна",
+    "statusExpired": "Истекла",
+    "statusLimited": "Ограничена",
+    "statusTrial": "Триал"
   },
   "balance": {
     "title": "Баланс",
@@ -767,7 +818,9 @@
         "already_used_by_user": "Вы уже использовали этот промокод",
         "user_not_found": "Пользователь не найден",
         "server_error": "Ошибка сервера"
-      }
+      },
+      "daysLeft": "Осталось дней: {{count}}",
+      "selectSubscription": "Выберите подписку"
     },
     "minAmountError": "Минимальная сумма: {{amount}} ₽",
     "maxAmountError": "Максимальная сумма: {{amount}} ₽",
@@ -827,7 +880,8 @@
       "timeoutDesc": "Обработка платежа занимает больше времени. Вы можете проверить статус ещё раз.",
       "goToBalance": "Перейти к балансу",
       "tryAgain": "Попробовать снова"
-    }
+    },
+    "top_up": "Пополнить баланс"
   },
   "referral": {
     "title": "Реферальная программа",
@@ -1013,7 +1067,8 @@
     "useExternalLink": "Для получения поддержки воспользуйтесь внешней ссылкой",
     "openSupport": "Открыть поддержку",
     "contactSupport": "Для получения поддержки обратитесь к {{username}}",
-    "contactUs": "Связаться с поддержкой"
+    "contactUs": "Связаться с поддержкой",
+    "create_ticket": "Создать тикет"
   },
   "wheel": {
     "title": "Колесо удачи",
@@ -1047,7 +1102,8 @@
       "insufficientBalance": "Недостаточно средств на балансе",
       "topUpRequired": "Пополните баланс для оплаты спина",
       "starsNotAvailable": "Оплата Stars недоступна. Откройте приложение через Telegram.",
-      "noSubscription": "Для вращения колеса необходима активная подписка. Активируйте подписку в разделе «Подписка»."
+      "noSubscription": "Для вращения колеса необходима активная подписка. Активируйте подписку в разделе «Подписка».",
+      "selectSubscription": "Сначала выберите подписку"
     },
     "payWithStars": "Оплатить Stars",
     "payWithDays": "Оплатить днями",
@@ -1066,7 +1122,8 @@
       "title": "Испытай удачу!",
       "description": "Крути колесо и выигрывай призы: дни подписки, баланс, трафик и многое другое!",
       "button": "Перейти к колесу"
-    }
+    },
+    "selectSubscription": "Выберите подписку"
   },
   "admin": {
     "backgrounds": {
@@ -1566,7 +1623,8 @@
       "firstTopupWas": "Было",
       "firstTopupWasNot": "Не было",
       "cancelButton": "Отмена",
-      "saveButton": "Сохранить"
+      "saveButton": "Сохранить",
+      "notFound": "Метод оплаты не найден"
     },
     "remnawave": {
       "title": "RemnaWave",
@@ -1634,7 +1692,8 @@
           "offline": "Офлайн",
           "disabled": "Отключены",
           "users": "Пользователей"
-        }
+        },
+        "usersOnlineCount": "{{count}} онлайн"
       },
       "squads": {
         "synced": "Синхронизирован",
@@ -1667,7 +1726,9 @@
         "localSettings": "Локальные настройки",
         "trialEligible": "Доступен триал",
         "price": "Цена",
-        "users": "Пользователей"
+        "users": "Пользователей",
+        "inboundsCount": "{{count}} входящих",
+        "membersCount": "{{count}} участников"
       },
       "sync": {
         "autoSync": "Автосинхронизация",
@@ -1846,7 +1907,12 @@
       "btnConnect": "Подключиться",
       "btnSubscription": "Подписка",
       "btnSupport": "Техподдержка",
-      "btnHome": "На главную"
+      "btnHome": "На главную",
+      "category": "Категория",
+      "categoryNews": "Новости",
+      "categoryPromo": "Промо",
+      "categorySystem": "Системные",
+      "stopping": "Останавливается…"
     },
     "pinnedMessages": {
       "title": "Закреплённые сообщения",
@@ -2705,7 +2771,10 @@
       "remnaWaveSettings": "Настройки RemnaWave",
       "remnaWaveConfigUuid": "UUID конфигурации",
       "remnaWaveConfigUuidHint": "UUID конфигурации страницы подписки из панели RemnaWave",
-      "availableConfigs": "Доступные конфигурации"
+      "availableConfigs": "Доступные конфигурации",
+      "noConfigs": "Нет настроенных конфигов",
+      "remnaWaveConnected": "RemnaWave подключён",
+      "remnaWaveDisconnected": "RemnaWave отключён"
     },
     "tickets": {
       "title": "Управление тикетами",
@@ -2756,7 +2825,13 @@
       "userNotificationsEnabled": "Уведомления для пользователей",
       "userNotificationsEnabledDesc": "Отправлять уведомления пользователям об ответах админа",
       "adminNotificationsEnabled": "Уведомления для админов",
-      "adminNotificationsEnabledDesc": "Отправлять уведомления админам о новых тикетах и ответах"
+      "adminNotificationsEnabledDesc": "Отправлять уведомления админам о новых тикетах и ответах",
+      "replyFailed": "Не удалось отправить ответ",
+      "validation": {
+        "checkIntervalRange": "Интервал проверки должен быть от 1 до 1440 мин",
+        "reminderCooldownRange": "Кулдаун напоминания должен быть от 0 до 1440 мин",
+        "slaMinutesRange": "SLA должен быть от 1 до 10080 мин"
+      }
     },
     "tariffs": {
       "title": "Управление тарифами",
@@ -2987,7 +3062,8 @@
         "deactivate": "Деактивировать",
         "activate": "Активировать",
         "edit": "Редактировать",
-        "delete": "Удалить"
+        "delete": "Удалить",
+        "registrations": "Регистрации"
       },
       "modal": {
         "editTitle": "Редактирование кампании",
@@ -3059,7 +3135,9 @@
         "totalSpending": "Расход на подписки",
         "periodComparison": "Сравнение периодов",
         "vsLastWeek": "vs прошлая неделя",
-        "topRegistrations": "Топ регистрации"
+        "topRegistrations": "Топ регистрации",
+        "subscriptionsIssued": "Выдано подписок",
+        "tariffsIssued": "Выдано тарифов"
       },
       "users": {
         "title": "Пользователи кампании",
@@ -3083,7 +3161,10 @@
         "delete": "Удалить"
       },
       "loadError": "Не удалось загрузить кампанию",
-      "updateError": "Не удалось сохранить изменения"
+      "updateError": "Не удалось сохранить изменения",
+      "validation": {
+        "nameRequired": "Название обязательно"
+      }
     },
     "withdrawals": {
       "title": "Выводы средств",
@@ -3254,7 +3335,10 @@
         "createTitle": "Создать кампанию",
         "createSubtitle": "Кампания будет автоматически привязана к партнёру",
         "autoAssignNote": "Кампания будет автоматически привязана к партнёру {{name}}",
-        "createAndAssign": "Создать и привязать"
+        "createAndAssign": "Создать и привязать",
+        "earnings": "Доход",
+        "referrals": "Рефералы",
+        "registrations": "Регистрации"
       },
       "dangerZone": {
         "title": "Опасная зона",
@@ -3331,7 +3415,10 @@
         "firstPurchaseOnly": "Только для первой покупки",
         "cancel": "Отмена",
         "saving": "Сохранение...",
-        "save": "Сохранить"
+        "save": "Сохранить",
+        "defaultTrialTariff": "Тариф триала по умолчанию",
+        "selectTariff": "Выберите тариф",
+        "tariff": "Тариф"
       },
       "stats": {
         "title": "Статистика промокода",
@@ -3362,7 +3449,8 @@
         "totalPromocodes": "Всего промокодов",
         "activeCount": "Активных",
         "usagesCount": "Использований",
-        "exhausted": "Исчерпано"
+        "exhausted": "Исчерпано",
+        "hoursValue": "{{count}} ч"
       },
       "actions": {
         "stats": "Статистика",
@@ -3654,7 +3742,9 @@
           "expired": "истёк",
           "daysLeft": "дн. осталось",
           "deviceLimitUpdated": "Лимит устройств обновлён",
-          "invalidDays": "Введите корректное количество дней (больше 0)"
+          "invalidDays": "Введите корректное количество дней (больше 0)",
+          "backToList": "К списку подписок",
+          "createNew": "Создать новую"
         },
         "balance": {
           "current": "Текущий баланс",
@@ -3738,7 +3828,9 @@
           "alreadyReferred": "уже чей-то реферал",
           "noUsersFound": "Пользователи не найдены"
         }
-      }
+      },
+      "notFound": "Пользователь не найден",
+      "purchaseCount": "Покупок: {{count}}"
     },
     "promoOffers": {
       "title": "Промопредложения",
@@ -3748,7 +3840,8 @@
         "templates_one": "Шаблоны ({{count}} шаблон)",
         "templates_few": "Шаблоны ({{count}} шаблона)",
         "templates_many": "Шаблоны ({{count}} шаблонов)",
-        "logs": "Логи"
+        "logs": "Логи",
+        "templates": "Шаблоны"
       },
       "noData": {
         "templates": "Нет шаблонов",
@@ -3778,7 +3871,9 @@
         "activeDiscountHours": "Действие скидки (часы)",
         "discountDurationHint": "Сколько действует скидка после активации",
         "templateActive": "Шаблон активен",
-        "saving": "Сохранение..."
+        "saving": "Сохранение...",
+        "noServers": "Нет серверов",
+        "testSquads": "Тестовые сквады"
       },
       "send": {
         "title": "Отправка промопредложения",
@@ -3807,7 +3902,10 @@
         "notificationsFailed_one": "(не доставлено: {{count}})",
         "notificationsFailed_few": "(не доставлено: {{count}})",
         "notificationsFailed_many": "(не доставлено: {{count}})",
-        "sendError": "Не удалось отправить предложение"
+        "sendError": "Не удалось отправить предложение",
+        "notificationsSent": "Отправлено уведомлений",
+        "offersCreated": "Создано офферов",
+        "notificationsFailed": "(не отправлено: {{count}})"
       },
       "notFound": "Шаблон не найден",
       "noActiveTemplates": "Нет активных шаблонов",
@@ -4073,7 +4171,8 @@
         "selectedPermissions_many": "{{count}} разрешений выбрано",
         "cancel": "Отмена",
         "saving": "Сохранение...",
-        "save": "Сохранить"
+        "save": "Сохранить",
+        "selectedPermissions": "Выбрано прав"
       },
       "presets": {
         "moderator": "Модератор",
@@ -4093,7 +4192,9 @@
         "updateFailed": "Не удалось обновить роль",
         "nameRequired": "Укажите название роли",
         "deleteFailed": "Не удалось удалить роль"
-      }
+      },
+      "permissionsCount": "{{count}} прав",
+      "usersCount": "{{count}} пользователей"
     },
     "roleAssign": {
       "title": "Назначение ролей",
@@ -4147,7 +4248,8 @@
         "roleRequired": "Выберите роль",
         "assignFailed": "Не удалось назначить роль",
         "revokeFailed": "Не удалось отозвать роль"
-      }
+      },
+      "totalAssignments": "Всего назначений: {{count}}"
     },
     "policies": {
       "title": "Политики доступа",
@@ -4216,7 +4318,8 @@
         "day3": "Ср",
         "day4": "Чт",
         "day5": "Пт",
-        "day6": "Сб"
+        "day6": "Сб",
+        "ipCount": "Кол-во IP"
       },
       "confirm": {
         "title": "Удалить политику?",
@@ -4306,7 +4409,10 @@
         "hoursAgo_many": "{{count}} ч назад",
         "daysAgo_one": "{{count}} день назад",
         "daysAgo_few": "{{count}} дня назад",
-        "daysAgo_many": "{{count}} дней назад"
+        "daysAgo_many": "{{count}} дней назад",
+        "daysAgo": "{{count}} дн назад",
+        "hoursAgo": "{{count}} ч назад",
+        "minutesAgo": "{{count}} мин назад"
       },
       "pagination": {
         "pageSize": "На странице:",
@@ -4319,7 +4425,8 @@
       "errors": {
         "loadFailed": "Не удалось загрузить журнал аудита",
         "retry": "Попробовать снова"
-      }
+      },
+      "totalEntries": "Всего записей: {{count}}"
     },
     "landings": {
       "title": "Лендинги",
@@ -4413,7 +4520,8 @@
         "funnel": "Воронка",
         "loadError": "Не удалось загрузить статистику",
         "noPurchases": "Нет покупок",
-        "paid": "оплачено"
+        "paid": "оплачено",
+        "dailyPurchases": "Покупок в день"
       },
       "purchases": {
         "title": "Покупки",
@@ -4439,7 +4547,16 @@
         "page": "Стр. {{current}} из {{total}}",
         "prev": "Назад",
         "next": "Далее"
-      }
+      },
+      "methodCurrency": "Валюта",
+      "methodDescPlaceholder": "Краткое описание метода для пользователя",
+      "methodDescription": "Описание метода",
+      "methodDisplayName": "Отображаемое имя",
+      "methodIconUrl": "URL иконки",
+      "methodMaxAmount": "Максимальная сумма",
+      "methodMinAmount": "Минимальная сумма",
+      "methodReturnUrl": "URL возврата",
+      "stickyPayButton": "Закреплённая кнопка оплаты"
     },
     "infoPages": {
       "title": "Информационные страницы",
@@ -4552,7 +4669,8 @@
       "hide": "Скрыть ({{count}})",
       "showMore_one": "Показать еще {{count}} ноду",
       "showMore_few": "Показать еще {{count}} ноды",
-      "showMore_many": "Показать еще {{count}} нод"
+      "showMore_many": "Показать еще {{count}} нод",
+      "showMore": "Показать ещё"
     },
     "revenue": {
       "title": "Доходы",
@@ -4597,7 +4715,8 @@
       "byEarnings": "По доходу",
       "byInvited": "По пригл.",
       "invites": "пригл.",
-      "people": "чел."
+      "people": "чел.",
+      "stats": "реф., {{count}} приглашений"
     },
     "period": {
       "today": "Сегодня",
@@ -4609,7 +4728,8 @@
       "stats_one": "камп., {{count}} рег.",
       "stats_few": "камп., {{count}} рег.",
       "stats_many": "камп., {{count}} рег.",
-      "total": "Всего от РК"
+      "total": "Всего от РК",
+      "stats": "кампания, {{count}} регистр."
     },
     "recentPayments": {
       "title": "Последние платежи",
@@ -5006,7 +5126,8 @@
         "yandex": "Яндекс",
         "discord": "Discord",
         "vk": "VK"
-      }
+      },
+      "backToAccounts": "К списку аккаунтов"
     }
   },
   "theme": {
@@ -5163,7 +5284,8 @@
       "warning": "Отменённый промокод нельзя будет использовать повторно. Скидка перестанет действовать немедленно.",
       "confirm": "Отменить",
       "deactivating": "Отмена...",
-      "error": "Не удалось отменить промокод. Попробуйте позже."
+      "error": "Не удалось отменить промокод. Попробуйте позже.",
+      "success": "Акция отключена"
     }
   },
   "telegramRedirect": {
@@ -5342,7 +5464,9 @@
       "nDays_many": "{{count}} дней",
       "nMonths_one": "{{count}} месяц",
       "nMonths_few": "{{count}} месяца",
-      "nMonths_many": "{{count}} месяцев"
+      "nMonths_many": "{{count}} месяцев",
+      "nDays": "{{count}} дн",
+      "nMonths": "{{count}} мес"
     }
   },
   "gift": {
@@ -5525,5 +5649,12 @@
         "linkUrlPrompt": "URL ссылки:"
       }
     }
+  },
+  "subscriptions": {
+    "buy": "Купить подписку",
+    "buyAnother": "Купить ещё подписку",
+    "empty": "У вас пока нет подписок",
+    "emptyDesc": "Выберите тариф, чтобы начать пользоваться сервисом",
+    "title": "Мои подписки"
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -29,8 +29,16 @@
     "collapse": "收起",
     "units": {
       "gb": "GB",
-      "perGb": "/GB"
-    }
+      "perGb": "/GB",
+      "days": "天",
+      "mo": "月"
+    },
+    "balance": "余额",
+    "copied": "已复制",
+    "no_results": "无结果",
+    "ok": "确定",
+    "processing": "处理中…",
+    "rangeTo": "至"
   },
   "nav": {
     "dashboard": "首页",
@@ -45,7 +53,8 @@
     "info": "信息",
     "wheel": "幸运转盘",
     "menu": "菜单",
-    "gift": "赠送"
+    "gift": "赠送",
+    "navigation": "导航"
   },
   "notifications": {
     "ticketNotifications": "工单通知",
@@ -142,7 +151,17 @@
     "tariff": "套餐",
     "validUntil": "有效期至",
     "goToSubscription": "查看订阅",
-    "goToBalance": "查看余额"
+    "goToBalance": "查看余额",
+    "devicesAdded": "+{{count}} 设备",
+    "devicesPurchased": {
+      "title": "设备已添加"
+    },
+    "totalDevices": "总设备数：{{count}}",
+    "totalTraffic": "总流量：{{value}}",
+    "trafficAdded": "+{{value}} 流量",
+    "trafficPurchased": {
+      "title": "流量已添加"
+    }
   },
   "auth": {
     "login": "登录",
@@ -243,13 +262,38 @@
       "tariffs": "套餐",
       "traffic": "流量",
       "devices": "设备",
-      "expiredDate": "过期时间"
+      "expiredDate": "过期时间",
+      "activeUntil": "已过期 — 至 {{date}}"
     },
     "deviceLimitReached": "断开设备以添加新设备",
     "suspended": {
       "title": "订阅已暂停",
       "resume": "恢复"
-    }
+    },
+    "manageAll": "全部管理",
+    "showAll": "全部显示",
+    "subscriptions": "订阅",
+    "connectDevice": "连接设备",
+    "devicesConnectedUnlimited": "已连接 {{count}} 台设备",
+    "devicesOfMax": "{{used}} / {{max}}",
+    "maxUsage": "最大",
+    "remaining": "剩余",
+    "stats": {
+      "balance": "余额",
+      "referrals": "推荐人"
+    },
+    "tariff": "套餐",
+    "trafficUsageTitle": "流量使用",
+    "trialOffer": {
+      "freeDesc": "免费试用 {{days}} 天 — 无需付款",
+      "freeTitle": "免费试用",
+      "paidDesc": "{{days}} 天试用，仅需 {{price}}",
+      "paidTitle": "付费试用"
+    },
+    "unlimited": "无限",
+    "usageLast14Days": "近 14 天使用情况",
+    "usedSuffix": "已用",
+    "validUntil": "有效期至 {{date}}"
   },
   "subscription": {
     "title": "订阅",
@@ -339,7 +383,10 @@
       "devices_other": "{{count}} 个设备",
       "price": "激活费用",
       "activate": "激活免费试用",
-      "unavailable": "试用不可用"
+      "unavailable": "试用不可用",
+      "insufficientBalance": "余额不足以激活试用",
+      "payAndActivate": "付费并激活",
+      "topUpToActivate": "充值以激活试用"
     },
     "connection": {
       "title": "连接VPN",
@@ -368,7 +415,8 @@
       "goToApps": "前往应用设置",
       "qrTitle": "订阅二维码",
       "qrScanHint": "使用相机扫描以连接",
-      "qrButton": "二维码"
+      "qrButton": "二维码",
+      "openQr": "打开二维码"
     },
     "additionalOptions": {
       "title": "附加选项",
@@ -387,7 +435,20 @@
       "buyTrafficGb": "购买 {{gb}} GB",
       "buyUnlimited": "购买无限流量",
       "manageServers": "小队管理",
-      "manageServersTitle": "小队管理"
+      "manageServersTitle": "小队管理",
+      "connectedDevices": "已连接设备",
+      "currentDeviceLimit": "当前设备限制",
+      "decrementDevices": "减少设备数量",
+      "disconnectDevicesFirst": "请先断开多余的设备",
+      "incrementDevices": "增加设备数量",
+      "minDeviceLimit": "最低设备限制",
+      "newDeviceLimit": "新设备限制",
+      "reduce": "减少",
+      "reduceDevices": "减少设备数量",
+      "reduceDevicesDescription": "调整您的设备限制。如有需要，请先断开多余设备的连接",
+      "reduceDevicesTitle": "减少设备数量",
+      "reduceUnavailable": "当前无法减少设备数量",
+      "reducing": "正在减少…"
     },
     "serverManagement": {
       "statusLegend": "✅ — 已连接 • ➕ — 将添加（付费）• ➖ — 将断开",
@@ -499,6 +560,46 @@
       "stopScan": "关闭摄像头",
       "noCamera": "无法访问摄像头",
       "codeFound": "找到代码"
+    },
+    "allTariffsPurchased": "所有套餐已购买",
+    "autopay": "自动续订",
+    "backToList": "返回订阅列表",
+    "confirmDelete": "删除订阅？",
+    "cta": {
+      "renewHint": "订阅已过期 — 续订以继续使用",
+      "activeHint": "订阅有效 — 您可以连接设备并使用 VPN",
+      "expiredHint": "订阅已过期 — 续订以继续使用",
+      "trialHint": "您正在试用中 — 升级到付费套餐以解锁所有功能"
+    },
+    "dailyAutoCharge": "每日自动扣费",
+    "defaultName": "订阅",
+    "delete": "删除",
+    "deleteTitle": "删除订阅",
+    "get_config": "获取配置",
+    "loadError": "加载订阅失败",
+    "newTariff": "新套餐",
+    "noOptionsAvailable": "暂无可用选项",
+    "noRenewalOptions": "无续订选项",
+    "notFound": "未找到订阅",
+    "notFoundDesc": "可能已被删除或尚未激活",
+    "servers": "服务器",
+    "statusActive": "已激活",
+    "statusExpired": "已过期",
+    "statusLimited": "受限",
+    "statusTrial": "试用",
+    "daysShort": "天",
+    "expiredBanner": {
+      "selectTariff": "选择套餐",
+      "title": "订阅已过期"
+    },
+    "trialInfo": {
+      "description": "免费试用我们的服务 {{days}} 天",
+      "remaining": "剩余 {{count}} 天",
+      "title": "试用期"
+    },
+    "trialUpgrade": {
+      "description": "升级到付费订阅以解锁所有功能并继续使用",
+      "title": "升级订阅"
     }
   },
   "balance": {
@@ -575,7 +676,9 @@
         "already_used_by_user": "您已使用过此优惠码",
         "user_not_found": "用户不存在",
         "server_error": "服务器错误"
-      }
+      },
+      "daysLeft": "剩余天数：{{count}}",
+      "selectSubscription": "选择订阅"
     },
     "minAmountError": "最小金额：{{amount}}",
     "maxAmountError": "最大金额：{{amount}}",
@@ -633,7 +736,8 @@
       "timeoutDesc": "付款处理时间比平时长。您可以再次检查状态。",
       "goToBalance": "查看余额",
       "tryAgain": "重试"
-    }
+    },
+    "top_up": "充值"
   },
   "referral": {
     "title": "推荐计划",
@@ -817,7 +921,8 @@
     "contactUs": "联系支持",
     "openSupport": "打开支持",
     "ticketsDisabled": "工单已禁用",
-    "useExternalLink": "请使用外部链接获取支持"
+    "useExternalLink": "请使用外部链接获取支持",
+    "create_ticket": "创建工单"
   },
   "wheel": {
     "title": "幸运转盘",
@@ -853,7 +958,8 @@
       "insufficientBalance": "余额不足",
       "topUpRequired": "请充值以支付抽奖费用",
       "starsNotAvailable": "Stars支付不可用。请通过Telegram打开应用。",
-      "noSubscription": "需要有效订阅才能转动轮盘。请先激活订阅。"
+      "noSubscription": "需要有效订阅才能转动轮盘。请先激活订阅。",
+      "selectSubscription": "请先选择订阅"
     },
     "payWithStars": "支付 {stars} Stars",
     "processingPayment": "处理中...",
@@ -868,7 +974,8 @@
       "title": "试试运气！",
       "description": "转动转盘赢取奖品：订阅天数、余额、流量等！",
       "button": "前往转盘"
-    }
+    },
+    "selectSubscription": "选择订阅"
   },
   "admin": {
     "backgrounds": {
@@ -1309,7 +1416,8 @@
       "promoGroupsShort": "组",
       "noPromoGroups": "没有促销组",
       "cancelButton": "取消",
-      "saveButton": "保存"
+      "saveButton": "保存",
+      "notFound": "未找到支付方式"
     },
     "emailTemplates": {
       "title": "邮件模板",
@@ -1498,7 +1606,32 @@
       "customButtonTypeCallback": "回调",
       "customButtonTypeUrl": "链接",
       "customButtonCallbackPlaceholder": "callback_data（例如 back_to_menu）",
-      "customButtonUrlPlaceholder": "https://example.com"
+      "customButtonUrlPlaceholder": "https://example.com",
+      "category": "类别",
+      "categoryNews": "新闻",
+      "categoryPromo": "促销",
+      "categorySystem": "系统",
+      "stopping": "正在停止…",
+      "btnBalance": "充值",
+      "btnConnect": "连接",
+      "btnHome": "主页",
+      "btnPartners": "推荐计划",
+      "btnPromocode": "优惠码",
+      "btnSubscription": "订阅",
+      "btnSupport": "客服支持",
+      "emailContent": "邮件内容",
+      "emailContentHint": "支持 HTML",
+      "emailContentPlaceholder": "<p>您好，{{user_name}}！</p>\n<p>您的消息内容...</p>",
+      "emailSection": "邮件群发",
+      "emailSubject": "邮件主题",
+      "emailSubjectPlaceholder": "请输入邮件主题...",
+      "emailVariables": "可用变量",
+      "preview": "预览",
+      "previewEmpty": "— 空 —",
+      "selectChannel": "群发渠道",
+      "selectEmailFilter": "选择邮件受众",
+      "selectEmailFilterPlaceholder": "选择筛选器...",
+      "telegramSection": "Telegram 群发"
     },
     "pinnedMessages": {
       "title": "置顶消息",
@@ -1763,8 +1896,8 @@
         "telegramOidcClientId": "Client ID（机器人 ID）",
         "telegramOidcClientSecret": "Client Secret"
       },
-      "offlineConv": "\u79bb\u7ebf\u8f6c\u5316",
-      "apiKey": "API \u5bc6\u94a5"
+      "offlineConv": "离线转化",
+      "apiKey": "API 密钥"
     },
     "buttons": {
       "color": "按钮颜色",
@@ -1870,7 +2003,10 @@
         "subscription": "订阅",
         "connect": "连接",
         "additional": "附加"
-      }
+      },
+      "noConfigs": "未配置任何配置",
+      "remnaWaveConnected": "RemnaWave 已连接",
+      "remnaWaveDisconnected": "RemnaWave 未连接"
     },
     "tickets": {
       "title": "工单管理",
@@ -1921,7 +2057,13 @@
       "copyTelegramId": "点击复制Telegram ID",
       "viewUser": "用户",
       "userNotificationsEnabled": "用户通知",
-      "userNotificationsEnabledDesc": "向用户发送管理员回复通知"
+      "userNotificationsEnabledDesc": "向用户发送管理员回复通知",
+      "replyFailed": "发送回复失败",
+      "validation": {
+        "checkIntervalRange": "检查间隔必须在 1 到 1440 分钟之间",
+        "reminderCooldownRange": "提醒冷却时间必须在 0 到 1440 分钟之间",
+        "slaMinutesRange": "SLA 必须在 1 到 10080 分钟之间"
+      }
     },
     "tariffs": {
       "title": "套餐管理",
@@ -2138,7 +2280,8 @@
         "deactivate": "停用",
         "activate": "启用",
         "edit": "编辑",
-        "delete": "删除"
+        "delete": "删除",
+        "registrations": "注册"
       },
       "modal": {
         "editTitle": "编辑活动",
@@ -2206,7 +2349,9 @@
         "totalSpending": "订阅支出",
         "periodComparison": "期间比较",
         "vsLastWeek": "与上周对比",
-        "topRegistrations": "热门注册"
+        "topRegistrations": "热门注册",
+        "subscriptionsIssued": "已发放订阅",
+        "tariffsIssued": "已发放套餐"
       },
       "users": {
         "title": "活动用户",
@@ -2230,7 +2375,11 @@
         "delete": "删除"
       },
       "loadError": "加载活动失败",
-      "updateError": "保存更改失败"
+      "updateError": "保存更改失败",
+      "validation": {
+        "nameRequired": "名称为必填项"
+      },
+      "loadMore": "加载更多"
     },
     "withdrawals": {
       "title": "提现",
@@ -2337,7 +2486,30 @@
         "description": "拒绝来自 {{name}} 的合作伙伴申请",
         "commentLabel": "备注（可选）",
         "commentPlaceholder": "拒绝原因..."
-      }
+      },
+      "settings": "设置",
+      "settingsFields": {
+        "cooldownDays": "提款冷却期（天）",
+        "cooldownDaysDesc": "两次提款请求之间需间隔多少天",
+        "minAmount": "最小提款金额（戈比）",
+        "minAmountDesc": "提款请求的最低金额（100 戈比 = 1 ₽）",
+        "partnerVisible": "在面板中显示推荐部分",
+        "partnerVisibleDesc": "为用户显示/隐藏合作申请和提款部分",
+        "programEnabled": "推荐计划已启用",
+        "programEnabledDesc": "启用整个推荐人功能",
+        "requisitesText": "收款信息文本",
+        "requisitesTextDesc": "将在合作申请表单中向用户显示",
+        "requisitesTextPlaceholder": "请输入您的收款信息...",
+        "withdrawalEnabled": "允许提款",
+        "withdrawalEnabledDesc": "允许用户请求提款"
+      },
+      "settingsLoadError": "加载推荐设置失败",
+      "settingsSection": {
+        "referralProgram": "推荐计划",
+        "withdrawalSettings": "提款设置"
+      },
+      "settingsSubtitle": "推荐计划和合作伙伴提款设置",
+      "settingsUpdateError": "保存推荐设置失败"
     },
     "partnerDetail": {
       "title": "合作伙伴详情",
@@ -2378,7 +2550,10 @@
         "createTitle": "创建活动",
         "createSubtitle": "活动将自动分配给合作伙伴",
         "autoAssignNote": "活动将自动分配给合作伙伴 {{name}}",
-        "createAndAssign": "创建并分配"
+        "createAndAssign": "创建并分配",
+        "earnings": "收入",
+        "referrals": "推荐人",
+        "registrations": "注册"
       },
       "dangerZone": {
         "title": "危险操作",
@@ -2451,7 +2626,10 @@
         "firstPurchaseOnly": "仅限首次购买",
         "cancel": "取消",
         "saving": "保存中...",
-        "save": "保存"
+        "save": "保存",
+        "defaultTrialTariff": "默认试用套餐",
+        "selectTariff": "选择套餐",
+        "tariff": "套餐"
       },
       "stats": {
         "title": "促销码统计",
@@ -2480,7 +2658,8 @@
         "totalPromocodes": "促销码总数",
         "activeCount": "活跃的",
         "usagesCount": "使用次数",
-        "exhausted": "已用完"
+        "exhausted": "已用完",
+        "hoursValue": "{{count}}小时"
       },
       "actions": {
         "stats": "统计",
@@ -2735,7 +2914,9 @@
           "expired": "已过期",
           "daysLeft": "天剩余",
           "deviceLimitUpdated": "设备限制已更新",
-          "invalidDays": "请输入有效天数（大于0）"
+          "invalidDays": "请输入有效天数（大于0）",
+          "backToList": "返回订阅列表",
+          "createNew": "新建"
         },
         "balance": {
           "current": "当前余额",
@@ -2818,6 +2999,26 @@
           "searchPlaceholder": "按名称、邮箱或 Telegram ID 搜索...",
           "alreadyReferred": "已有推荐人",
           "noUsersFound": "未找到用户"
+        },
+        "actions": {
+          "areYouSure": "确定要继续？",
+          "title": "操作"
+        },
+        "noVpnData": "无 VPN 数据"
+      },
+      "notFound": "未找到用户",
+      "purchaseCount": "购买次数：{{count}}",
+      "userActions": {
+        "delete": "删除用户",
+        "disable": "禁用",
+        "error": "操作失败",
+        "resetSubscription": "重置订阅",
+        "resetTrial": "重置试用",
+        "success": {
+          "delete": "用户已删除",
+          "disable": "用户已禁用",
+          "resetSubscription": "订阅已重置",
+          "resetTrial": "试用已重置"
         }
       }
     },
@@ -2827,7 +3028,8 @@
       "sendButton": "发送",
       "tabs": {
         "templates_other": "模板 ({{count}})",
-        "logs": "日志"
+        "logs": "日志",
+        "templates": "模板"
       },
       "noData": {
         "templates": "没有模板",
@@ -2857,7 +3059,9 @@
         "activeDiscountHours": "折扣有效期（小时）",
         "discountDurationHint": "激活后折扣持续多长时间",
         "templateActive": "模板已激活",
-        "saving": "保存中..."
+        "saving": "保存中...",
+        "noServers": "无服务器",
+        "testSquads": "测试小队"
       },
       "send": {
         "title": "发送促销优惠",
@@ -2880,7 +3084,9 @@
         "offersCreated_other": "已创建优惠: {{count}}",
         "notificationsSent_other": "已发送通知: {{count}}",
         "notificationsFailed": "（失败: {{count}}）",
-        "sendError": "发送优惠失败"
+        "sendError": "发送优惠失败",
+        "notificationsSent": "已发送通知",
+        "offersCreated": "已创建优惠"
       },
       "notFound": "未找到模板",
       "noActiveTemplates": "没有活跃的模板",
@@ -2978,7 +3184,8 @@
           "offline": "离线",
           "disabled": "已禁用",
           "users": "用户"
-        }
+        },
+        "usersOnlineCount": "{{count}} 在线"
       },
       "overview": {
         "bandwidth": "实时带宽",
@@ -3029,7 +3236,9 @@
         "localSettings": "本地设置",
         "trialEligible": "可试用",
         "price": "价格",
-        "users": "用户"
+        "users": "用户",
+        "inboundsCount": "{{count}} 入站",
+        "membersCount": "{{count}} 成员"
       },
       "sync": {
         "autoSync": "自动同步",
@@ -3145,7 +3354,8 @@
         "selectedPermissions_other": "已选择 {{count}} 个权限",
         "cancel": "取消",
         "saving": "保存中...",
-        "save": "保存"
+        "save": "保存",
+        "selectedPermissions": "已选权限"
       },
       "presets": {
         "moderator": "版主",
@@ -3165,7 +3375,9 @@
         "updateFailed": "更新角色失败",
         "nameRequired": "请输入角色名称",
         "deleteFailed": "删除角色失败"
-      }
+      },
+      "permissionsCount": "{{count}} 项权限",
+      "usersCount": "{{count}} 个用户"
     },
     "roleAssign": {
       "title": "角色分配",
@@ -3217,7 +3429,8 @@
         "roleRequired": "请选择角色",
         "assignFailed": "角色分配失败",
         "revokeFailed": "角色撤销失败"
-      }
+      },
+      "totalAssignments": "总分配数：{{count}}"
     },
     "policies": {
       "title": "访问策略",
@@ -3284,7 +3497,8 @@
         "day3": "三",
         "day4": "四",
         "day5": "五",
-        "day6": "六"
+        "day6": "六",
+        "ipCount": "IP 数量"
       },
       "confirm": {
         "title": "删除策略？",
@@ -3366,7 +3580,10 @@
         "justNow": "刚刚",
         "minutesAgo_other": "{{count}} 分钟前",
         "hoursAgo_other": "{{count}} 小时前",
-        "daysAgo_other": "{{count}} 天前"
+        "daysAgo_other": "{{count}} 天前",
+        "daysAgo": "{{count}}天前",
+        "hoursAgo": "{{count}}小时前",
+        "minutesAgo": "{{count}}分钟前"
       },
       "pagination": {
         "pageSize": "每页：",
@@ -3379,7 +3596,8 @@
       "errors": {
         "loadFailed": "加载审计日志失败",
         "retry": "重试"
-      }
+      },
+      "totalEntries": "总条目数：{{count}}"
     },
     "landings": {
       "title": "落地页",
@@ -3473,7 +3691,8 @@
         "funnel": "漏斗",
         "loadError": "加载统计失败",
         "noPurchases": "无购买记录",
-        "paid": "已支付"
+        "paid": "已支付",
+        "dailyPurchases": "每日购买量"
       },
       "purchases": {
         "title": "购买记录",
@@ -3499,7 +3718,16 @@
         "page": "第 {{current}} 页，共 {{total}} 页",
         "prev": "上一页",
         "next": "下一页"
-      }
+      },
+      "methodCurrency": "货币",
+      "methodDescPlaceholder": "向用户显示的简短说明",
+      "methodDescription": "方法描述",
+      "methodDisplayName": "显示名称",
+      "methodIconUrl": "图标 URL",
+      "methodMaxAmount": "最大金额",
+      "methodMinAmount": "最小金额",
+      "methodReturnUrl": "回调 URL",
+      "stickyPayButton": "固定支付按钮"
     },
     "infoPages": {
       "title": "信息页面",
@@ -3596,7 +3824,9 @@
       },
       "deleteSubscription": {
         "warning": "选中的订阅将从机器人和RemnaWave面板中永久删除！",
-        "hint": "用户将失去已删除订阅的VPN访问权限。此操作无法撤销。"
+        "hint": "用户将失去已删除订阅的VPN访问权限。此操作无法撤销。",
+        "activePaidWarning": "所选订阅中有 {{count}} / {{total}} 是有效的付费订阅",
+        "forceDeleteConfirm": "我确认删除有效的付费订阅"
       },
       "deleteUser": {
         "warning": "选中的用户将从机器人中永久删除！他们的所有订阅、余额和数据将丢失！",
@@ -3717,7 +3947,8 @@
       "enable": "启用",
       "disable": "禁用",
       "hide": "隐藏 ({{count}})",
-      "showMore_other": "显示更多 {{count}} 个节点"
+      "showMore_other": "显示更多 {{count}} 个节点",
+      "showMore": "显示更多"
     },
     "revenue": {
       "title": "收入",
@@ -3781,6 +4012,16 @@
       "uptime": "运行时间",
       "users": "用户",
       "activeSubs": "订阅"
+    },
+    "tariffs": {
+      "activeSubscriptions": "活跃订阅",
+      "purchasedMonth": "本月已售出",
+      "purchasedToday": "今日已售出",
+      "purchasedWeek": "本周已售出",
+      "subtitle": "各套餐统计",
+      "tariffName": "套餐名称",
+      "title": "套餐统计",
+      "trialSubscriptions": "试用订阅"
     }
   },
   "profile": {
@@ -3878,7 +4119,8 @@
         "yandex": "Yandex",
         "discord": "Discord",
         "vk": "VK"
-      }
+      },
+      "backToAccounts": "返回账户列表"
     }
   },
   "theme": {
@@ -4029,7 +4271,8 @@
       "warning": "已取消的优惠码无法重新使用。折扣将立即失效。",
       "confirm": "取消折扣",
       "deactivating": "取消中...",
-      "error": "取消优惠码失败，请稍后重试。"
+      "error": "取消优惠码失败，请稍后重试。",
+      "success": "活动已停用"
     }
   },
   "telegramRedirect": {
@@ -4317,6 +4560,12 @@
       "d456": "1年3个月",
       "nDays": "{{count}}天",
       "nMonths": "{{count}}个月"
+    },
+    "discount": {
+      "days": "天",
+      "hours": "小时",
+      "minutes": "分钟",
+      "seconds": "秒"
     }
   },
   "gift": {
@@ -4375,7 +4624,43 @@
     },
     "warning": {
       "telegram_unresolvable": "无法验证此 Telegram 用户名。收件人可能不会收到礼物通知。"
-    }
+    },
+    "activateButton": "激活",
+    "activateCodePlaceholder": "输入礼物代码",
+    "activatedBy": "由 {{name}} 激活",
+    "activateDescription": "输入您收到的礼物代码以激活订阅",
+    "activatedGiftsTitle": "已激活的礼物",
+    "activateError": "激活礼物失败",
+    "activateSelfError": "您不能激活自己的礼物",
+    "activateSuccess": "礼物已激活！",
+    "activateSuccessDesc": "订阅已添加到您的账户",
+    "activateTitle": "激活礼物",
+    "activeGiftsTitle": "活跃的礼物",
+    "codeLabel": "礼物代码",
+    "codeReadyTitle": "您的礼物代码已就绪",
+    "copyMessage": "复制消息",
+    "daysShort": "天",
+    "deviceCount": "设备数",
+    "devicesShort": "台",
+    "gbShort": "GB",
+    "myGiftsEmpty": "暂无礼物",
+    "myGiftsEmptyDesc": "您发送或收到的礼物将显示在这里",
+    "pageTitle": "礼物",
+    "receivedGiftsTitle": "已收到的礼物",
+    "selectPeriod": "选择时长",
+    "selectTariff": "选择套餐",
+    "sentTo": "已发送给 {{name}}",
+    "shareGift": "分享礼物",
+    "shareModalActivateVia": "通过以下方式激活",
+    "shareModalActivateViaCabinet": "通过个人中心",
+    "shareText": "我为您准备了一份 Bedolaga VPN 礼物：{{code}}",
+    "shareToastCopied": "链接已复制",
+    "statusActivated": "已激活",
+    "statusAvailable": "可激活",
+    "tabActivate": "激活",
+    "tabBuy": "购买",
+    "tabMyGifts": "我的礼物",
+    "unlimitedTraffic": "无限流量"
   },
   "news": {
     "title": "新闻与更新",
@@ -4436,5 +4721,12 @@
         "linkUrlPrompt": "URL："
       }
     }
+  },
+  "subscriptions": {
+    "buy": "购买订阅",
+    "buyAnother": "再购买一个订阅",
+    "empty": "您还没有订阅",
+    "emptyDesc": "选择套餐以开始使用",
+    "title": "我的订阅"
   }
 }

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -1086,7 +1086,7 @@ export default function Subscription() {
                     disabled={autopayMutation.isPending}
                     role="switch"
                     aria-checked={subscription.autopay_enabled}
-                    aria-label={t('subscription.autopay.title', 'Auto-payment')}
+                    aria-label={t('subscription.autopay', 'Auto-payment')}
                     className="relative h-7 w-[52px] rounded-full transition-colors duration-300"
                     style={{
                       background: subscription.autopay_enabled ? zone.mainHex : g.textGhost,


### PR DESCRIPTION
Хотфикс на жалобу из багов-топика: на экране «Продлить подписку» вместо названия промогруппы показывался служебный текст `subscription.promoGroup.title`.

При проверке всех локалей нашёл ещё 118 мест в кабинете, где интерфейс показывал служебные ключи вместо переведённого текста (статусы подписок, кнопки удаления, пустые списки, успешные уведомления и т.д.). Плюс закрыл накопившийся drift на zh/fa (140 ключей), где китайцы и иранцы вместо своего перевода видели русский текст.

### Что починено
- Текст промогруппы на экране продления (баг Серёжи)
- Статусы подписок (Активна / Истекла / Ограничена / Триал)
- Кнопки и тексты удаления подписок
- Пустые состояния списка подписок и подсказки CTA
- Уведомления об успешной покупке устройств / трафика
- Тексты колеса удачи, баланса, дашборда, профиля
- Подсказки в админ-формах кампаний, промокодов, рассылок, партнёрки
- Полные переводы для китайской и фарси-локалей (исторический долг)

### Состояние
- 0 пропусков ключей во всех 4 локалях
- Build + tsc + lint зелёные

Готово к мерджу — release-please выкатит как v1.55.0 (patch bump по `fix:` коммиту).