### PR TITLE
fix: убрать кнопку «назад» на единственной подписке

### DIFF
--- a/src/AppWithNavigator.tsx
+++ b/src/AppWithNavigator.tsx
@@ -6,6 +6,7 @@ import {
   onBackButtonClick,
   offBackButtonClick,
 } from '@telegram-apps/sdk-react';
+import { useQuery } from '@tanstack/react-query';
 import Twemoji from 'react-twemoji';
 import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -16,6 +17,7 @@ import { ToastProvider } from './components/Toast';
 import { TooltipProvider } from './components/primitives/Tooltip';
 import { isInTelegramWebApp } from './hooks/useTelegramSDK';
 import { hasInAppHistory, getFallbackParentPath } from './utils/navigation';
+import { subscriptionApi } from './api/subscription';
 
 const TWEMOJI_OPTIONS = { className: 'twemoji', folder: 'svg', ext: '.svg' } as const;
 
@@ -26,6 +28,13 @@ const TWEMOJI_OPTIONS = { className: 'twemoji', folder: 'svg', ext: '.svg' } as 
 /** Pages reachable from bottom nav — treat as top-level (no back button). */
 const BOTTOM_NAV_PATHS = ['/', '/subscriptions', '/balance', '/referral', '/support', '/wheel'];
 
+/** Matches /subscriptions/:numericId — single-tariff users land here from
+ * bot deep-links, but their /subscriptions list is empty (the list view
+ * auto-redirects them straight back to this page). Pressing Back would loop
+ * back to detail, so on a deep-link entry (idx=0) we hide the back button
+ * and let Telegram surface its native Close (X) button instead. */
+const SUBSCRIPTION_DETAIL_RE = /^\/subscriptions\/\d+\/?$/;
+
 function TelegramBackButton() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -34,16 +43,30 @@ function TelegramBackButton() {
   const pathnameRef = useRef(location.pathname);
   pathnameRef.current = location.pathname;
 
+  // Share the subscriptions-list query with the page-level components.
+  // React Query dedupes by key so this does not cause an extra fetch when
+  // Subscriptions/Subscription/Dashboard pages mount.
+  const { data: subData } = useQuery({
+    queryKey: ['subscriptions-list'],
+    queryFn: () => subscriptionApi.getSubscriptions(),
+    staleTime: 30_000,
+    // Don't fetch outside Telegram — the cabinet still loads on the web.
+    enabled: isInTelegramWebApp(),
+  });
+  const isMultiTariff = subData?.multi_tariff_enabled ?? false;
+
   useEffect(() => {
     const isTopLevel = location.pathname === '' || BOTTOM_NAV_PATHS.includes(location.pathname);
+    const isSingleTariffDetailDeepLink =
+      !isMultiTariff && SUBSCRIPTION_DETAIL_RE.test(location.pathname) && !hasInAppHistory();
     try {
-      if (isTopLevel) {
+      if (isTopLevel || isSingleTariffDetailDeepLink) {
         hideBackButton();
       } else {
         showBackButton();
       }
     } catch {}
-  }, [location]);
+  }, [location, isMultiTariff]);
 
   // Stable handler — ref prevents re-subscription on every render
   const handler = useCallback(() => {

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -9,7 +9,6 @@ import { getGlassColors } from '../utils/glassTheme';
 import { useAuthStore } from '../store/auth';
 import SubscriptionListCard from '../components/subscription/SubscriptionListCard';
 import TrialOfferCard from '../components/dashboard/TrialOfferCard';
-import { hasInAppHistory } from '../utils/navigation';
 
 function EmptyState({ onBuy }: { onBuy: () => void }) {
   const { t } = useTranslation();
@@ -107,11 +106,8 @@ export default function Subscriptions() {
     },
   });
 
-  // Single-tariff mode with one subscription: skip list, go directly to detail.
-  // Skip the redirect when the user just hit the Telegram BackButton from
-  // /subscriptions/:id — that lands us here with idx=0, and redirecting back
-  // to the detail page creates a Back-button loop the user can't escape (#599679).
-  if (data && !isMultiTariff && subscriptions.length === 1 && hasInAppHistory()) {
+  // Single-tariff mode with one subscription: skip list, go directly to detail
+  if (data && !isMultiTariff && subscriptions.length === 1) {
     return <Navigate to={`/subscriptions/${subscriptions[0].id}`} replace />;
   }
 

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -9,6 +9,7 @@ import { getGlassColors } from '../utils/glassTheme';
 import { useAuthStore } from '../store/auth';
 import SubscriptionListCard from '../components/subscription/SubscriptionListCard';
 import TrialOfferCard from '../components/dashboard/TrialOfferCard';
+import { hasInAppHistory } from '../utils/navigation';
 
 function EmptyState({ onBuy }: { onBuy: () => void }) {
   const { t } = useTranslation();
@@ -106,8 +107,11 @@ export default function Subscriptions() {
     },
   });
 
-  // Single-tariff mode with one subscription: skip list, go directly to detail
-  if (data && !isMultiTariff && subscriptions.length === 1) {
+  // Single-tariff mode with one subscription: skip list, go directly to detail.
+  // Skip the redirect when the user just hit the Telegram BackButton from
+  // /subscriptions/:id — that lands us here with idx=0, and redirecting back
+  // to the detail page creates a Back-button loop the user can't escape (#599679).
+  if (data && !isMultiTariff && subscriptions.length === 1 && hasInAppHistory()) {
     return <Navigate to={`/subscriptions/${subscriptions[0].id}`} replace />;
   }
 


### PR DESCRIPTION
Доклеиваю фикс после жалобы из багов-топика: при открытии единственной подписки из тг (через кнопку или диплинк) в полноэкранной MiniApp вместо «закрыть» в шапке висела «назад», и тап по ней крутил юзера в петле.

### Что починено
- В single-tariff режиме, когда юзер проваливается прямо на свою подписку из тг, в шапке теперь сразу «закрыть» — один тап и MiniApp закрыт
- При обычной навигации внутри приложения (главная → список → подписка) кнопка «назад» работает как и раньше
- Для multi-tariff (если у юзера несколько подписок) «назад» с экрана подписки ведёт на список — не сломано
- Все остальные глубокие ссылки в кабинет (/balance/top-up, админка и т.п.) — поведение не тронуто

### Состояние
- Build + проверка типов + линтер — зелёные
- Только один файл `AppWithNavigator.tsx`, +25/−2 строк

Готово к мерджу. release-please выкатит как **v1.54.2** (patch bump по `fix:` коммиту).