### PR TITLE
fix(currency): Persian Phase A — fa balance, amount_display, تومان placeholder

### DIFF
--- a/src/api/adminUsers.ts
+++ b/src/api/adminUsers.ts
@@ -306,7 +306,9 @@ export interface PanelSyncStatusResponse {
 
 // Update types
 export interface UpdateBalanceRequest {
-  amount_kopeks: number;
+  /** Display units (Toman); server converts ×100 to kopeks. XOR with amount_kopeks. */
+  amount_display?: number;
+  amount_kopeks?: number;
   description?: string;
   create_transaction?: boolean;
 }

--- a/src/api/adminUsers.ts
+++ b/src/api/adminUsers.ts
@@ -306,7 +306,7 @@ export interface PanelSyncStatusResponse {
 
 // Update types
 export interface UpdateBalanceRequest {
-  /** Display units (Toman); server converts ×100 to kopeks. XOR with amount_kopeks. */
+  /** Display units (Toman 1:1); stored as balance_kopeks integer. XOR with amount_kopeks. */
   amount_display?: number;
   amount_kopeks?: number;
   description?: string;

--- a/src/components/WebSocketNotifications.tsx
+++ b/src/components/WebSocketNotifications.tsx
@@ -276,7 +276,7 @@ export default function WebSocketNotifications() {
 
       if (type === 'autopay.insufficient_funds') {
         const required = message.required_rubles ?? (message.required_kopeks ?? 0) / 100;
-        const balance = message.balance_rubles ?? (message.balance_kopeks ?? 0) / 100;
+        const balance = message.balance_rubles ?? message.balance_kopeks ?? 0;
         showToast({
           type: 'warning',
           title: t('wsNotifications.autopay.insufficientTitle', 'Insufficient funds'),

--- a/src/components/admin/userDetail/BalanceTab.tsx
+++ b/src/components/admin/userDetail/BalanceTab.tsx
@@ -62,20 +62,24 @@ export function BalanceTab({
     if (balanceAmount === '') return;
     setActionLoading(true);
     try {
-      const amount = Math.abs(toNumber(balanceAmount) * 100);
-      await adminUsersApi.updateBalance(userId, {
-        amount_kopeks: isAdd ? amount : -amount,
+      const displayAmount = toNumber(balanceAmount);
+      const result = await adminUsersApi.updateBalance(userId, {
+        amount_display: isAdd ? displayAmount : -displayAmount,
         description:
           balanceDescription ||
           (isAdd
             ? t('admin.users.detail.balance.addByAdmin')
             : t('admin.users.detail.balance.subtractByAdmin')),
       });
+      if (result.message) {
+        notify.success(result.message, t('common.success'));
+      }
       await onUserRefresh();
       setBalanceAmount('');
       setBalanceDescription('');
     } catch (error) {
       console.error('Failed to update balance:', error);
+      notify.error(t('admin.users.userActions.error'), t('common.error'));
     } finally {
       setActionLoading(false);
     }

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -41,8 +41,13 @@ export function useCurrency() {
   const currentLanguage = i18n.language;
   const targetCurrency = LANGUAGE_CURRENCY_MAP[currentLanguage] || 'USD';
 
-  // Check if current language is Russian (no conversion needed)
+  // Russian: amounts are already in display rubles. Persian: bot balance_rubles is
+  // already Toman (÷100 on server) — do not apply FX again.
   const isRussian = currentLanguage === 'ru';
+  const skipFxConversion =
+    isRussian ||
+    currentLanguage === 'fa' ||
+    import.meta.env.VITE_DISABLE_BALANCE_FX === 'true';
 
   // Get currency symbol from translations
   const currencySymbol = t('common.currency');
@@ -50,7 +55,10 @@ export function useCurrency() {
   // Format amount with currency conversion
   const formatAmount = useCallback(
     (rubAmount: number, decimals: number = 2): string => {
-      if (isRussian) {
+      if (skipFxConversion) {
+        if (currentLanguage === 'fa') {
+          return Math.round(rubAmount).toLocaleString('fa-IR');
+        }
         return rubAmount.toFixed(decimals);
       }
 
@@ -68,7 +76,7 @@ export function useCurrency() {
 
       return convertedAmount.toFixed(decimals);
     },
-    [isRussian, targetCurrency, exchangeRates],
+    [skipFxConversion, currentLanguage, targetCurrency, exchangeRates],
   );
 
   // Format amount with currency symbol
@@ -90,7 +98,7 @@ export function useCurrency() {
   // Get raw converted amount (for calculations)
   const convertAmount = useCallback(
     (rubAmount: number): number => {
-      if (isRussian) {
+      if (skipFxConversion) {
         return rubAmount;
       }
       return currencyApi.convertFromRub(
@@ -99,18 +107,18 @@ export function useCurrency() {
         exchangeRates,
       );
     },
-    [isRussian, targetCurrency, exchangeRates],
+    [skipFxConversion, targetCurrency, exchangeRates],
   );
 
   // Convert from user's currency back to rubles
   const convertToRub = useCallback(
     (amount: number): number => {
-      if (isRussian) {
+      if (skipFxConversion) {
         return amount;
       }
       return currencyApi.convertToRub(amount, targetCurrency as keyof ExchangeRates, exchangeRates);
     },
-    [isRussian, targetCurrency, exchangeRates],
+    [skipFxConversion, targetCurrency, exchangeRates],
   );
 
   return useMemo(
@@ -118,6 +126,7 @@ export function useCurrency() {
       exchangeRates,
       targetCurrency,
       isRussian,
+      skipFxConversion,
       currencySymbol,
       formatAmount,
       formatWithCurrency,
@@ -129,6 +138,7 @@ export function useCurrency() {
       exchangeRates,
       targetCurrency,
       isRussian,
+      skipFxConversion,
       currencySymbol,
       formatAmount,
       formatWithCurrency,

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -2932,7 +2932,7 @@
         },
         "balance": {
           "current": "موجودی فعلی",
-          "amountPlaceholder": "مبلغ به روبل",
+          "amountPlaceholder": "مبلغ به تومان",
           "descriptionPlaceholder": "توضیحات (اختیاری)",
           "add": "افزودن",
           "subtract": "کسر",


### PR DESCRIPTION
## Summary

Persian currency Phase A fixes for cabinet frontend:

- **fa balance display without FX** — show stored balance in Toman for `fa` locale without applying an extra FX conversion layer
- **`amount_display` API** — align client with Phase B balance/amount display contract from the bot API
- **fa placeholder تومان** — Persian currency label in relevant UI placeholders

## Commits

- `526b166` — fix(currency): fa balance display without FX + amount_display
- `efe99bc` — fix(currency): align cabinet balance display with Phase B API

## Test plan

- [ ] Open cabinet with `fa` locale — balance shows in تومان without double conversion
- [ ] Verify amount fields use `amount_display` from API where applicable
- [ ] Confirm تومان placeholder text in balance/payment UI
- [ ] Smoke: non-fa locales unchanged


Made with [Cursor](https://cursor.com)