### PR TITLE
feat: legal documents management (privacy / offer / recurrent)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,6 @@ import {
   ChannelSubscriptionScreen,
   BlacklistedScreen,
   AccountDeletedScreen,
-  ServiceUnavailableScreen,
 } from './components/blocking';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PermissionRoute } from '@/components/auth/PermissionRoute';
@@ -66,7 +65,6 @@ const Connection = lazyWithRetry(() => import('./pages/Connection'));
 const ConnectionQR = lazyWithRetry(() => import('./pages/ConnectionQR'));
 const QuickPurchase = lazyWithRetry(() => import('./pages/QuickPurchase'));
 const PurchaseSuccess = lazyWithRetry(() => import('./pages/PurchaseSuccess'));
-const GiftClaim = lazyWithRetry(() => import('./pages/GiftClaim'));
 const RenewSubscription = lazyWithRetry(() => import('./pages/RenewSubscription'));
 const AutoLogin = lazyWithRetry(() => import('./pages/AutoLogin'));
 const TopUpMethodSelect = lazyWithRetry(() => import('./pages/TopUpMethodSelect'));
@@ -75,6 +73,15 @@ const TopUpResult = lazyWithRetry(() => import('./pages/TopUpResult'));
 const ConnectedAccounts = lazyWithRetry(() => import('./pages/ConnectedAccounts'));
 const LinkTelegramCallback = lazyWithRetry(() => import('./pages/LinkTelegramCallback'));
 const MergeAccounts = lazyWithRetry(() => import('./pages/MergeAccounts'));
+const PublicPrivacyPage = lazyWithRetry(() =>
+  import('./pages/PublicLegalDoc').then((m) => ({ default: m.PublicPrivacyPage })),
+);
+const PublicOfferPage = lazyWithRetry(() =>
+  import('./pages/PublicLegalDoc').then((m) => ({ default: m.PublicOfferPage })),
+);
+const PublicRecurrentPaymentsPage = lazyWithRetry(() =>
+  import('./pages/PublicLegalDoc').then((m) => ({ default: m.PublicRecurrentPaymentsPage })),
+);
 
 // Admin pages - lazy load (only for admins)
 const AdminPanel = lazyWithRetry(() => import('./pages/AdminPanel'));
@@ -202,16 +209,9 @@ function AdminRoute({ children }: { children: React.ReactNode }) {
   return <Layout>{children}</Layout>;
 }
 
-// Suspense + error boundary wrapper for lazy routes. The boundary lives
-// OUTSIDE Suspense so chunk-load failures (caught by lazyWithRetry's reload
-// path) and render-time exceptions both surface in the page-level fallback
-// instead of crashing the entire shell via the top-level boundary.
+// Suspense wrapper for lazy components
 function LazyPage({ children }: { children: React.ReactNode }) {
-  return (
-    <ErrorBoundary level="page">
-      <Suspense fallback={<PageLoader variant="dark" />}>{children}</Suspense>
-    </ErrorBoundary>
-  );
+  return <Suspense fallback={<PageLoader variant="dark" />}>{children}</Suspense>;
 }
 
 function BlockingOverlay() {
@@ -231,10 +231,6 @@ function BlockingOverlay() {
 
   if (blockingType === 'account_deleted') {
     return <AccountDeletedScreen />;
-  }
-
-  if (blockingType === 'backend_unavailable') {
-    return <ServiceUnavailableScreen />;
   }
 
   return null;
@@ -277,32 +273,56 @@ function App() {
         <Route
           path="/buy/success/:token"
           element={
-            <LazyPage>
-              <PurchaseSuccess />
-            </LazyPage>
-          }
-        />
-        <Route
-          path="/buy/gift/:token"
-          element={
-            <LazyPage>
-              <GiftClaim />
-            </LazyPage>
+            <ErrorBoundary level="app">
+              <LazyPage>
+                <PurchaseSuccess />
+              </LazyPage>
+            </ErrorBoundary>
           }
         />
         <Route
           path="/buy/:slug"
           element={
-            <LazyPage>
-              <QuickPurchase />
-            </LazyPage>
+            <ErrorBoundary level="app">
+              <LazyPage>
+                <QuickPurchase />
+              </LazyPage>
+            </ErrorBoundary>
           }
         />
         <Route
           path="/auto-login"
           element={
+            <ErrorBoundary level="app">
+              <LazyPage>
+                <AutoLogin />
+              </LazyPage>
+            </ErrorBoundary>
+          }
+        />
+
+        {/* Public legal pages — accessible without authentication */}
+        <Route
+          path="/privacy"
+          element={
             <LazyPage>
-              <AutoLogin />
+              <PublicPrivacyPage />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="/offer"
+          element={
+            <LazyPage>
+              <PublicOfferPage />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="/recurrent-payments"
+          element={
+            <LazyPage>
+              <PublicRecurrentPaymentsPage />
             </LazyPage>
           }
         />
@@ -402,9 +422,11 @@ function App() {
           path="/balance/top-up/result"
           element={
             <ProtectedRoute withLayout={false}>
-              <LazyPage>
-                <TopUpResult />
-              </LazyPage>
+              <ErrorBoundary level="app">
+                <LazyPage>
+                  <TopUpResult />
+                </LazyPage>
+              </ErrorBoundary>
             </ProtectedRoute>
           }
         />
@@ -531,21 +553,25 @@ function App() {
         <Route
           path="/gift"
           element={
-            <ProtectedRoute>
-              <LazyPage>
-                <GiftSubscription />
-              </LazyPage>
-            </ProtectedRoute>
+            <ErrorBoundary level="app">
+              <ProtectedRoute>
+                <LazyPage>
+                  <GiftSubscription />
+                </LazyPage>
+              </ProtectedRoute>
+            </ErrorBoundary>
           }
         />
         <Route
           path="/gift/result"
           element={
-            <ProtectedRoute>
-              <LazyPage>
-                <GiftResult />
-              </LazyPage>
-            </ProtectedRoute>
+            <ErrorBoundary level="app">
+              <ProtectedRoute>
+                <LazyPage>
+                  <GiftResult />
+                </LazyPage>
+              </ProtectedRoute>
+            </ErrorBoundary>
           }
         />
         <Route

--- a/src/api/branding.ts
+++ b/src/api/branding.ts
@@ -325,4 +325,10 @@ export const brandingApi = {
   storeYandexCid: async (cid: string): Promise<void> => {
     await apiClient.post('/cabinet/branding/analytics/yandex-cid', { cid });
   },
+
+  // Store partner / affiliate click_id (Keitaro etc.) for the authenticated user.
+  // Saved into yandex_client_id_map.subid for S2S postback delivery.
+  storePartnerClickId: async (click_id: string): Promise<void> => {
+    await apiClient.post('/cabinet/branding/analytics/partner-click-id', { click_id });
+  },
 };

--- a/src/api/info.ts
+++ b/src/api/info.ts
@@ -23,6 +23,11 @@ export interface PublicOfferResponse {
   updated_at: string | null;
 }
 
+export interface RecurrentPaymentsResponse {
+  content: string;
+  updated_at: string | null;
+}
+
 export interface ServiceInfo {
   name: string;
   description: string | null;
@@ -65,6 +70,14 @@ export const infoApi = {
   // Get public offer
   getPublicOffer: async (): Promise<PublicOfferResponse> => {
     const response = await apiClient.get<PublicOfferResponse>('/cabinet/info/public-offer');
+    return response.data;
+  },
+
+  // Get recurrent payments agreement
+  getRecurrentPaymentsAgreement: async (): Promise<RecurrentPaymentsResponse> => {
+    const response = await apiClient.get<RecurrentPaymentsResponse>(
+      '/cabinet/info/recurrent-payments',
+    );
     return response.data;
   },
 

--- a/src/components/LegalFooter.tsx
+++ b/src/components/LegalFooter.tsx
@@ -1,0 +1,46 @@
+import { Fragment } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface LegalLink {
+  href: string;
+  labelKey: string;
+  fallback: string;
+}
+
+const LINKS: LegalLink[] = [
+  { href: '/offer', labelKey: 'footer.offer', fallback: 'Публичная оферта' },
+  { href: '/privacy', labelKey: 'footer.privacy', fallback: 'Политика конфиденциальности' },
+  { href: '/recurrent-payments', labelKey: 'footer.recurrent', fallback: 'Рекуррентные платежи' },
+];
+
+interface LegalFooterProps {
+  className?: string;
+}
+
+export default function LegalFooter({ className = '' }: LegalFooterProps) {
+  const { t } = useTranslation();
+
+  return (
+    <footer
+      className={`flex flex-wrap items-center justify-center gap-x-2.5 gap-y-1 text-center text-[11px] leading-relaxed text-dark-500 ${className}`}
+    >
+      {LINKS.map((link, index) => (
+        <Fragment key={link.href}>
+          {index > 0 && (
+            <span className="text-dark-700" aria-hidden="true">
+              ·
+            </span>
+          )}
+          <a
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-accent-400"
+          >
+            {t(link.labelKey, link.fallback)}
+          </a>
+        </Fragment>
+      ))}
+    </footer>
+  );
+}

--- a/src/components/admin/BrandingTab.tsx
+++ b/src/components/admin/BrandingTab.tsx
@@ -116,7 +116,6 @@ export function BrandingTab({ accentColor = '#3b82f6' }: BrandingTabProps) {
                 <img
                   src={brandingApi.getLogoUrl(branding) ?? undefined}
                   alt="Logo"
-                  loading="lazy"
                   className="h-full w-full object-cover"
                 />
               ) : (
@@ -180,8 +179,8 @@ export function BrandingTab({ accentColor = '#3b82f6' }: BrandingTabProps) {
                 </button>
               </div>
             ) : (
-              <div className="flex min-w-0 items-center gap-2">
-                <span className="min-w-0 truncate text-lg text-dark-100">
+              <div className="flex items-center gap-2">
+                <span className="text-lg text-dark-100">
                   {branding?.name || t('admin.settings.notSpecified')}
                 </span>
                 <button
@@ -189,7 +188,7 @@ export function BrandingTab({ accentColor = '#3b82f6' }: BrandingTabProps) {
                     setNewName(branding?.name ?? '');
                     setEditingName(true);
                   }}
-                  className="shrink-0 rounded-lg p-1.5 text-dark-400 transition-colors hover:bg-dark-700 hover:text-dark-200"
+                  className="rounded-lg p-1.5 text-dark-400 transition-colors hover:bg-dark-700 hover:text-dark-200"
                 >
                   <PencilIcon />
                 </button>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,19 +26,11 @@
     "all": "All",
     "units": {
       "gb": "GB",
-      "perGb": "/GB",
-      "days": "days",
-      "mo": "mo"
+      "perGb": "/GB"
     },
     "retry": "Retry",
     "saving": "Saving...",
-    "understand": "Got it",
-    "balance": "Balance",
-    "copied": "Copied",
-    "no_results": "No results",
-    "ok": "OK",
-    "processing": "Processing…",
-    "rangeTo": "to"
+    "understand": "Got it"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -53,8 +45,7 @@
     "info": "Info",
     "wheel": "Fortune Wheel",
     "menu": "Menu",
-    "gift": "Gift",
-    "navigation": "Navigation"
+    "gift": "Gift"
   },
   "notifications": {
     "ticketNotifications": "Ticket Notifications",
@@ -157,17 +148,7 @@
     "tariff": "Tariff",
     "validUntil": "Valid until",
     "goToSubscription": "Go to Subscription",
-    "goToBalance": "Go to Balance",
-    "devicesAdded": "+{{count}} devices",
-    "devicesPurchased": {
-      "title": "Devices added"
-    },
-    "totalDevices": "Total devices: {{count}}",
-    "totalTraffic": "Total traffic: {{value}}",
-    "trafficAdded": "+{{value}} traffic",
-    "trafficPurchased": {
-      "title": "Traffic added"
-    }
+    "goToBalance": "Go to Balance"
   },
   "auth": {
     "login": "Login",
@@ -301,7 +282,7 @@
     "trialOffer": {
       "freeTitle": "Free Trial Available",
       "paidTitle": "Trial Subscription",
-      "freeDesc": "Try our VPN for free, no commitment required",
+      "freeDesc": "Try our VPN for free — no commitment required",
       "paidDesc": "Get started with a trial subscription"
     },
     "stats": {
@@ -309,10 +290,7 @@
       "subscription": "Subscription",
       "referrals": "Referrals",
       "earnings": "Earnings"
-    },
-    "manageAll": "Manage all",
-    "showAll": "Show all",
-    "subscriptions": "Subscriptions"
+    }
   },
   "subscription": {
     "title": "Subscription",
@@ -368,8 +346,7 @@
     "cta": {
       "expiredHint": "Choose a plan and pay",
       "trialHint": "More traffic and devices",
-      "activeHint": "Renewal and plan change",
-      "renewHint": "Subscription expired — renew to continue using"
+      "activeHint": "Renewal and plan change"
     },
     "connectionInfo": "Connection Info",
     "copyLink": "Copy Link",
@@ -481,8 +458,7 @@
       "goToApps": "Go to Apps settings",
       "qrTitle": "Subscription QR Code",
       "qrScanHint": "Scan to connect",
-      "qrButton": "QR Code",
-      "openQr": "Open QR code"
+      "qrButton": "QR Code"
     },
     "myDevices": "My Devices",
     "noDevices": "No connected devices",
@@ -579,20 +555,13 @@
       "buyTraffic": "Buy more traffic",
       "currentTrafficLimit": "Current limit: {{limit}} GB (used {{used}} GB)",
       "buyTrafficTitle": "Buy more traffic",
-      "trafficWarning": "Purchased traffic is added to your current limit and is valid for 30 days from purchase",
+      "trafficWarning": "Purchased traffic is added to your current limit and does not carry over to the next period",
       "trafficUnavailable": "Traffic purchase is not available for your tariff",
       "unlimited": "Unlimited",
       "buyTrafficGb": "Buy {{gb}} GB",
       "buyUnlimited": "Buy Unlimited",
       "manageServers": "Squad management",
-      "manageServersTitle": "Squad management",
-      "connectedDevices": "Connected devices",
-      "currentDeviceLimit": "Current device limit",
-      "decrementDevices": "Decrease devices",
-      "disconnectDevicesFirst": "Disconnect extra devices first",
-      "incrementDevices": "Add devices",
-      "minDeviceLimit": "Minimum device limit",
-      "newDeviceLimit": "New device limit"
+      "manageServersTitle": "Squad management"
     },
     "serverManagement": {
       "statusLegend": "✅ — connected • ➕ — will be added (paid) • ➖ — will be disconnected",
@@ -651,27 +620,7 @@
       "stopScan": "Close camera",
       "noCamera": "Camera access denied",
       "codeFound": "Code found"
-    },
-    "allTariffsPurchased": "All tariffs already purchased",
-    "autopay": "Auto-renew",
-    "backToList": "Back to subscriptions",
-    "confirmDelete": "Delete subscription?",
-    "dailyAutoCharge": "Daily auto-charge",
-    "defaultName": "Subscription",
-    "delete": "Delete",
-    "deleteTitle": "Delete subscription",
-    "get_config": "Get config",
-    "loadError": "Failed to load subscription",
-    "newTariff": "New tariff",
-    "noOptionsAvailable": "No options available",
-    "noRenewalOptions": "No renewal options",
-    "notFound": "Subscription not found",
-    "notFoundDesc": "It may have been deleted or not yet activated",
-    "servers": "Servers",
-    "statusActive": "Active",
-    "statusExpired": "Expired",
-    "statusLimited": "Limited",
-    "statusTrial": "Trial"
+    }
   },
   "balance": {
     "title": "Balance",
@@ -789,9 +738,7 @@
         "already_used_by_user": "You have already used this promo code",
         "user_not_found": "User not found",
         "server_error": "Server error"
-      },
-      "daysLeft": "Days left: {{count}}",
-      "selectSubscription": "Select a subscription"
+      }
     },
     "minAmountError": "Minimum amount: {{amount}} ₽",
     "maxAmountError": "Maximum amount: {{amount}} ₽",
@@ -851,8 +798,7 @@
       "timeoutDesc": "Payment processing is taking longer than usual. You can try checking the status again.",
       "goToBalance": "Go to Balance",
       "tryAgain": "Try Again"
-    },
-    "top_up": "Top up balance"
+    }
   },
   "referral": {
     "title": "Referral Program",
@@ -1038,8 +984,7 @@
     "useExternalLink": "Please use the external link to get support",
     "openSupport": "Open Support",
     "contactSupport": "Please contact {{username}} for support",
-    "contactUs": "Contact Support",
-    "create_ticket": "Create ticket"
+    "contactUs": "Contact Support"
   },
   "wheel": {
     "title": "Fortune Wheel",
@@ -1072,8 +1017,7 @@
       "insufficientBalance": "Insufficient balance",
       "topUpRequired": "Top up your balance to pay for spin",
       "starsNotAvailable": "Stars payment not available. Open the app via Telegram.",
-      "noSubscription": "An active subscription is required to spin the wheel. Activate your subscription first.",
-      "selectSubscription": "Select a subscription first"
+      "noSubscription": "An active subscription is required to spin the wheel. Activate your subscription first."
     },
     "payWithStars": "Pay with Stars",
     "payWithDays": "Pay with days",
@@ -1092,8 +1036,7 @@
       "title": "Try your luck!",
       "description": "Spin the wheel and win prizes: subscription days, balance, traffic and more!",
       "button": "Go to wheel"
-    },
-    "selectSubscription": "Select subscription"
+    }
   },
   "admin": {
     "backgrounds": {
@@ -1207,7 +1150,7 @@
       "broadcasts": "Broadcasts",
       "users": "Users",
       "payments": "Payments",
-      "remnawave": "Remnawave",
+      "remnawave": "RemnaWave",
       "emailTemplates": "Email Templates",
       "paymentMethods": "Payment Methods",
       "campaigns": "Campaigns",
@@ -1282,9 +1225,6 @@
       "title": "Sales Statistics",
       "subtitle": "Revenue, trials, subscriptions, and renewals",
       "period": {
-        "thisMonth": "This month",
-        "from": "From",
-        "to": "To",
         "week": "7 days",
         "month": "30 days",
         "quarter": "90 days",
@@ -1296,15 +1236,13 @@
         "sales": "Sales",
         "renewals": "Renewals",
         "addons": "Add-ons",
-        "deposits": "Deposits",
-        "payment": "Payments"
+        "deposits": "Deposits"
       },
       "summary": {
         "revenue": "Revenue",
         "activeSubs": "Active Subs",
         "activeTrials": "Active Trials",
         "newTrials": "New Trials",
-        "newPaid": "New Paid Subscriptions",
         "conversion": "Conversion",
         "renewals": "Renewals",
         "addonRevenue": "Add-on Revenue",
@@ -1315,13 +1253,13 @@
         "totalRegistrations": "Registrations",
         "trialsIssued": "Trials Issued",
         "conversion": "Conversion Rate",
+        "avgDuration": "Avg Duration",
         "byProvider": "By Registration Source",
         "dailyChart": "Daily Registrations & Trials",
         "registrations": "Registrations"
       },
       "sales": {
         "totalSales": "Total Sales",
-        "totalRevenue": "Subscription turnover",
         "avgOrder": "Avg Order",
         "topTariff": "Top Tariff",
         "byTariff": "Sales by Tariff",
@@ -1360,12 +1298,6 @@
         "dailyChart": "Daily Deposits",
         "dailyByMethod": "Daily Deposits by Payment Method",
         "revenue": "Revenue"
-      },
-      "payments": {
-        "successRate": "Payment success rate",
-        "attempts": "Payment attempts",
-        "failedPurchases": "Failed purchases",
-        "byGateway": "Success rate by gateway"
       },
       "loadError": "Failed to load statistics"
     },
@@ -1543,7 +1475,7 @@
       "description": "Search and manage payments",
       "searchPlaceholder": "Search: invoice, TG ID, @username, email...",
       "searchHint": "Examples: SP-78291, @username, 123456789, user@mail.ru",
-      "searchResults": "Results for: {{query}}. Found {{count}}",
+      "searchResults": "Results for: {{query}} — found {{count}}",
       "resetSearch": "Reset",
       "statusAll": "All",
       "statusPending": "Pending",
@@ -1589,7 +1521,7 @@
       "methodEnabled": "Method enabled",
       "providerNotConfigured": "Provider not configured in env",
       "openUrlDirect": "Open payment page directly",
-      "openUrlDirectHint": "Skip the link panel: the provider opens inside the MiniApp/tab right after the click. After payment the user returns to /balance/top-up/result. Ignored for Stars/CryptoBot and other t.me/ links.",
+      "openUrlDirectHint": "Skip the link panel — the provider opens inside the MiniApp/tab right after the click. After payment the user returns to /balance/top-up/result. Ignored for Stars/CryptoBot and other t.me/ links.",
       "displayName": "Display name",
       "displayNameHint": "Leave empty for default name",
       "subOptions": "Payment options",
@@ -1612,11 +1544,10 @@
       "promoGroupsShort": "groups",
       "noPromoGroups": "No promo groups",
       "cancelButton": "Cancel",
-      "saveButton": "Save",
-      "notFound": "Payment method not found"
+      "saveButton": "Save"
     },
     "remnawave": {
-      "title": "Remnawave",
+      "title": "RemnaWave",
       "subtitle": "Panel management and statistics",
       "connected": "Connected",
       "disconnected": "Not configured",
@@ -1680,8 +1611,7 @@
           "offline": "Offline",
           "disabled": "Disabled",
           "users": "Users"
-        },
-        "usersOnlineCount": "{{count}} online"
+        }
       },
       "squads": {
         "synced": "Synced",
@@ -1712,9 +1642,7 @@
         "localSettings": "Local Settings",
         "trialEligible": "Trial Eligible",
         "price": "Price",
-        "users": "Users",
-        "inboundsCount": "{{count}} inbounds",
-        "membersCount": "{{count}} members"
+        "users": "Users"
       },
       "sync": {
         "autoSync": "Auto Sync",
@@ -1730,9 +1658,9 @@
         "success": "Success",
         "runAutoSyncNow": "Run Auto Sync Now",
         "fromPanel": "From Panel",
-        "fromPanelDesc": "Import users from Remnawave to bot",
+        "fromPanelDesc": "Import users from RemnaWave to bot",
         "toPanel": "To Panel",
-        "toPanelDesc": "Export users from bot to Remnawave"
+        "toPanelDesc": "Export users from bot to RemnaWave"
       }
     },
     "wheel": {
@@ -1756,8 +1684,7 @@
         "dailyLimit": "Daily Spin Limit (0 = unlimited)",
         "minSubDays": "Min subscription days for day payment",
         "promocodes": "Promocodes",
-        "promoPrefix": "Promo code prefix",
-        "promoValidityDays": "Promo code validity (days)"
+        "promoPrefix": "Promo code prefix"
       },
       "starsNotEnabledGlobally": "Star payments are not enabled in Payment Methods. Enable \"Telegram Stars\" in the Payment Methods section.",
       "prizes": {
@@ -1784,9 +1711,7 @@
           "emoji": "Emoji",
           "color": "Color",
           "active": "Active",
-          "worth": "Worth",
-          "probability": "Manual probability (0–1)",
-          "probabilityHint": "Empty = auto by RTP"
+          "worth": "Worth"
         },
         "promo": {
           "title": "Promo Code Settings",
@@ -1804,9 +1729,7 @@
         "times": "times",
         "times_one": "{{count}} time",
         "times_other": "{{count}} times",
-        "topWins": "Top Wins",
-        "loadError": "Failed to load statistics",
-        "empty": "No spins yet"
+        "topWins": "Top Wins"
       }
     },
     "broadcasts": {
@@ -1897,12 +1820,7 @@
       "btnConnect": "Connect",
       "btnSubscription": "Subscription",
       "btnSupport": "Support",
-      "btnHome": "Home",
-      "category": "Category",
-      "categoryNews": "News",
-      "categoryPromo": "Promo",
-      "categorySystem": "System",
-      "stopping": "Stopping…"
+      "btnHome": "Home"
     },
     "pinnedMessages": {
       "title": "Pinned Messages",
@@ -2144,7 +2062,7 @@
         "db_sqlite": "SQLite",
         "db_redis": "Redis",
         "sys_core": "Core & Debug",
-        "sys_remnawave": "Remnawave",
+        "sys_remnawave": "RemnaWave",
         "sys_webapi": "Web API",
         "sys_webhook": "Webhook",
         "sys_server": "Server status",
@@ -2194,7 +2112,7 @@
         "deleteUser": "Delete users"
       },
       "deleteSubscription": {
-        "warning": "Selected subscriptions will be permanently deleted from the bot and Remnawave panel!",
+        "warning": "Selected subscriptions will be permanently deleted from the bot and RemnaWave panel!",
         "hint": "Users will lose VPN access for deleted subscriptions. This action cannot be undone.",
         "activePaidWarning": "{{count}} of {{total}} selected subscriptions are active paid",
         "forceDeleteConfirm": "I confirm deletion of active paid subscriptions"
@@ -2202,7 +2120,7 @@
       "deleteUser": {
         "warning": "Selected users will be permanently deleted from the bot! All their subscriptions, balance, and data will be lost!",
         "hint": "This action cannot be undone. Users will need to restart the bot to create a new account.",
-        "deleteFromPanel": "Also delete from Remnawave panel"
+        "deleteFromPanel": "Also delete from RemnaWave panel"
       },
       "params": {
         "days": "Number of days",
@@ -2233,7 +2151,7 @@
         "summaryErrors": "{{count}} errors"
       },
       "errors": {
-        "title": "{{count}} errors. Show details"
+        "title": "{{count}} errors — show details"
       },
       "filters": {
         "search": "Search by ID, username, email",
@@ -2386,16 +2304,13 @@
       "importError": "Invalid JSON file format",
       "importCreateError": "Failed to create some apps",
       "noAppsToImport": "No apps to import",
-      "remnaWaveToggle": "Toggle Remnawave source",
-      "refreshRemnaWave": "Refresh from Remnawave",
-      "remnaWaveMode": "Showing apps from Remnawave panel. Read-only mode.",
-      "remnaWaveSettings": "Remnawave Settings",
+      "remnaWaveToggle": "Toggle RemnaWave source",
+      "refreshRemnaWave": "Refresh from RemnaWave",
+      "remnaWaveMode": "Showing apps from RemnaWave panel. Read-only mode.",
+      "remnaWaveSettings": "RemnaWave Settings",
       "remnaWaveConfigUuid": "Config UUID",
-      "remnaWaveConfigUuidHint": "UUID of subscription page config from Remnawave panel",
-      "availableConfigs": "Available configs",
-      "noConfigs": "No configs",
-      "remnaWaveConnected": "Remnawave connected",
-      "remnaWaveDisconnected": "Remnawave disconnected"
+      "remnaWaveConfigUuidHint": "UUID of subscription page config from RemnaWave panel",
+      "availableConfigs": "Available configs"
     },
     "tickets": {
       "title": "Ticket Management",
@@ -2446,13 +2361,7 @@
       "userNotificationsEnabled": "User Notifications",
       "userNotificationsEnabledDesc": "Send notifications to users about admin replies",
       "adminNotificationsEnabled": "Admin Notifications",
-      "adminNotificationsEnabledDesc": "Send notifications to admins about new tickets and replies",
-      "replyFailed": "Failed to send reply",
-      "validation": {
-        "checkIntervalRange": "Check interval must be between 1 and 1440 minutes",
-        "reminderCooldownRange": "Reminder cooldown must be between 0 and 1440 minutes",
-        "slaMinutesRange": "SLA must be between 1 and 10080 minutes"
-      }
+      "adminNotificationsEnabledDesc": "Send notifications to admins about new tickets and replies"
     },
     "tariffs": {
       "title": "Tariff Management",
@@ -2489,7 +2398,7 @@
       "confirmDeleteText": "This action cannot be undone. The tariff will be permanently deleted.",
       "confirmDeleteWithSubscriptions": "This tariff has {{count}} active subscriptions. After deletion, users will need to select a new tariff when renewing.",
       "deleteSuccess": "Tariff deleted successfully",
-      "deleteSuccessWithSubscriptions": "Tariff deleted. {{count}} subscriptions reset. Users will choose a new tariff on renewal.",
+      "deleteSuccessWithSubscriptions": "Tariff deleted. {{count}} subscriptions reset — users will choose a new tariff on renewal.",
       "saveOrder": "Save order",
       "orderSaved": "Order saved",
       "dragToReorder": "Drag to reorder",
@@ -2544,13 +2453,13 @@
       "daysShort": "d.",
       "serversTitle": "Servers",
       "externalSquadTitle": "External Squad",
-      "externalSquadHint": "Assign a Remnawave external squad for users on this tariff. When a subscription is created, the user will be automatically added to the selected squad.",
+      "externalSquadHint": "Assign a RemnaWave external squad for users on this tariff. When a subscription is created, the user will be automatically added to the selected squad.",
       "noExternalSquad": "No external squad",
       "externalSquadUsers": "users",
       "serversTabHint": "Select servers available on this tariff.",
       "noServersAvailable": "No servers available",
       "promoGroupsTitle": "Promo Groups",
-      "promoGroupsHint": "Select promo groups that have access to this tariff. If none selected, available to everyone.",
+      "promoGroupsHint": "Select promo groups that have access to this tariff. If none selected — available to everyone.",
       "noPromoGroups": "No promo groups",
       "extraDeviceTitle": "Additional devices",
       "devicePriceLabel": "Device price (30 days):",
@@ -2623,7 +2532,7 @@
       "sync": "Sync",
       "syncing": "Syncing...",
       "syncNow": "Sync now",
-      "noServers": "No servers. Sync with Remnawave.",
+      "noServers": "No servers. Sync with RemnaWave.",
       "edit": "Edit Server",
       "originalName": "Original Name",
       "displayName": "Display Name",
@@ -2679,8 +2588,7 @@
         "deactivate": "Deactivate",
         "activate": "Activate",
         "edit": "Edit",
-        "delete": "Delete",
-        "registrations": "Registrations"
+        "delete": "Delete"
       },
       "modal": {
         "editTitle": "Edit Campaign",
@@ -2704,7 +2612,7 @@
         "notSelected": "Not selected",
         "tariffOption": "{{traffic}} GB, {{devices}} dev.",
         "durationDays": "Duration (days)",
-        "noBonusDescription": "Campaign without bonuses: only for tracking clicks and registrations.",
+        "noBonusDescription": "Campaign without bonuses — only for tracking clicks and registrations.",
         "active": "Active",
         "cancel": "Cancel",
         "save": "Save",
@@ -2750,13 +2658,11 @@
         "totalSpending": "Subscription Spending",
         "periodComparison": "Period comparison",
         "vsLastWeek": "vs last week",
-        "topRegistrations": "Top registrations",
-        "subscriptionsIssued": "Subscriptions issued",
-        "tariffsIssued": "Tariffs issued"
+        "topRegistrations": "Top registrations"
       },
       "users": {
         "title": "Campaign Users",
-        "campaignRegistrations": "{{name}}: {{count}} registrations",
+        "campaignRegistrations": "{{name}} — {{count}} registrations",
         "noUsers": "No registered users",
         "user": "User",
         "bonus": "Bonus",
@@ -2776,10 +2682,7 @@
         "delete": "Delete"
       },
       "loadError": "Failed to load campaign",
-      "updateError": "Failed to save changes",
-      "validation": {
-        "nameRequired": "Name is required"
-      }
+      "updateError": "Failed to save changes"
     },
     "withdrawals": {
       "title": "Withdrawals",
@@ -2950,10 +2853,7 @@
         "createTitle": "Create Campaign",
         "createSubtitle": "Campaign will be auto-assigned to the partner",
         "autoAssignNote": "Campaign will be automatically assigned to partner {{name}}",
-        "createAndAssign": "Create & Assign",
-        "earnings": "Earnings",
-        "referrals": "Referrals",
-        "registrations": "Registrations"
+        "createAndAssign": "Create & Assign"
       },
       "dangerZone": {
         "title": "Danger Zone",
@@ -3028,10 +2928,7 @@
         "firstPurchaseOnly": "First purchase only",
         "cancel": "Cancel",
         "saving": "Saving...",
-        "save": "Save",
-        "defaultTrialTariff": "Default trial tariff",
-        "selectTariff": "Select tariff",
-        "tariff": "Tariff"
+        "save": "Save"
       },
       "stats": {
         "title": "Promo code statistics",
@@ -3061,8 +2958,7 @@
         "totalPromocodes": "Total promo codes",
         "activeCount": "Active",
         "usagesCount": "Uses",
-        "exhausted": "Exhausted",
-        "hoursValue": "{{count}}h"
+        "exhausted": "Exhausted"
       },
       "actions": {
         "stats": "Statistics",
@@ -3353,9 +3249,7 @@
           "expired": "expired",
           "daysLeft": "d left",
           "deviceLimitUpdated": "Device limit updated",
-          "invalidDays": "Please enter a valid number of days (greater than 0)",
-          "backToList": "Back to subscriptions",
-          "createNew": "Create new"
+          "invalidDays": "Please enter a valid number of days (greater than 0)"
         },
         "balance": {
           "current": "Current balance",
@@ -3439,9 +3333,7 @@
           "alreadyReferred": "already has referrer",
           "noUsersFound": "No users found"
         }
-      },
-      "notFound": "User not found",
-      "purchaseCount": "Purchases: {{count}}"
+      }
     },
     "promoOffers": {
       "title": "Promo Offers",
@@ -3450,8 +3342,7 @@
       "tabs": {
         "templates_one": "Templates ({{count}} template)",
         "templates_other": "Templates ({{count}} templates)",
-        "logs": "Logs",
-        "templates": "Templates"
+        "logs": "Logs"
       },
       "noData": {
         "templates": "No templates",
@@ -3481,9 +3372,7 @@
         "activeDiscountHours": "Discount validity (hours)",
         "discountDurationHint": "How long the discount lasts after activation",
         "templateActive": "Template active",
-        "saving": "Saving...",
-        "noServers": "No servers",
-        "testSquads": "Test squads"
+        "saving": "Saving..."
       },
       "send": {
         "title": "Send promo offer",
@@ -3509,10 +3398,7 @@
         "notificationsSent_other": "Notifications sent: {{count}}",
         "notificationsFailed_one": "(failed: {{count}})",
         "notificationsFailed_other": "(failed: {{count}})",
-        "sendError": "Failed to send offer",
-        "notificationsSent": "Notifications sent",
-        "offersCreated": "Offers created",
-        "notificationsFailed": "(failed: {{count}})"
+        "sendError": "Failed to send offer"
       },
       "notFound": "Template not found",
       "noActiveTemplates": "No active templates",
@@ -3649,8 +3535,7 @@
         "selectedPermissions_other": "{{count}} permissions selected",
         "cancel": "Cancel",
         "saving": "Saving...",
-        "save": "Save",
-        "selectedPermissions": "Selected permissions"
+        "save": "Save"
       },
       "presets": {
         "moderator": "Moderator",
@@ -3670,9 +3555,7 @@
         "updateFailed": "Failed to update role",
         "nameRequired": "Role name is required",
         "deleteFailed": "Failed to delete role"
-      },
-      "permissionsCount": "{{count}} permissions",
-      "usersCount": "{{count}} users"
+      }
     },
     "roleAssign": {
       "title": "Role Assignment",
@@ -3725,8 +3608,7 @@
         "roleRequired": "Please select a role",
         "assignFailed": "Failed to assign role",
         "revokeFailed": "Failed to revoke role"
-      },
-      "totalAssignments": "Total assignments: {{count}}"
+      }
     },
     "policies": {
       "title": "Access Policies",
@@ -3794,8 +3676,7 @@
         "day3": "Wed",
         "day4": "Thu",
         "day5": "Fri",
-        "day6": "Sat",
-        "ipCount": "IP count"
+        "day6": "Sat"
       },
       "confirm": {
         "title": "Delete policy?",
@@ -3881,10 +3762,7 @@
         "hoursAgo_one": "{{count}} hr ago",
         "hoursAgo_other": "{{count}} hrs ago",
         "daysAgo_one": "{{count}} day ago",
-        "daysAgo_other": "{{count}} days ago",
-        "daysAgo": "{{count}}d ago",
-        "hoursAgo": "{{count}}h ago",
-        "minutesAgo": "{{count}}m ago"
+        "daysAgo_other": "{{count}} days ago"
       },
       "pagination": {
         "pageSize": "Per page:",
@@ -3897,8 +3775,7 @@
       "errors": {
         "loadFailed": "Failed to load audit log",
         "retry": "Try again"
-      },
-      "totalEntries": "Total entries: {{count}}"
+      }
     },
     "landings": {
       "title": "Landing Pages",
@@ -3983,12 +3860,6 @@
         "dailyChart": "Purchases & Revenue by Day",
         "tariffChart": "Tariff Distribution",
         "giftBreakdown": "Gifts vs Regular",
-        "funnelTitle": "Conversion funnel",
-        "giftClaimTitle": "Gift activation",
-        "giftClaimLabel": "claimed / sent",
-        "dailyRevenue": "Daily revenue",
-        "byPaymentMethod": "By payment method",
-        "bySource": "Traffic sources",
         "purchases": "Purchases",
         "revenueLabel": "Revenue",
         "gifts": "Gifts",
@@ -3998,8 +3869,7 @@
         "funnel": "Funnel",
         "loadError": "Failed to load statistics",
         "noPurchases": "No purchases",
-        "paid": "paid",
-        "dailyPurchases": "Purchases per day"
+        "paid": "paid"
       },
       "purchases": {
         "title": "Purchases",
@@ -4025,16 +3895,7 @@
         "page": "Page {{current}} of {{total}}",
         "prev": "Previous",
         "next": "Next"
-      },
-      "methodCurrency": "Currency",
-      "methodDescPlaceholder": "Short description shown to the user",
-      "methodDescription": "Method description",
-      "methodDisplayName": "Display name",
-      "methodIconUrl": "Icon URL",
-      "methodMaxAmount": "Maximum amount",
-      "methodMinAmount": "Minimum amount",
-      "methodReturnUrl": "Return URL",
-      "stickyPayButton": "Sticky pay button"
+      }
     },
     "infoPages": {
       "title": "Information Pages",
@@ -4146,8 +4007,7 @@
       "disable": "Disable",
       "hide": "Hide ({{count}})",
       "showMore_one": "Show {{count}} more node",
-      "showMore_other": "Show {{count}} more nodes",
-      "showMore": "Show more"
+      "showMore_other": "Show {{count}} more nodes"
     },
     "topReferrers": {
       "title": "Top referrers",
@@ -4597,15 +4457,8 @@
         "yandex": "Yandex",
         "discord": "Discord",
         "vk": "VK"
-      },
-      "backToAccounts": "Back to accounts"
-    },
-    "emailMergePasswordRequired": "This email already belongs to another account. To merge the accounts, enter that account's password.",
-    "emailMergeCodeSent": "A confirmation code was sent to that email.",
-    "emailMergeCodeDescription": "This email already belongs to another account. We sent a code to it — enter it to confirm ownership and merge the accounts.",
-    "emailMergeCodeLabel": "Code from the email",
-    "emailMergeConfirm": "Confirm and merge",
-    "emailMergeCodeInvalid": "Invalid or expired code"
+      }
+    }
   },
   "theme": {
     "colors": "Theme Colors",
@@ -4758,8 +4611,7 @@
       "warning": "A cancelled promo code cannot be reused. The discount will stop working immediately.",
       "confirm": "Cancel discount",
       "deactivating": "Cancelling...",
-      "error": "Failed to cancel promo code. Please try again later.",
-      "success": "Offer deactivated"
+      "error": "Failed to cancel promo code. Please try again later."
     }
   },
   "telegramRedirect": {
@@ -4821,14 +4673,6 @@
       "openBot": "Open the bot",
       "retry": "I pressed /start, retry",
       "hint": "After running /start, return here and tap «Retry»."
-    },
-    "serviceUnavailable": {
-      "title": "Service unavailable",
-      "description": "We can't reach the service right now. It may be undergoing maintenance or there's a temporary connection issue.",
-      "retry": "Try again",
-      "checking": "Checking connection...",
-      "hint": "This page will refresh automatically as soon as the service is back.",
-      "close": "Close"
     }
   },
   "merge": {
@@ -4859,36 +4703,6 @@
     "merging": "Merging..."
   },
   "landing": {
-    "giftClaim": {
-      "title": "You have a gift!",
-      "error": "Could not activate the gift.",
-      "notFoundTitle": "Gift not found",
-      "notFoundDesc": "This gift link is invalid or no longer available.",
-      "alreadyTitle": "Gift already activated",
-      "alreadyDesc": "This gift has already been claimed.",
-      "successTitle": "Gift activated!",
-      "connectDesc": "Use this link to connect:",
-      "copyLink": "Copy link",
-      "pendingTitle": "Almost ready…",
-      "pendingDesc": "The payment is still being confirmed. This page will update automatically.",
-      "replaceWarning": "You already have a subscription — activating this gift will replace it.",
-      "activateTelegram": "Activate in Telegram",
-      "activateWeb": "Activate by email",
-      "emailLabel": "Your email",
-      "claimNow": "Get my gift",
-      "failedTitle": "Gift unavailable",
-      "failedDesc": "The payment for this gift did not go through, so it cannot be activated."
-    },
-    "giftLink": {
-      "shareText": "I have a gift for you! Activate it here:",
-      "viaTelegram": "Telegram:",
-      "title": "Gift is ready!",
-      "subtitle": "Send this link to whoever you want to receive the gift — they activate it themselves.",
-      "linkLabel": "Gift link",
-      "telegramLabel": "Telegram link",
-      "alsoSent": "We also emailed it to {{contact}}.",
-      "copyMessage": "Copy message"
-    },
     "notFound": "Page not found",
     "forMe": "For me",
     "asGift": "As a gift",
@@ -4927,6 +4741,7 @@
     "copy": "Copy",
     "copied": "Copied!",
     "copyLink": "Copy link",
+    "consent": "I agree with the <privacy>privacy policy</privacy>, <offer>terms of service</offer> and <recurrent>recurring payments agreement</recurrent>.",
     "giftToggleLabel": "Purchase type",
     "pollTimedOut": "Taking longer than expected",
     "pollTimedOutDesc": "Payment processing is taking longer than usual. You can try checking again.",
@@ -4974,9 +4789,7 @@
       "nDays_one": "{{count}} day",
       "nDays_other": "{{count}} days",
       "nMonths_one": "{{count}} month",
-      "nMonths_other": "{{count}} months",
-      "nDays": "{{count}} days",
-      "nMonths": "{{count}} months"
+      "nMonths_other": "{{count}} months"
     }
   },
   "gift": {
@@ -5050,7 +4863,7 @@
     "activateButton": "Activate gift",
     "activating": "Activating...",
     "activateSuccess": "Gift activated!",
-    "activateSuccessDesc": "{{tariff}}: {{days}} days added to your subscription",
+    "activateSuccessDesc": "{{tariff}} — {{days}} days added to your subscription",
     "activateError": "Failed to activate gift",
     "activateSelfError": "You cannot activate your own gift",
     "myGiftsEmpty": "No gifts yet",
@@ -5154,13 +4967,5 @@
         "linkUrlPrompt": "URL:"
       }
     }
-  },
-  "subscriptions": {
-    "buy": "Buy subscription",
-    "buyAnother": "Buy another subscription",
-    "browsePlans": "View plans and subscribe",
-    "empty": "You have no subscriptions yet",
-    "emptyDesc": "Choose a tariff to get started",
-    "title": "My subscriptions"
   }
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -23,22 +23,14 @@
     "copy": "کپی",
     "units": {
       "gb": "GB",
-      "perGb": "/GB",
-      "days": "روز",
-      "mo": "ماه"
+      "perGb": "/GB"
     },
     "add": "افزودن",
     "refresh": "بازخوانی",
     "retry": "تلاش مجدد",
     "saving": "در حال ذخیره...",
     "understand": "متوجه شدم",
-    "collapse": "جمع کردن",
-    "balance": "موجودی",
-    "copied": "کپی شد",
-    "no_results": "نتیجه‌ای یافت نشد",
-    "ok": "تأیید",
-    "processing": "در حال پردازش…",
-    "rangeTo": "تا"
+    "collapse": "جمع کردن"
   },
   "nav": {
     "dashboard": "داشبورد",
@@ -53,8 +45,7 @@
     "info": "اطلاعات",
     "wheel": "چرخ شانس",
     "menu": "منو",
-    "gift": "هدیه",
-    "navigation": "ناوبری"
+    "gift": "هدیه"
   },
   "notifications": {
     "ticketNotifications": "اعلان‌های تیکت",
@@ -151,17 +142,7 @@
     "tariff": "تعرفه",
     "validUntil": "معتبر تا",
     "goToSubscription": "رفتن به اشتراک",
-    "goToBalance": "رفتن به موجودی",
-    "devicesAdded": "+{{count}} دستگاه",
-    "devicesPurchased": {
-      "title": "دستگاه‌ها افزوده شدند"
-    },
-    "totalDevices": "مجموع دستگاه‌ها: {{count}}",
-    "totalTraffic": "مجموع ترافیک: {{value}}",
-    "trafficAdded": "+{{value}} ترافیک",
-    "trafficPurchased": {
-      "title": "ترافیک افزوده شد"
-    }
+    "goToBalance": "رفتن به موجودی"
   },
   "auth": {
     "login": "ورود",
@@ -262,38 +243,13 @@
       "tariffs": "تعرفه‌ها",
       "traffic": "ترافیک",
       "devices": "دستگاه‌ها",
-      "expiredDate": "منقضی شده",
-      "activeUntil": "منقضی شده — تا {{date}}"
+      "expiredDate": "منقضی شده"
     },
     "deviceLimitReached": "برای افزودن دستگاه جدید، دستگاه‌های فعلی را قطع کنید",
     "suspended": {
       "title": "اشتراک معلق شده",
       "resume": "از سرگیری"
-    },
-    "manageAll": "مدیریت همه",
-    "showAll": "نمایش همه",
-    "subscriptions": "اشتراک‌ها",
-    "connectDevice": "اتصال دستگاه",
-    "devicesConnectedUnlimited": "{{count}} دستگاه متصل",
-    "devicesOfMax": "{{used}} از {{max}}",
-    "maxUsage": "حداکثر",
-    "remaining": "باقی‌مانده",
-    "stats": {
-      "balance": "موجودی",
-      "referrals": "معرفی‌شده‌ها"
-    },
-    "tariff": "تعرفه",
-    "trafficUsageTitle": "مصرف ترافیک",
-    "trialOffer": {
-      "freeDesc": "{{days}} روز رایگان آزمایش کنید — بدون پرداخت",
-      "freeTitle": "دوره آزمایشی رایگان",
-      "paidDesc": "{{days}} روز آزمایشی فقط با {{price}}",
-      "paidTitle": "دوره آزمایشی پرداختی"
-    },
-    "unlimited": "نامحدود",
-    "usageLast14Days": "مصرف ۱۴ روز اخیر",
-    "usedSuffix": "مصرف شده",
-    "validUntil": "معتبر تا {{date}}"
+    }
   },
   "subscription": {
     "title": "اشتراک",
@@ -383,10 +339,7 @@
       "devices_other": "{{count}} دستگاه",
       "price": "هزینه فعال‌سازی",
       "activate": "فعال‌سازی دوره آزمایشی",
-      "unavailable": "دوره آزمایشی در دسترس نیست",
-      "insufficientBalance": "موجودی برای فعال‌سازی دوره آزمایشی کافی نیست",
-      "payAndActivate": "پرداخت و فعال‌سازی",
-      "topUpToActivate": "برای فعال‌سازی دوره آزمایشی موجودی را افزایش دهید"
+      "unavailable": "دوره آزمایشی در دسترس نیست"
     },
     "connection": {
       "title": "اتصال VPN",
@@ -415,8 +368,7 @@
       "goToApps": "رفتن به تنظیمات برنامه‌ها",
       "qrTitle": "کد QR اشتراک",
       "qrScanHint": "برای اتصال با دوربین اسکن کنید",
-      "qrButton": "کد QR",
-      "openQr": "باز کردن کد QR"
+      "qrButton": "کد QR"
     },
     "additionalOptions": {
       "title": "گزینه‌های اضافی",
@@ -429,26 +381,13 @@
       "buyTraffic": "خرید ترافیک بیشتر",
       "currentTrafficLimit": "محدودیت فعلی: {{limit}} GB (مصرف شده {{used}} GB)",
       "buyTrafficTitle": "خرید ترافیک بیشتر",
-      "trafficWarning": "ترافیک خریداری‌شده به محدودیت فعلی اضافه می‌شود و تا ۳۰ روز از زمان خرید معتبر است",
+      "trafficWarning": "ترافیک خریداری شده به محدودیت فعلی اضافه می‌شود و به دوره بعدی منتقل نمی‌شود",
       "trafficUnavailable": "خرید ترافیک برای اشتراک شما در دسترس نیست",
       "unlimited": "نامحدود",
       "buyTrafficGb": "خرید {{gb}} GB",
       "buyUnlimited": "خرید نامحدود",
       "manageServers": "مدیریت اسکوادها",
-      "manageServersTitle": "مدیریت اسکوادها",
-      "connectedDevices": "دستگاه‌های متصل",
-      "currentDeviceLimit": "محدودیت فعلی دستگاه",
-      "decrementDevices": "کاهش تعداد دستگاه‌ها",
-      "disconnectDevicesFirst": "ابتدا دستگاه‌های اضافی را قطع کنید",
-      "incrementDevices": "افزایش تعداد دستگاه‌ها",
-      "minDeviceLimit": "حداقل محدودیت دستگاه",
-      "newDeviceLimit": "محدودیت جدید دستگاه",
-      "reduce": "کاهش",
-      "reduceDevices": "کاهش تعداد دستگاه‌ها",
-      "reduceDevicesDescription": "محدودیت دستگاه‌های خود را تنظیم کنید. در صورت لزوم ابتدا دستگاه‌های اضافه را قطع کنید",
-      "reduceDevicesTitle": "کاهش تعداد دستگاه‌ها",
-      "reduceUnavailable": "در حال حاضر کاهش تعداد دستگاه‌ها امکان‌پذیر نیست",
-      "reducing": "در حال کاهش…"
+      "manageServersTitle": "مدیریت اسکوادها"
     },
     "serverManagement": {
       "statusLegend": "✅ — متصل • ➕ — اضافه خواهد شد (پولی) • ➖ — قطع خواهد شد",
@@ -560,46 +499,6 @@
       "stopScan": "بستن دوربین",
       "noCamera": "دسترسی به دوربین امکان‌پذیر نیست",
       "codeFound": "کد پیدا شد"
-    },
-    "allTariffsPurchased": "همه تعرفه‌ها قبلاً خریداری شده‌اند",
-    "autopay": "تمدید خودکار",
-    "backToList": "بازگشت به فهرست اشتراک‌ها",
-    "confirmDelete": "اشتراک حذف شود؟",
-    "cta": {
-      "renewHint": "اشتراک منقضی شده — برای ادامه استفاده تمدید کنید",
-      "activeHint": "اشتراک فعال است — می‌توانید دستگاه‌ها را متصل کرده و از VPN استفاده کنید",
-      "expiredHint": "اشتراک منقضی شده — برای ادامه استفاده تمدید کنید",
-      "trialHint": "شما در دوره آزمایشی هستید — برای دسترسی به همه امکانات به تعرفه پرداختی ارتقا دهید"
-    },
-    "dailyAutoCharge": "برداشت خودکار روزانه",
-    "defaultName": "اشتراک",
-    "delete": "حذف",
-    "deleteTitle": "حذف اشتراک",
-    "get_config": "دریافت پیکربندی",
-    "loadError": "بارگذاری اشتراک ناموفق بود",
-    "newTariff": "تعرفه جدید",
-    "noOptionsAvailable": "گزینه‌ای در دسترس نیست",
-    "noRenewalOptions": "گزینه‌ای برای تمدید وجود ندارد",
-    "notFound": "اشتراک یافت نشد",
-    "notFoundDesc": "ممکن است حذف شده یا هنوز فعال نشده باشد",
-    "servers": "سرورها",
-    "statusActive": "فعال",
-    "statusExpired": "منقضی شده",
-    "statusLimited": "محدود",
-    "statusTrial": "آزمایشی",
-    "daysShort": "روز",
-    "expiredBanner": {
-      "selectTariff": "تعرفه را انتخاب کنید",
-      "title": "اشتراک منقضی شده است"
-    },
-    "trialInfo": {
-      "description": "{{days}} روز سرویس ما را رایگان امتحان کنید",
-      "remaining": "{{count}} روز باقی‌مانده",
-      "title": "دوره آزمایشی"
-    },
-    "trialUpgrade": {
-      "description": "برای دسترسی به همه امکانات و ادامه استفاده به اشتراک پرداختی ارتقا دهید",
-      "title": "ارتقای اشتراک"
     }
   },
   "balance": {
@@ -676,9 +575,7 @@
         "already_used_by_user": "شما قبلاً از این کد استفاده کرده‌اید",
         "user_not_found": "کاربر یافت نشد",
         "server_error": "خطای سرور"
-      },
-      "daysLeft": "روزهای باقی‌مانده: {{count}}",
-      "selectSubscription": "اشتراک را انتخاب کنید"
+      }
     },
     "minAmountError": "حداقل مبلغ: {{amount}}",
     "maxAmountError": "حداکثر مبلغ: {{amount}}",
@@ -736,8 +633,7 @@
       "timeoutDesc": "پردازش پرداخت بیشتر از حد معمول طول می‌کشد. می‌توانید دوباره وضعیت را بررسی کنید.",
       "goToBalance": "مشاهده موجودی",
       "tryAgain": "تلاش مجدد"
-    },
-    "top_up": "افزایش موجودی"
+    }
   },
   "referral": {
     "title": "برنامه معرفی",
@@ -921,8 +817,7 @@
     "contactUs": "تماس با پشتیبانی",
     "openSupport": "باز کردن پشتیبانی",
     "ticketsDisabled": "تیکت‌ها غیرفعال است",
-    "useExternalLink": "لطفاً از لینک خارجی برای دریافت پشتیبانی استفاده کنید",
-    "create_ticket": "ایجاد تیکت"
+    "useExternalLink": "لطفاً از لینک خارجی برای دریافت پشتیبانی استفاده کنید"
   },
   "wheel": {
     "title": "چرخ شانس",
@@ -954,8 +849,7 @@
       "insufficientBalance": "موجودی کافی نیست",
       "topUpRequired": "برای پرداخت شارژ کنید",
       "starsNotAvailable": "پرداخت Stars در دسترس نیست. برنامه را از طریق تلگرام باز کنید.",
-      "noSubscription": "برای چرخاندن گردونه نیاز به اشتراک فعال دارید. ابتدا اشتراک خود را فعال کنید.",
-      "selectSubscription": "ابتدا یک اشتراک انتخاب کنید"
+      "noSubscription": "برای چرخاندن گردونه نیاز به اشتراک فعال دارید. ابتدا اشتراک خود را فعال کنید."
     },
     "payWithStars": "پرداخت {stars} Stars",
     "processingPayment": "در حال پردازش...",
@@ -974,8 +868,7 @@
     "noPrize": "این بار شانس نیاوردید...",
     "payWithDays": "پرداخت با روز",
     "starsPaymentSuccessCheckHistory": "پرداخت موفق! تاریخچه یا تلگرام را بررسی کنید.",
-    "youWon": "شما برنده شدید",
-    "selectSubscription": "اشتراک را انتخاب کنید"
+    "youWon": "شما برنده شدید"
   },
   "admin": {
     "backgrounds": {
@@ -1086,7 +979,7 @@
       "promoOffers": "پیشنهادات تبلیغاتی",
       "promocodes": "کدهای تخفیف",
       "promoGroups": "گروه‌های تخفیف",
-      "remnawave": "Remnawave",
+      "remnawave": "RemnaWave",
       "users": "کاربران",
       "trafficUsage": "مصرف ترافیک",
       "updates": "به‌روزرسانی‌ها",
@@ -1155,9 +1048,6 @@
       "title": "آمار فروش",
       "subtitle": "درآمد، آزمایشی، اشتراک و تمدید",
       "period": {
-        "thisMonth": "این ماه",
-        "from": "از",
-        "to": "تا",
         "week": "۷ روز",
         "month": "۳۰ روز",
         "quarter": "۹۰ روز",
@@ -1169,15 +1059,13 @@
         "sales": "فروش",
         "renewals": "تمدید",
         "addons": "خدمات اضافی",
-        "deposits": "شارژ",
-        "payment": "پرداخت‌ها"
+        "deposits": "شارژ"
       },
       "summary": {
         "revenue": "درآمد",
         "activeSubs": "اشتراک فعال",
         "activeTrials": "آزمایشی فعال",
         "newTrials": "آزمایشی جدید",
-        "newPaid": "اشتراک‌های پولی جدید",
         "conversion": "تبدیل",
         "renewals": "تمدید",
         "addonRevenue": "درآمد خدمات اضافی",
@@ -1188,13 +1076,13 @@
         "totalRegistrations": "ثبت‌نام‌ها",
         "trialsIssued": "آزمایشی صادرشده",
         "conversion": "نرخ تبدیل",
+        "avgDuration": "میانگین مدت",
         "byProvider": "بر اساس منبع",
         "dailyChart": "ثبت‌نام و آزمایشی روزانه",
         "registrations": "ثبت‌نام"
       },
       "sales": {
         "totalSales": "کل فروش",
-        "totalRevenue": "گردش اشتراک",
         "avgOrder": "میانگین سفارش",
         "topTariff": "تعرفه برتر",
         "byTariff": "بر اساس تعرفه",
@@ -1233,12 +1121,6 @@
         "dailyChart": "شارژ روزانه",
         "dailyByMethod": "شارژ روزانه بر اساس روش پرداخت",
         "revenue": "درآمد"
-      },
-      "payments": {
-        "successRate": "نرخ موفقیت پرداخت",
-        "attempts": "تلاش‌های پرداخت",
-        "failedPurchases": "خریدهای ناموفق",
-        "byGateway": "نرخ موفقیت بر اساس درگاه"
       },
       "loadError": "بارگذاری آمار ناموفق بود"
     },
@@ -1432,8 +1314,7 @@
         "promoPrefix": "پیشوند کد تخفیف",
         "spinCost": "هزینه چرخش",
         "limitsAndRtp": "محدودیت‌ها و RTP",
-        "promocodes": "کدهای تخفیف",
-        "promoValidityDays": "اعتبار کد تخفیف (روز)"
+        "promocodes": "کدهای تخفیف"
       },
       "starsNotEnabledGlobally": "پرداخت با ستاره در روش‌های پرداخت فعال نیست. «Telegram Stars» را در بخش «روش‌های پرداخت» فعال کنید.",
       "prizes": {
@@ -1460,9 +1341,7 @@
           "emoji": "ایموجی",
           "color": "رنگ",
           "active": "فعال",
-          "worth": "ارزش",
-          "probability": "احتمال دستی (۰–۱)",
-          "probabilityHint": "خالی = خودکار بر اساس RTP"
+          "worth": "ارزش"
         },
         "promo": {
           "title": "تنظیمات کد تخفیف",
@@ -1479,9 +1358,7 @@
         "prizeDistribution": "توزیع جوایز",
         "times": "بار",
         "times_other": "{{count}} بار",
-        "topWins": "برترین برنده‌ها",
-        "loadError": "بارگذاری آمار ناموفق بود",
-        "empty": "هنوز چرخشی انجام نشده"
+        "topWins": "برترین برنده‌ها"
       }
     },
     "broadcasts": {
@@ -1545,32 +1422,7 @@
       "customButtonTypeCallback": "Callback",
       "customButtonTypeUrl": "لینک",
       "customButtonCallbackPlaceholder": "callback_data (مثلاً back_to_menu)",
-      "customButtonUrlPlaceholder": "https://example.com",
-      "category": "دسته‌بندی",
-      "categoryNews": "اخبار",
-      "categoryPromo": "تبلیغاتی",
-      "categorySystem": "سیستمی",
-      "stopping": "در حال توقف…",
-      "btnBalance": "افزایش موجودی",
-      "btnConnect": "اتصال",
-      "btnHome": "صفحه اصلی",
-      "btnPartners": "برنامه معرفی",
-      "btnPromocode": "کد تخفیف",
-      "btnSubscription": "اشتراک",
-      "btnSupport": "پشتیبانی",
-      "emailContent": "محتوای ایمیل",
-      "emailContentHint": "پشتیبانی از HTML",
-      "emailContentPlaceholder": "<p>سلام، {{user_name}}!</p>\n<p>پیام شما اینجا...</p>",
-      "emailSection": "ارسال انبوه ایمیل",
-      "emailSubject": "موضوع ایمیل",
-      "emailSubjectPlaceholder": "موضوع ایمیل را وارد کنید...",
-      "emailVariables": "متغیرهای موجود",
-      "preview": "پیش‌نمایش",
-      "previewEmpty": "— خالی —",
-      "selectChannel": "کانال ارسال",
-      "selectEmailFilter": "مخاطبان ایمیل را انتخاب کنید",
-      "selectEmailFilterPlaceholder": "فیلتر را انتخاب کنید...",
-      "telegramSection": "ارسال انبوه تلگرام"
+      "customButtonUrlPlaceholder": "https://example.com"
     },
     "pinnedMessages": {
       "title": "Pinned Messages",
@@ -1659,7 +1511,7 @@
       "description": "جستجو و مدیریت پرداخت‌ها",
       "searchPlaceholder": "جستجو: فاکتور، شناسه تلگرام، @نام‌کاربری، ایمیل...",
       "searchHint": "مثال‌ها: SP-78291, @username, 123456789, user@mail.ru",
-      "searchResults": "نتایج برای: {{query}}. {{count}} یافت شد",
+      "searchResults": "نتایج برای: {{query}} — {{count}} یافت شد",
       "resetSearch": "بازنشانی",
       "statusAll": "همه",
       "statusPending": "در انتظار",
@@ -1848,7 +1700,7 @@
         "db_sqlite": "SQLite",
         "db_redis": "Redis",
         "sys_core": "هسته و اشکال‌زدایی",
-        "sys_remnawave": "Remnawave",
+        "sys_remnawave": "RemnaWave",
         "sys_webapi": "Web API",
         "sys_webhook": "Webhook",
         "sys_server": "وضعیت سرور",
@@ -1871,8 +1723,8 @@
         "telegramOidcClientId": "Client ID (شناسه ربات)",
         "telegramOidcClientSecret": "Client Secret"
       },
-      "offlineConv": "تبدیل‌های آفلاین",
-      "apiKey": "کلید API"
+      "offlineConv": "\u062a\u0628\u062f\u06cc\u0644\u200c\u0647\u0627\u06cc \u0622\u0641\u0644\u0627\u06cc\u0646",
+      "apiKey": "\u06a9\u0644\u06cc\u062f API"
     },
     "buttons": {
       "color": "رنگ دکمه",
@@ -1973,15 +1825,12 @@
       "importError": "فرمت فایل JSON نامعتبر",
       "importPreview": "پیش‌نمایش وارد کردن",
       "noAppsToImport": "هیچ برنامه‌ای برای وارد کردن نیست",
-      "refreshRemnaWave": "بازخوانی از Remnawave",
+      "refreshRemnaWave": "بازخوانی از RemnaWave",
       "remnaWaveConfigUuid": "UUID پیکربندی",
-      "remnaWaveConfigUuidHint": "UUID پیکربندی صفحه اشتراک از پنل Remnawave",
-      "remnaWaveMode": "نمایش برنامه‌ها از پنل Remnawave. حالت فقط خواندنی.",
-      "remnaWaveSettings": "تنظیمات Remnawave",
-      "remnaWaveToggle": "تغییر منبع Remnawave",
-      "noConfigs": "هیچ تنظیماتی وجود ندارد",
-      "remnaWaveConnected": "Remnawave متصل است",
-      "remnaWaveDisconnected": "Remnawave قطع است"
+      "remnaWaveConfigUuidHint": "UUID پیکربندی صفحه اشتراک از پنل RemnaWave",
+      "remnaWaveMode": "نمایش برنامه‌ها از پنل RemnaWave. حالت فقط خواندنی.",
+      "remnaWaveSettings": "تنظیمات RemnaWave",
+      "remnaWaveToggle": "تغییر منبع RemnaWave"
     },
     "tickets": {
       "title": "مدیریت تیکت‌ها",
@@ -2032,13 +1881,7 @@
       "copyTelegramId": "برای کپی شناسه تلگرام کلیک کنید",
       "viewUser": "کاربر",
       "userNotificationsEnabled": "اعلان‌های کاربر",
-      "userNotificationsEnabledDesc": "ارسال اعلان به کاربران درباره پاسخ‌های مدیر",
-      "replyFailed": "ارسال پاسخ ناموفق بود",
-      "validation": {
-        "checkIntervalRange": "بازه بررسی باید بین ۱ تا ۱۴۴۰ دقیقه باشد",
-        "reminderCooldownRange": "زمان تأخیر یادآوری باید بین ۰ تا ۱۴۴۰ دقیقه باشد",
-        "slaMinutesRange": "SLA باید بین ۱ تا ۱۰۰۸۰ دقیقه باشد"
-      }
+      "userNotificationsEnabledDesc": "ارسال اعلان به کاربران درباره پاسخ‌های مدیر"
     },
     "tariffs": {
       "title": "مدیریت تعرفه‌ها",
@@ -2072,7 +1915,7 @@
       "confirmDeleteText": "این عمل قابل بازگشت نیست. تعرفه برای همیشه حذف می‌شود.",
       "confirmDeleteWithSubscriptions": "این تعرفه {{count}} اشتراک فعال دارد. پس از حذف، کاربران هنگام تمدید باید تعرفه جدید انتخاب کنند.",
       "deleteSuccess": "تعرفه با موفقیت حذف شد",
-      "deleteSuccessWithSubscriptions": "تعرفه حذف شد. تعرفه {{count}} اشتراک بازنشانی شد. کاربران هنگام تمدید تعرفه جدید انتخاب می‌کنند.",
+      "deleteSuccessWithSubscriptions": "تعرفه حذف شد. تعرفه {{count}} اشتراک بازنشانی شد — کاربران هنگام تمدید تعرفه جدید انتخاب می‌کنند.",
       "saveOrder": "ذخیره ترتیب",
       "orderSaved": "ترتیب ذخیره شد",
       "dragToReorder": "برای تغییر ترتیب بکشید",
@@ -2123,7 +1966,7 @@
       "daysShort": "روز",
       "serversTitle": "سرورها",
       "externalSquadTitle": "گروه خارجی",
-      "externalSquadHint": "یک گروه خارجی Remnawave برای کاربران این تعرفه تعیین کنید. هنگام ایجاد اشتراک، کاربر به طور خودکار به گروه انتخاب شده اضافه می‌شود.",
+      "externalSquadHint": "یک گروه خارجی RemnaWave برای کاربران این تعرفه تعیین کنید. هنگام ایجاد اشتراک، کاربر به طور خودکار به گروه انتخاب شده اضافه می‌شود.",
       "noExternalSquad": "بدون گروه خارجی",
       "externalSquadUsers": "کاربران",
       "serversTabHint": "سرورهای موجود در این تعرفه را انتخاب کنید.",
@@ -2202,7 +2045,7 @@
       "sync": "همگام‌سازی",
       "syncing": "در حال همگام‌سازی...",
       "syncNow": "همگام‌سازی الان",
-      "noServers": "سروری نیست. با Remnawave همگام‌سازی کنید.",
+      "noServers": "سروری نیست. با RemnaWave همگام‌سازی کنید.",
       "edit": "ویرایش سرور",
       "originalName": "نام اصلی",
       "displayName": "نام نمایشی",
@@ -2245,7 +2088,7 @@
       "methodEnabled": "روش فعال است",
       "providerNotConfigured": "ارائه‌دهنده در env تنظیم نشده",
       "openUrlDirect": "صفحه پرداخت را مستقیماً باز کن",
-      "openUrlDirectHint": "بدون پنل لینک: ارائه‌دهنده داخل MiniApp/تب بلافاصله پس از کلیک باز می‌شود. پس از پرداخت کاربر به /balance/top-up/result بازمی‌گردد. برای Stars/CryptoBot و سایر لینک‌های t.me/ این پرچم نادیده گرفته می‌شود.",
+      "openUrlDirectHint": "بدون پنل لینک — ارائه‌دهنده داخل MiniApp/تب بلافاصله پس از کلیک باز می‌شود. پس از پرداخت کاربر به /balance/top-up/result بازمی‌گردد. برای Stars/CryptoBot و سایر لینک‌های t.me/ این پرچم نادیده گرفته می‌شود.",
       "displayName": "نام نمایشی",
       "displayNameHint": "برای نام پیش‌فرض خالی بگذارید",
       "subOptions": "گزینه‌های پرداخت",
@@ -2268,8 +2111,7 @@
       "promoGroupsShort": "گروه",
       "noPromoGroups": "هیچ گروه تبلیغاتی نیست",
       "cancelButton": "لغو",
-      "saveButton": "ذخیره",
-      "notFound": "روش پرداخت یافت نشد"
+      "saveButton": "ذخیره"
     },
     "campaigns": {
       "title": "کمپین‌های تبلیغاتی",
@@ -2297,8 +2139,7 @@
         "deactivate": "غیرفعال کردن",
         "activate": "فعال کردن",
         "edit": "ویرایش",
-        "delete": "حذف",
-        "registrations": "ثبت‌نام‌ها"
+        "delete": "حذف"
       },
       "modal": {
         "editTitle": "ویرایش کمپین",
@@ -2322,7 +2163,7 @@
         "notSelected": "انتخاب نشده",
         "tariffOption": "{{traffic}} GB، {{devices}} دستگاه",
         "durationDays": "مدت (روز)",
-        "noBonusDescription": "کمپین بدون پاداش: فقط برای ردیابی کلیک‌ها و ثبت‌نام‌ها.",
+        "noBonusDescription": "کمپین بدون پاداش — فقط برای ردیابی کلیک‌ها و ثبت‌نام‌ها.",
         "active": "فعال",
         "cancel": "لغو",
         "save": "ذخیره",
@@ -2366,13 +2207,11 @@
         "totalSpending": "هزینه اشتراک",
         "periodComparison": "مقایسه دوره‌ها",
         "vsLastWeek": "نسبت به هفته قبل",
-        "topRegistrations": "بالاترین ثبت‌نام‌ها",
-        "subscriptionsIssued": "اشتراک‌های صادر شده",
-        "tariffsIssued": "تعرفه‌های صادر شده"
+        "topRegistrations": "بالاترین ثبت‌نام‌ها"
       },
       "users": {
         "title": "کاربران کمپین",
-        "campaignRegistrations": "{{name}}: {{count}} ثبت‌نام",
+        "campaignRegistrations": "{{name}} — {{count}} ثبت‌نام",
         "noUsers": "کاربر ثبت‌نام شده‌ای وجود ندارد",
         "user": "کاربر",
         "bonus": "پاداش",
@@ -2392,11 +2231,7 @@
         "delete": "حذف"
       },
       "loadError": "بارگذاری کمپین ناموفق بود",
-      "updateError": "ذخیره تغییرات ناموفق بود",
-      "validation": {
-        "nameRequired": "نام الزامی است"
-      },
-      "loadMore": "بارگذاری بیشتر"
+      "updateError": "ذخیره تغییرات ناموفق بود"
     },
     "withdrawals": {
       "title": "برداشت‌ها",
@@ -2503,30 +2338,7 @@
         "description": "رد درخواست شراکت از {{name}}",
         "commentLabel": "نظر (اختیاری)",
         "commentPlaceholder": "دلیل رد..."
-      },
-      "settings": "تنظیمات",
-      "settingsFields": {
-        "cooldownDays": "فاصله بین برداشت‌ها (روز)",
-        "cooldownDaysDesc": "چند روز باید بین درخواست‌های برداشت بگذرد",
-        "minAmount": "حداقل مبلغ برداشت (کوپک)",
-        "minAmountDesc": "حداقل مبلغ برای درخواست برداشت (۱۰۰ کوپک = ۱ ₽)",
-        "partnerVisible": "بخش همکاران در کابین قابل مشاهده باشد",
-        "partnerVisibleDesc": "نمایش/مخفی کردن بخش‌های درخواست همکاری و برداشت برای کاربران",
-        "programEnabled": "برنامه معرفی فعال است",
-        "programEnabledDesc": "تمام عملکرد ارجاع را فعال می‌کند",
-        "requisitesText": "متن اطلاعات حساب",
-        "requisitesTextDesc": "در فرم درخواست همکاری به کاربر نمایش داده می‌شود",
-        "requisitesTextPlaceholder": "اطلاعات حساب خود را وارد کنید...",
-        "withdrawalEnabled": "برداشت مجاز است",
-        "withdrawalEnabledDesc": "به کاربران اجازه می‌دهد درخواست برداشت بدهند"
-      },
-      "settingsLoadError": "بارگذاری تنظیمات همکاری ناموفق بود",
-      "settingsSection": {
-        "referralProgram": "برنامه معرفی",
-        "withdrawalSettings": "تنظیمات برداشت"
-      },
-      "settingsSubtitle": "تنظیمات برنامه معرفی و برداشت همکاران",
-      "settingsUpdateError": "ذخیره تنظیمات همکاری ناموفق بود"
+      }
     },
     "partnerDetail": {
       "title": "جزئیات شریک",
@@ -2567,10 +2379,7 @@
         "createTitle": "ایجاد کمپین",
         "createSubtitle": "کمپین به‌طور خودکار به شریک اختصاص می‌یابد",
         "autoAssignNote": "کمپین به‌طور خودکار به شریک {{name}} اختصاص می‌یابد",
-        "createAndAssign": "ایجاد و اختصاص",
-        "earnings": "درآمد",
-        "referrals": "معرفی‌شده‌ها",
-        "registrations": "ثبت‌نام‌ها"
+        "createAndAssign": "ایجاد و اختصاص"
       },
       "dangerZone": {
         "title": "منطقه خطر",
@@ -2643,10 +2452,7 @@
         "firstPurchaseOnly": "فقط برای اولین خرید",
         "cancel": "لغو",
         "saving": "در حال ذخیره...",
-        "save": "ذخیره",
-        "defaultTrialTariff": "تعرفه پیش‌فرض آزمایشی",
-        "selectTariff": "تعرفه را انتخاب کنید",
-        "tariff": "تعرفه"
+        "save": "ذخیره"
       },
       "stats": {
         "title": "آمار کد تخفیف",
@@ -2675,8 +2481,7 @@
         "totalPromocodes": "کل کدهای تخفیف",
         "activeCount": "فعال",
         "usagesCount": "استفاده‌ها",
-        "exhausted": "تمام شده",
-        "hoursValue": "{{count}} ساعت"
+        "exhausted": "تمام شده"
       },
       "actions": {
         "stats": "آمار",
@@ -2931,9 +2736,7 @@
           "expired": "منقضی شده",
           "daysLeft": "روز باقیمانده",
           "deviceLimitUpdated": "محدودیت دستگاه به‌روز شد",
-          "invalidDays": "لطفاً تعداد روز معتبر وارد کنید (بیشتر از ۰)",
-          "backToList": "بازگشت به فهرست اشتراک‌ها",
-          "createNew": "ایجاد جدید"
+          "invalidDays": "لطفاً تعداد روز معتبر وارد کنید (بیشتر از ۰)"
         },
         "balance": {
           "current": "موجودی فعلی",
@@ -3016,26 +2819,6 @@
           "searchPlaceholder": "جستجو بر اساس نام، ایمیل یا شناسه تلگرام...",
           "alreadyReferred": "قبلاً معرفی شده",
           "noUsersFound": "کاربری یافت نشد"
-        },
-        "actions": {
-          "areYouSure": "آیا مطمئنید می‌خواهید ادامه دهید؟",
-          "title": "عملیات"
-        },
-        "noVpnData": "داده‌ای از VPN وجود ندارد"
-      },
-      "notFound": "کاربر یافت نشد",
-      "purchaseCount": "تعداد خرید: {{count}}",
-      "userActions": {
-        "delete": "حذف کاربر",
-        "disable": "غیرفعال‌سازی",
-        "error": "انجام عملیات ناموفق بود",
-        "resetSubscription": "بازنشانی اشتراک",
-        "resetTrial": "بازنشانی دوره آزمایشی",
-        "success": {
-          "delete": "کاربر حذف شد",
-          "disable": "کاربر غیرفعال شد",
-          "resetSubscription": "اشتراک بازنشانی شد",
-          "resetTrial": "دوره آزمایشی بازنشانی شد"
         }
       }
     },
@@ -3045,8 +2828,7 @@
       "sendButton": "ارسال",
       "tabs": {
         "templates_other": "قالب‌ها ({{count}})",
-        "logs": "گزارش‌ها",
-        "templates": "قالب‌ها"
+        "logs": "گزارش‌ها"
       },
       "noData": {
         "templates": "قالبی وجود ندارد",
@@ -3076,9 +2858,7 @@
         "activeDiscountHours": "اعتبار تخفیف (ساعت)",
         "discountDurationHint": "مدت زمان اعتبار تخفیف پس از فعال‌سازی",
         "templateActive": "قالب فعال",
-        "saving": "در حال ذخیره...",
-        "noServers": "هیچ سروری وجود ندارد",
-        "testSquads": "تیم‌های آزمایشی"
+        "saving": "در حال ذخیره..."
       },
       "send": {
         "title": "ارسال پیشنهاد تبلیغاتی",
@@ -3101,9 +2881,7 @@
         "offersCreated_other": "پیشنهادات ایجاد شده: {{count}}",
         "notificationsSent_other": "اعلان‌های ارسال شده: {{count}}",
         "notificationsFailed": "(ناموفق: {{count}})",
-        "sendError": "ارسال پیشنهاد ناموفق بود",
-        "notificationsSent": "اعلان‌های ارسال شده",
-        "offersCreated": "پیشنهادهای ایجاد شده"
+        "sendError": "ارسال پیشنهاد ناموفق بود"
       },
       "notFound": "قالب یافت نشد",
       "noActiveTemplates": "قالب فعالی وجود ندارد",
@@ -3154,7 +2932,7 @@
       "connected": "متصل",
       "disconnected": "تنظیم نشده",
       "noData": "بارگذاری داده‌ها ناموفق بود",
-      "title": "Remnawave",
+      "title": "RemnaWave",
       "subtitle": "مدیریت پنل و آمار",
       "tabs": {
         "overview": "نمای کلی",
@@ -3192,8 +2970,7 @@
           "offline": "آفلاین",
           "disabled": "غیرفعال",
           "users": "کاربران"
-        },
-        "usersOnlineCount": "{{count}} آنلاین"
+        }
       },
       "overview": {
         "bandwidth": "پهنای باند لحظه‌ای",
@@ -3244,9 +3021,7 @@
         "localSettings": "تنظیمات محلی",
         "trialEligible": "واجد شرایط آزمایشی",
         "price": "قیمت",
-        "users": "کاربران",
-        "inboundsCount": "{{count}} ورودی",
-        "membersCount": "{{count}} عضو"
+        "users": "کاربران"
       },
       "sync": {
         "autoSync": "همگام‌سازی خودکار",
@@ -3262,9 +3037,9 @@
         "success": "موفق",
         "runAutoSyncNow": "اجرای همگام‌سازی خودکار",
         "fromPanel": "از پنل",
-        "fromPanelDesc": "وارد کردن کاربران از Remnawave به ربات",
+        "fromPanelDesc": "وارد کردن کاربران از RemnaWave به ربات",
         "toPanel": "به پنل",
-        "toPanelDesc": "صادر کردن کاربران از ربات به Remnawave"
+        "toPanelDesc": "صادر کردن کاربران از ربات به RemnaWave"
       }
     },
     "theme": {
@@ -3371,8 +3146,7 @@
         "selectedPermissions_other": "{{count}} مجوز انتخاب شده",
         "cancel": "لغو",
         "saving": "در حال ذخیره...",
-        "save": "ذخیره",
-        "selectedPermissions": "مجوزهای انتخاب‌شده"
+        "save": "ذخیره"
       },
       "presets": {
         "moderator": "مدیر محتوا",
@@ -3392,9 +3166,7 @@
         "updateFailed": "به‌روزرسانی نقش ناموفق بود",
         "nameRequired": "نام نقش الزامی است",
         "deleteFailed": "حذف نقش ناموفق بود"
-      },
-      "permissionsCount": "{{count}} مجوز",
-      "usersCount": "{{count}} کاربر"
+      }
     },
     "roleAssign": {
       "title": "تخصیص نقش",
@@ -3446,8 +3218,7 @@
         "roleRequired": "لطفاً یک نقش انتخاب کنید",
         "assignFailed": "تخصیص نقش ناموفق بود",
         "revokeFailed": "لغو نقش ناموفق بود"
-      },
-      "totalAssignments": "مجموع انتساب‌ها: {{count}}"
+      }
     },
     "policies": {
       "title": "سیاست‌های دسترسی",
@@ -3514,8 +3285,7 @@
         "day3": "چهارشنبه",
         "day4": "پنجشنبه",
         "day5": "جمعه",
-        "day6": "شنبه",
-        "ipCount": "تعداد آی‌پی"
+        "day6": "شنبه"
       },
       "confirm": {
         "title": "حذف سیاست؟",
@@ -3597,10 +3367,7 @@
         "justNow": "همین الان",
         "minutesAgo_other": "{{count}} دقیقه پیش",
         "hoursAgo_other": "{{count}} ساعت پیش",
-        "daysAgo_other": "{{count}} روز پیش",
-        "daysAgo": "{{count}} روز پیش",
-        "hoursAgo": "{{count}} ساعت پیش",
-        "minutesAgo": "{{count}} دقیقه پیش"
+        "daysAgo_other": "{{count}} روز پیش"
       },
       "pagination": {
         "pageSize": "در هر صفحه:",
@@ -3613,8 +3380,7 @@
       "errors": {
         "loadFailed": "بارگذاری گزارش بازرسی ناموفق بود",
         "retry": "تلاش مجدد"
-      },
-      "totalEntries": "مجموع موارد: {{count}}"
+      }
     },
     "landings": {
       "title": "صفحات فرود",
@@ -3699,12 +3465,6 @@
         "dailyChart": "خرید و درآمد روزانه",
         "tariffChart": "توزیع طرح‌ها",
         "giftBreakdown": "هدایا در مقابل عادی",
-        "funnelTitle": "قیف تبدیل",
-        "giftClaimTitle": "فعال‌سازی هدیه",
-        "giftClaimLabel": "دریافت‌شده / ارسال‌شده",
-        "dailyRevenue": "درآمد روزانه",
-        "byPaymentMethod": "بر اساس روش پرداخت",
-        "bySource": "منابع ترافیک",
         "purchases": "خریدها",
         "revenueLabel": "درآمد",
         "gifts": "هدایا",
@@ -3714,8 +3474,7 @@
         "funnel": "قیف",
         "loadError": "بارگذاری آمار ناموفق بود",
         "noPurchases": "خریدی وجود ندارد",
-        "paid": "پرداخت شده",
-        "dailyPurchases": "خریدهای روزانه"
+        "paid": "پرداخت شده"
       },
       "purchases": {
         "title": "خریدها",
@@ -3741,16 +3500,7 @@
         "page": "صفحه {{current}} از {{total}}",
         "prev": "قبلی",
         "next": "بعدی"
-      },
-      "methodCurrency": "ارز",
-      "methodDescPlaceholder": "توضیح کوتاه برای کاربر",
-      "methodDescription": "توضیحات روش",
-      "methodDisplayName": "نام نمایشی",
-      "methodIconUrl": "آدرس نماد",
-      "methodMaxAmount": "حداکثر مبلغ",
-      "methodMinAmount": "حداقل مبلغ",
-      "methodReturnUrl": "آدرس بازگشت",
-      "stickyPayButton": "دکمه پرداخت ثابت"
+      }
     },
     "infoPages": {
       "title": "صفحات اطلاعات",
@@ -3846,15 +3596,13 @@
         "deleteUser": "حذف کاربران"
       },
       "deleteSubscription": {
-        "warning": "اشتراک‌های انتخاب شده برای همیشه از ربات و پنل Remnawave حذف خواهند شد!",
-        "hint": "کاربران دسترسی VPN اشتراک‌های حذف شده را از دست خواهند داد. این عملیات قابل بازگشت نیست.",
-        "activePaidWarning": "{{count}} از {{total}} اشتراک انتخاب‌شده اشتراک‌های فعال پرداختی هستند",
-        "forceDeleteConfirm": "حذف اشتراک‌های فعال پرداختی را تأیید می‌کنم"
+        "warning": "اشتراک‌های انتخاب شده برای همیشه از ربات و پنل RemnaWave حذف خواهند شد!",
+        "hint": "کاربران دسترسی VPN اشتراک‌های حذف شده را از دست خواهند داد. این عملیات قابل بازگشت نیست."
       },
       "deleteUser": {
         "warning": "کاربران انتخاب شده برای همیشه از ربات حذف خواهند شد! تمام اشتراک‌ها، موجودی و داده‌های آن‌ها از بین خواهد رفت!",
         "hint": "این عملیات قابل بازگشت نیست. کاربران باید ربات را دوباره راه‌اندازی کنند تا حساب جدید بسازند.",
-        "deleteFromPanel": "همچنین از پنل Remnawave حذف شود"
+        "deleteFromPanel": "همچنین از پنل RemnaWave حذف شود"
       },
       "params": {
         "days": "تعداد روز",
@@ -3885,7 +3633,7 @@
         "summaryErrors": "{{count}} خطا"
       },
       "errors": {
-        "title": "{{count}} خطا. نمایش جزئیات"
+        "title": "{{count}} خطا — نمایش جزئیات"
       },
       "filters": {
         "search": "جستجو بر اساس شناسه، نام کاربری، ایمیل",
@@ -3970,8 +3718,7 @@
       "enable": "فعال",
       "disable": "غیرفعال",
       "hide": "پنهان کردن ({{count}})",
-      "showMore_other": "نمایش {{count}} گره بیشتر",
-      "showMore": "نمایش بیشتر"
+      "showMore_other": "نمایش {{count}} گره بیشتر"
     },
     "revenue": {
       "title": "درآمد",
@@ -4035,16 +3782,6 @@
       "uptime": "آپتایم",
       "users": "کاربران",
       "activeSubs": "اشتراک‌ها"
-    },
-    "tariffs": {
-      "activeSubscriptions": "اشتراک‌های فعال",
-      "purchasedMonth": "فروش ماه",
-      "purchasedToday": "فروش امروز",
-      "purchasedWeek": "فروش هفته",
-      "subtitle": "آمار به تفکیک تعرفه",
-      "tariffName": "نام تعرفه",
-      "title": "آمار تعرفه‌ها",
-      "trialSubscriptions": "اشتراک‌های آزمایشی"
     }
   },
   "profile": {
@@ -4142,15 +3879,8 @@
         "yandex": "یاندکس",
         "discord": "دیسکورد",
         "vk": "VK"
-      },
-      "backToAccounts": "بازگشت به فهرست حساب‌ها"
-    },
-    "emailMergePasswordRequired": "این ایمیل قبلاً به حساب دیگری تعلق دارد. برای ادغام حساب‌ها، رمز عبور آن حساب را وارد کنید.",
-    "emailMergeCodeSent": "کد تأیید به آن ایمیل ارسال شد.",
-    "emailMergeCodeDescription": "این ایمیل قبلاً به حساب دیگری تعلق دارد. کدی به آن ارسال کردیم — برای تأیید مالکیت و ادغام حساب‌ها آن را وارد کنید.",
-    "emailMergeCodeLabel": "کد ارسال‌شده در ایمیل",
-    "emailMergeConfirm": "تأیید و ادغام",
-    "emailMergeCodeInvalid": "کد نامعتبر یا منقضی‌شده"
+      }
+    }
   },
   "theme": {
     "colors": "رنگ‌های تم",
@@ -4300,8 +4030,7 @@
       "warning": "کد تخفیف لغو شده قابل استفاده مجدد نیست. تخفیف بلافاصله متوقف می‌شود.",
       "confirm": "لغو تخفیف",
       "deactivating": "در حال لغو...",
-      "error": "لغو کد تخفیف ناموفق بود. لطفاً بعداً دوباره امتحان کنید.",
-      "success": "پیشنهاد غیرفعال شد"
+      "error": "لغو کد تخفیف ناموفق بود. لطفاً بعداً دوباره امتحان کنید."
     }
   },
   "telegramRedirect": {
@@ -4481,14 +4210,6 @@
       "openBot": "باز کردن ربات",
       "retry": "من /start را زدم، دوباره امتحان کن",
       "hint": "پس از اجرای /start، به اینجا بازگردید و «دوباره امتحان کنید» را بزنید."
-    },
-    "serviceUnavailable": {
-      "title": "سرویس در دسترس نیست",
-      "description": "در حال حاضر امکان اتصال به سرویس وجود ندارد. ممکن است در حال تعمیر باشد یا مشکل موقتی در اتصال وجود داشته باشد.",
-      "retry": "تلاش مجدد",
-      "checking": "در حال بررسی اتصال...",
-      "hint": "به‌محض در دسترس قرار گرفتن سرویس، این صفحه به‌طور خودکار بازخوانی می‌شود.",
-      "close": "بستن"
     }
   },
   "merge": {
@@ -4519,36 +4240,6 @@
     "merging": "در حال ادغام..."
   },
   "landing": {
-    "giftClaim": {
-      "title": "شما یک هدیه دارید!",
-      "error": "فعال‌سازی هدیه ناموفق بود.",
-      "notFoundTitle": "هدیه یافت نشد",
-      "notFoundDesc": "این لینک هدیه نامعتبر یا دیگر در دسترس نیست.",
-      "alreadyTitle": "هدیه قبلاً فعال شده است",
-      "alreadyDesc": "این هدیه قبلاً دریافت شده است.",
-      "successTitle": "هدیه فعال شد!",
-      "connectDesc": "از این لینک برای اتصال استفاده کنید:",
-      "copyLink": "کپی لینک",
-      "pendingTitle": "تقریباً آماده است…",
-      "pendingDesc": "پرداخت در حال تأیید است. این صفحه به‌طور خودکار به‌روزرسانی می‌شود.",
-      "replaceWarning": "شما در حال حاضر اشتراک دارید — فعال‌سازی این هدیه جایگزین آن خواهد شد.",
-      "activateTelegram": "فعال‌سازی در تلگرام",
-      "activateWeb": "فعال‌سازی با ایمیل",
-      "emailLabel": "ایمیل شما",
-      "claimNow": "دریافت هدیه",
-      "failedTitle": "هدیه در دسترس نیست",
-      "failedDesc": "پرداخت این هدیه انجام نشد، بنابراین قابل فعال‌سازی نیست."
-    },
-    "giftLink": {
-      "shareText": "یک هدیه برای شما دارم! اینجا فعال کنید:",
-      "viaTelegram": "تلگرام:",
-      "title": "هدیه آماده است!",
-      "subtitle": "این لینک را برای کسی که می‌خواهید هدیه را دریافت کند بفرستید — خودش آن را فعال می‌کند.",
-      "linkLabel": "لینک هدیه",
-      "telegramLabel": "لینک تلگرام",
-      "alsoSent": "آن را به {{contact}} نیز ایمیل کردیم.",
-      "copyMessage": "کپی پیام"
-    },
     "notFound": "صفحه یافت نشد",
     "forMe": "برای خودم",
     "asGift": "به عنوان هدیه",
@@ -4587,6 +4278,7 @@
     "copy": "کپی",
     "copied": "کپی شد!",
     "copyLink": "کپی لینک",
+    "consent": "من با <privacy>سیاست حفظ حریم خصوصی</privacy>، <offer>شرایط خدمات</offer> و <recurrent>توافق‌نامه پرداخت‌های تکرارشونده</recurrent> موافقم.",
     "giftToggleLabel": "نوع خرید",
     "pollTimedOut": "زمان بیشتری طول کشید",
     "pollTimedOutDesc": "پردازش پرداخت بیشتر از حد معمول طول کشیده است. می‌توانید دوباره بررسی کنید.",
@@ -4627,12 +4319,6 @@
       "d456": "۱ سال و ۳ ماه",
       "nDays": "{{count}} روز",
       "nMonths": "{{count}} ماه"
-    },
-    "discount": {
-      "days": "روز",
-      "hours": "ساعت",
-      "minutes": "دقیقه",
-      "seconds": "ثانیه"
     }
   },
   "gift": {
@@ -4691,43 +4377,7 @@
     },
     "warning": {
       "telegram_unresolvable": "نام کاربری تلگرام قابل تأیید نبود. ممکن است گیرنده اعلان هدیه را دریافت نکند."
-    },
-    "activateButton": "فعال‌سازی",
-    "activateCodePlaceholder": "کد هدیه را وارد کنید",
-    "activatedBy": "توسط {{name}} فعال شد",
-    "activateDescription": "برای فعال‌سازی اشتراک، کد هدیه دریافتی را وارد کنید",
-    "activatedGiftsTitle": "هدایای فعال‌شده",
-    "activateError": "فعال‌سازی هدیه ناموفق بود",
-    "activateSelfError": "نمی‌توانید هدیه خودتان را فعال کنید",
-    "activateSuccess": "هدیه فعال شد!",
-    "activateSuccessDesc": "اشتراک به حساب شما افزوده شد",
-    "activateTitle": "فعال‌سازی هدیه",
-    "activeGiftsTitle": "هدایای فعال",
-    "codeLabel": "کد هدیه",
-    "codeReadyTitle": "کد هدیه شما آماده است",
-    "copyMessage": "کپی پیام",
-    "daysShort": "روز",
-    "deviceCount": "تعداد دستگاه‌ها",
-    "devicesShort": "دستگاه",
-    "gbShort": "گیگابایت",
-    "myGiftsEmpty": "هنوز هدیه‌ای ندارید",
-    "myGiftsEmptyDesc": "هدایایی که ارسال یا دریافت می‌کنید اینجا نمایش داده می‌شوند",
-    "pageTitle": "هدایا",
-    "receivedGiftsTitle": "هدایای دریافت‌شده",
-    "selectPeriod": "دوره را انتخاب کنید",
-    "selectTariff": "تعرفه را انتخاب کنید",
-    "sentTo": "به {{name}} ارسال شد",
-    "shareGift": "به اشتراک گذاشتن هدیه",
-    "shareModalActivateVia": "از طریق فعال‌سازی",
-    "shareModalActivateViaCabinet": "از طریق کابین",
-    "shareText": "برای شما هدیه‌ای از Bedolaga VPN دارم: {{code}}",
-    "shareToastCopied": "لینک کپی شد",
-    "statusActivated": "فعال شده",
-    "statusAvailable": "قابل فعال‌سازی",
-    "tabActivate": "فعال‌سازی",
-    "tabBuy": "خرید",
-    "tabMyGifts": "هدایای من",
-    "unlimitedTraffic": "ترافیک نامحدود"
+    }
   },
   "news": {
     "title": "اخبار و به‌روزرسانی‌ها",
@@ -4788,13 +4438,5 @@
         "linkUrlPrompt": "آدرس پیوند:"
       }
     }
-  },
-  "subscriptions": {
-    "buy": "خرید اشتراک",
-    "buyAnother": "خرید اشتراک دیگر",
-    "browsePlans": "مشاهده تعرفه‌ها و خرید اشتراک",
-    "empty": "هنوز اشتراکی ندارید",
-    "emptyDesc": "برای شروع تعرفه‌ای انتخاب کنید",
-    "title": "اشتراک‌های من"
   }
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -29,16 +29,8 @@
     "understand": "Понятно",
     "units": {
       "gb": "ГБ",
-      "perGb": "/ГБ",
-      "days": "дн",
-      "mo": "мес"
-    },
-    "balance": "Баланс",
-    "copied": "Скопировано",
-    "no_results": "Ничего не найдено",
-    "ok": "ОК",
-    "processing": "Обработка…",
-    "rangeTo": "до"
+      "perGb": "/ГБ"
+    }
   },
   "nav": {
     "dashboard": "Главная",
@@ -53,8 +45,7 @@
     "info": "Информация",
     "wheel": "Колесо удачи",
     "menu": "Меню",
-    "gift": "Подарить",
-    "navigation": "Навигация"
+    "gift": "Подарить"
   },
   "notifications": {
     "ticketNotifications": "Уведомления о тикетах",
@@ -160,17 +151,7 @@
     "tariff": "Тариф",
     "validUntil": "Действует до",
     "goToSubscription": "Перейти к подписке",
-    "goToBalance": "Перейти к балансу",
-    "devicesAdded": "+{{count}} устройств",
-    "devicesPurchased": {
-      "title": "Устройства добавлены"
-    },
-    "totalDevices": "Всего устройств: {{count}}",
-    "totalTraffic": "Всего трафика: {{value}}",
-    "trafficAdded": "+{{value}} трафика",
-    "trafficPurchased": {
-      "title": "Трафик добавлен"
-    }
+    "goToBalance": "Перейти к балансу"
   },
   "auth": {
     "login": "Вход",
@@ -191,7 +172,7 @@
     "registerHint": "Для регистрации по email сначала авторизуйтесь через Telegram, затем привяжите email в настройках.",
     "telegramRequired": "Требуется авторизация через Telegram",
     "telegramRetryFailed": "Авторизация не удалась. Закройте приложение и откройте заново.",
-    "telegramReopenHint": "Если проблема повторяется, закройте и откройте приложение заново",
+    "telegramReopenHint": "Если проблема повторяется — закройте и откройте приложение заново",
     "telegramNotConfigured": "Telegram бот не настроен",
     "telegramUnavailable": "Вход через Telegram временно недоступен",
     "authenticating": "Авторизация...",
@@ -314,7 +295,7 @@
     "trialOffer": {
       "freeTitle": "Бесплатный пробный период",
       "paidTitle": "Пробная подписка",
-      "freeDesc": "Попробуйте наш VPN бесплатно: без обязательств",
+      "freeDesc": "Попробуйте наш VPN бесплатно — без обязательств",
       "paidDesc": "Начните с пробной подписки"
     },
     "stats": {
@@ -322,10 +303,7 @@
       "subscription": "Подписка",
       "referrals": "Рефералы",
       "earnings": "Заработок"
-    },
-    "manageAll": "Управлять всеми",
-    "showAll": "Показать все",
-    "subscriptions": "Подписки"
+    }
   },
   "subscription": {
     "title": "Подписка",
@@ -387,8 +365,7 @@
     "cta": {
       "expiredHint": "Выберите тариф и оплатите",
       "trialHint": "Больше трафика и устройств",
-      "activeHint": "Продление и смена тарифа",
-      "renewHint": "Подписка истекла — продлите, чтобы продолжить пользоваться"
+      "activeHint": "Продление и смена тарифа"
     },
     "connectionInfo": "Данные для подключения",
     "copyLink": "Копировать ссылку",
@@ -505,8 +482,7 @@
       "goToApps": "Перейти к настройке приложений",
       "qrTitle": "QR-код подписки",
       "qrScanHint": "Отсканируйте для подключения",
-      "qrButton": "QR-код",
-      "openQr": "Открыть QR-код"
+      "qrButton": "QR-код"
     },
     "myDevices": "Мои устройства",
     "noDevices": "Нет подключенных устройств",
@@ -608,20 +584,13 @@
       "buyTraffic": "Докупить трафик",
       "currentTrafficLimit": "Текущий лимит: {{limit}} ГБ (использовано {{used}} ГБ)",
       "buyTrafficTitle": "Докупить трафик",
-      "trafficWarning": "Докупленный трафик добавляется к текущему лимиту и действует 30 дней с момента покупки",
+      "trafficWarning": "Докупленный трафик добавляется к текущему лимиту и не переносится на следующий период",
       "trafficUnavailable": "Докупка трафика недоступна для вашего тарифа",
       "unlimited": "Безлимит",
       "buyTrafficGb": "Купить {{gb}} ГБ",
       "buyUnlimited": "Купить Безлимит",
       "manageServers": "Управление сквадами",
-      "manageServersTitle": "Управление сквадами",
-      "connectedDevices": "Подключённые устройства",
-      "currentDeviceLimit": "Текущий лимит устройств",
-      "decrementDevices": "Уменьшить кол-во устройств",
-      "disconnectDevicesFirst": "Сначала отключите лишние устройства",
-      "incrementDevices": "Увеличить кол-во устройств",
-      "minDeviceLimit": "Минимальный лимит устройств",
-      "newDeviceLimit": "Новый лимит устройств"
+      "manageServersTitle": "Управление сквадами"
     },
     "serverManagement": {
       "statusLegend": "✅ — подключено • ➕ — будет добавлено (платно) • ➖ — будет отключено",
@@ -680,27 +649,7 @@
       "stopScan": "Закрыть камеру",
       "noCamera": "Нет доступа к камере",
       "codeFound": "Код найден"
-    },
-    "allTariffsPurchased": "Все тарифы уже куплены",
-    "autopay": "Автопродление",
-    "backToList": "К списку подписок",
-    "confirmDelete": "Удалить подписку?",
-    "dailyAutoCharge": "Ежедневное списание",
-    "defaultName": "Подписка",
-    "delete": "Удалить",
-    "deleteTitle": "Удаление подписки",
-    "get_config": "Получить конфиг",
-    "loadError": "Не удалось загрузить подписку",
-    "newTariff": "Новый тариф",
-    "noOptionsAvailable": "Доступных опций нет",
-    "noRenewalOptions": "Нет вариантов продления",
-    "notFound": "Подписка не найдена",
-    "notFoundDesc": "Возможно, она была удалена или ещё не активирована",
-    "servers": "Серверы",
-    "statusActive": "Активна",
-    "statusExpired": "Истекла",
-    "statusLimited": "Ограничена",
-    "statusTrial": "Триал"
+    }
   },
   "balance": {
     "title": "Баланс",
@@ -818,9 +767,7 @@
         "already_used_by_user": "Вы уже использовали этот промокод",
         "user_not_found": "Пользователь не найден",
         "server_error": "Ошибка сервера"
-      },
-      "daysLeft": "Осталось дней: {{count}}",
-      "selectSubscription": "Выберите подписку"
+      }
     },
     "minAmountError": "Минимальная сумма: {{amount}} ₽",
     "maxAmountError": "Максимальная сумма: {{amount}} ₽",
@@ -880,8 +827,7 @@
       "timeoutDesc": "Обработка платежа занимает больше времени. Вы можете проверить статус ещё раз.",
       "goToBalance": "Перейти к балансу",
       "tryAgain": "Попробовать снова"
-    },
-    "top_up": "Пополнить баланс"
+    }
   },
   "referral": {
     "title": "Реферальная программа",
@@ -1067,8 +1013,7 @@
     "useExternalLink": "Для получения поддержки воспользуйтесь внешней ссылкой",
     "openSupport": "Открыть поддержку",
     "contactSupport": "Для получения поддержки обратитесь к {{username}}",
-    "contactUs": "Связаться с поддержкой",
-    "create_ticket": "Создать тикет"
+    "contactUs": "Связаться с поддержкой"
   },
   "wheel": {
     "title": "Колесо удачи",
@@ -1102,8 +1047,7 @@
       "insufficientBalance": "Недостаточно средств на балансе",
       "topUpRequired": "Пополните баланс для оплаты спина",
       "starsNotAvailable": "Оплата Stars недоступна. Откройте приложение через Telegram.",
-      "noSubscription": "Для вращения колеса необходима активная подписка. Активируйте подписку в разделе «Подписка».",
-      "selectSubscription": "Сначала выберите подписку"
+      "noSubscription": "Для вращения колеса необходима активная подписка. Активируйте подписку в разделе «Подписка»."
     },
     "payWithStars": "Оплатить Stars",
     "payWithDays": "Оплатить днями",
@@ -1122,8 +1066,7 @@
       "title": "Испытай удачу!",
       "description": "Крути колесо и выигрывай призы: дни подписки, баланс, трафик и многое другое!",
       "button": "Перейти к колесу"
-    },
-    "selectSubscription": "Выберите подписку"
+    }
   },
   "admin": {
     "backgrounds": {
@@ -1229,7 +1172,7 @@
       "broadcasts": "Рассылки",
       "users": "Пользователи",
       "payments": "Платежи",
-      "remnawave": "Remnawave",
+      "remnawave": "RemnaWave",
       "emailTemplates": "Email-шаблоны",
       "paymentMethods": "Платёжные методы",
       "campaigns": "Кампании",
@@ -1304,9 +1247,6 @@
       "title": "Статистика продаж",
       "subtitle": "Доход, триалы, подписки и продления",
       "period": {
-        "thisMonth": "Этот месяц",
-        "from": "Начало",
-        "to": "Конец",
         "week": "7 дней",
         "month": "30 дней",
         "quarter": "90 дней",
@@ -1318,15 +1258,13 @@
         "sales": "Продажи",
         "renewals": "Продления",
         "addons": "Доп. услуги",
-        "deposits": "Пополнения",
-        "payment": "Оплаты"
+        "deposits": "Пополнения"
       },
       "summary": {
         "revenue": "Доход",
         "activeSubs": "Активные подписки",
         "activeTrials": "Активные триалы",
         "newTrials": "Новые триалы",
-        "newPaid": "Новые платные подписки",
         "conversion": "Конверсия",
         "renewals": "Продления",
         "addonRevenue": "Доп. услуги",
@@ -1337,13 +1275,13 @@
         "totalRegistrations": "Регистрации",
         "trialsIssued": "Выданные триалы",
         "conversion": "Конверсия",
+        "avgDuration": "Средняя длит.",
         "byProvider": "По источнику регистрации",
         "dailyChart": "Регистрации и триалы по дням",
         "registrations": "Регистрации"
       },
       "sales": {
         "totalSales": "Всего продаж",
-        "totalRevenue": "Оборот по подпискам",
         "avgOrder": "Средний чек",
         "topTariff": "Топ тариф",
         "byTariff": "Продажи по тарифам",
@@ -1382,12 +1320,6 @@
         "dailyChart": "Пополнения по дням",
         "dailyByMethod": "Пополнения по дням по платёжкам",
         "revenue": "Доход"
-      },
-      "payments": {
-        "successRate": "Успешность оплат",
-        "attempts": "Попыток оплат",
-        "failedPurchases": "Неудачные покупки",
-        "byGateway": "Успешность по шлюзам"
       },
       "loadError": "Не удалось загрузить статистику"
     },
@@ -1565,7 +1497,7 @@
       "description": "Поиск и управление платежами",
       "searchPlaceholder": "Поиск: инвойс, TG ID, @username, email...",
       "searchHint": "Примеры: SP-78291, @username, 123456789, user@mail.ru",
-      "searchResults": "Результаты по запросу: {{query}}. Найдено {{count}}",
+      "searchResults": "Результаты по запросу: {{query}} — найдено {{count}}",
       "resetSearch": "Сбросить",
       "statusAll": "Все",
       "statusPending": "В ожидании",
@@ -1611,7 +1543,7 @@
       "methodEnabled": "Метод включён",
       "providerNotConfigured": "Провайдер не настроен в env",
       "openUrlDirect": "Открывать страницу оплаты сразу",
-      "openUrlDirectHint": "Без панели со ссылкой: провайдер открывается внутри MiniApp/вкладки сразу после клика. После оплаты юзер возвращается на /balance/top-up/result. Для Stars/CryptoBot и других t.me/-ссылок флаг игнорируется.",
+      "openUrlDirectHint": "Без панели со ссылкой — провайдер открывается внутри MiniApp/вкладки сразу после клика. После оплаты юзер возвращается на /balance/top-up/result. Для Stars/CryptoBot и других t.me/-ссылок флаг игнорируется.",
       "displayName": "Отображаемое имя",
       "displayNameHint": "Оставьте пустым для имени по умолчанию",
       "subOptions": "Варианты оплаты",
@@ -1634,11 +1566,10 @@
       "firstTopupWas": "Было",
       "firstTopupWasNot": "Не было",
       "cancelButton": "Отмена",
-      "saveButton": "Сохранить",
-      "notFound": "Метод оплаты не найден"
+      "saveButton": "Сохранить"
     },
     "remnawave": {
-      "title": "Remnawave",
+      "title": "RemnaWave",
       "subtitle": "Управление панелью и статистика",
       "connected": "Подключено",
       "disconnected": "Не настроено",
@@ -1656,7 +1587,6 @@
         "totalUpload": "Отдача",
         "totalTraffic": "Всего",
         "online": "онлайн",
-        "realtimeTitle": "Текущий трафик",
         "inbounds": "Inbounds",
         "outbounds": "Outbounds"
       },
@@ -1704,8 +1634,7 @@
           "offline": "Офлайн",
           "disabled": "Отключены",
           "users": "Пользователей"
-        },
-        "usersOnlineCount": "{{count}} онлайн"
+        }
       },
       "squads": {
         "synced": "Синхронизирован",
@@ -1738,9 +1667,7 @@
         "localSettings": "Локальные настройки",
         "trialEligible": "Доступен триал",
         "price": "Цена",
-        "users": "Пользователей",
-        "inboundsCount": "{{count}} входящих",
-        "membersCount": "{{count}} участников"
+        "users": "Пользователей"
       },
       "sync": {
         "autoSync": "Автосинхронизация",
@@ -1756,9 +1683,9 @@
         "success": "Успешно",
         "runAutoSyncNow": "Запустить автосинхронизацию",
         "fromPanel": "Из панели",
-        "fromPanelDesc": "Импорт пользователей из Remnawave в бота",
+        "fromPanelDesc": "Импорт пользователей из RemnaWave в бота",
         "toPanel": "В панель",
-        "toPanelDesc": "Экспорт пользователей из бота в Remnawave"
+        "toPanelDesc": "Экспорт пользователей из бота в RemnaWave"
       }
     },
     "wheel": {
@@ -1782,8 +1709,7 @@
         "dailyLimit": "Дневной лимит вращений (0 = безлимит)",
         "minSubDays": "Мин. дней подписки для оплаты днями",
         "promocodes": "Промокоды",
-        "promoPrefix": "Префикс промокодов",
-        "promoValidityDays": "Срок действия промокода (дней)"
+        "promoPrefix": "Префикс промокодов"
       },
       "starsNotEnabledGlobally": "Оплата звёздами не включена в платёжных методах. Включите метод «Telegram Stars» в разделе «Платёжные методы».",
       "prizes": {
@@ -1810,9 +1736,7 @@
           "emoji": "Эмодзи",
           "color": "Цвет",
           "active": "Активен",
-          "worth": "Стоимость",
-          "probability": "Ручная вероятность (0–1)",
-          "probabilityHint": "Пусто — авто по RTP"
+          "worth": "Стоимость"
         },
         "promo": {
           "title": "Настройки промокода",
@@ -1831,9 +1755,7 @@
         "times_one": "{{count}} раз",
         "times_few": "{{count}} раза",
         "times_many": "{{count}} раз",
-        "topWins": "Топ выигрышей",
-        "loadError": "Не удалось загрузить статистику",
-        "empty": "Пока нет вращений"
+        "topWins": "Топ выигрышей"
       }
     },
     "broadcasts": {
@@ -1924,12 +1846,7 @@
       "btnConnect": "Подключиться",
       "btnSubscription": "Подписка",
       "btnSupport": "Техподдержка",
-      "btnHome": "На главную",
-      "category": "Категория",
-      "categoryNews": "Новости",
-      "categoryPromo": "Промо",
-      "categorySystem": "Системные",
-      "stopping": "Останавливается…"
+      "btnHome": "На главную"
     },
     "pinnedMessages": {
       "title": "Закреплённые сообщения",
@@ -2162,7 +2079,7 @@
         "db_sqlite": "SQLite",
         "db_redis": "Redis",
         "sys_core": "Ядро и отладка",
-        "sys_remnawave": "Remnawave",
+        "sys_remnawave": "RemnaWave",
         "sys_webapi": "Web API",
         "sys_webhook": "Webhook",
         "sys_server": "Статус сервера",
@@ -2372,8 +2289,8 @@
         "Api Key": "API ключ",
         "Api Token": "API токен",
         "Webhook Secret": "Секрет вебхука",
-        "Remnawave Url": "URL Remnawave",
-        "Remnawave Token": "Токен Remnawave",
+        "Remnawave Url": "URL RemnaWave",
+        "Remnawave Token": "Токен RemnaWave",
         "Server Status Enabled": "Статус сервера",
         "Monitoring Enabled": "Мониторинг",
         "Backup Enabled": "Бэкап",
@@ -2663,7 +2580,7 @@
         "SQLITE": "SQLite",
         "REDIS": "Redis",
         "CORE": "Бот",
-        "REMNAWAVE": "Remnawave",
+        "REMNAWAVE": "RemnaWave",
         "SERVER_STATUS": "Статус сервера",
         "MONITORING": "Мониторинг",
         "MAINTENANCE": "Обслуживание",
@@ -2782,16 +2699,13 @@
       "importError": "Неверный формат JSON файла",
       "importCreateError": "Ошибка при создании приложений",
       "noAppsToImport": "Нет приложений для импорта",
-      "remnaWaveToggle": "Переключить источник Remnawave",
-      "refreshRemnaWave": "Обновить данные из Remnawave",
-      "remnaWaveMode": "Отображаются приложения из панели Remnawave. Режим только для чтения.",
-      "remnaWaveSettings": "Настройки Remnawave",
+      "remnaWaveToggle": "Переключить источник RemnaWave",
+      "refreshRemnaWave": "Обновить данные из RemnaWave",
+      "remnaWaveMode": "Отображаются приложения из панели RemnaWave. Режим только для чтения.",
+      "remnaWaveSettings": "Настройки RemnaWave",
       "remnaWaveConfigUuid": "UUID конфигурации",
-      "remnaWaveConfigUuidHint": "UUID конфигурации страницы подписки из панели Remnawave",
-      "availableConfigs": "Доступные конфигурации",
-      "noConfigs": "Нет настроенных конфигов",
-      "remnaWaveConnected": "Remnawave подключён",
-      "remnaWaveDisconnected": "Remnawave отключён"
+      "remnaWaveConfigUuidHint": "UUID конфигурации страницы подписки из панели RemnaWave",
+      "availableConfigs": "Доступные конфигурации"
     },
     "tickets": {
       "title": "Управление тикетами",
@@ -2842,13 +2756,7 @@
       "userNotificationsEnabled": "Уведомления для пользователей",
       "userNotificationsEnabledDesc": "Отправлять уведомления пользователям об ответах админа",
       "adminNotificationsEnabled": "Уведомления для админов",
-      "adminNotificationsEnabledDesc": "Отправлять уведомления админам о новых тикетах и ответах",
-      "replyFailed": "Не удалось отправить ответ",
-      "validation": {
-        "checkIntervalRange": "Интервал проверки должен быть от 1 до 1440 мин",
-        "reminderCooldownRange": "Кулдаун напоминания должен быть от 0 до 1440 мин",
-        "slaMinutesRange": "SLA должен быть от 1 до 10080 мин"
-      }
+      "adminNotificationsEnabledDesc": "Отправлять уведомления админам о новых тикетах и ответах"
     },
     "tariffs": {
       "title": "Управление тарифами",
@@ -2888,7 +2796,7 @@
       "confirmDeleteText": "Это действие нельзя отменить. Тариф будет удалён навсегда.",
       "confirmDeleteWithSubscriptions": "У этого тарифа {{count}} активных подписок. При удалении пользователям потребуется выбрать новый тариф при продлении.",
       "deleteSuccess": "Тариф успешно удален",
-      "deleteSuccessWithSubscriptions": "Тариф удален. У {{count}} подписок сброшен тариф. При продлении пользователи выберут новый.",
+      "deleteSuccessWithSubscriptions": "Тариф удален. У {{count}} подписок сброшен тариф — при продлении пользователи выберут новый.",
       "saveOrder": "Сохранить порядок",
       "orderSaved": "Порядок сохранён",
       "dragToReorder": "Перетащите для изменения порядка",
@@ -2943,13 +2851,13 @@
       "daysShort": "дн.",
       "serversTitle": "Серверы",
       "externalSquadTitle": "Внешний сквад",
-      "externalSquadHint": "Назначьте внешний сквад Remnawave для пользователей этого тарифа. При создании подписки пользователь будет автоматически добавлен в выбранный сквад.",
+      "externalSquadHint": "Назначьте внешний сквад RemnaWave для пользователей этого тарифа. При создании подписки пользователь будет автоматически добавлен в выбранный сквад.",
       "noExternalSquad": "Без внешнего сквада",
       "externalSquadUsers": "пользователей",
       "serversTabHint": "Выберите серверы, доступные на этом тарифе.",
       "noServersAvailable": "Нет доступных серверов",
       "promoGroupsTitle": "Промо-группы",
-      "promoGroupsHint": "Выберите промо-группы, которым доступен этот тариф. Если не выбрано ничего, доступен всем.",
+      "promoGroupsHint": "Выберите промо-группы, которым доступен этот тариф. Если не выбрано ничего — доступен всем.",
       "noPromoGroups": "Нет промо-групп",
       "extraDeviceTitle": "Докупка устройств",
       "devicePriceLabel": "Цена за устройство (30 дней):",
@@ -3022,7 +2930,7 @@
       "sync": "Синхронизировать",
       "syncing": "Синхронизация...",
       "syncNow": "Синхронизировать сейчас",
-      "noServers": "Нет серверов. Синхронизируйте с Remnawave.",
+      "noServers": "Нет серверов. Синхронизируйте с RemnaWave.",
       "edit": "Редактировать сервер",
       "originalName": "Оригинальное название",
       "displayName": "Отображаемое название",
@@ -3079,8 +2987,7 @@
         "deactivate": "Деактивировать",
         "activate": "Активировать",
         "edit": "Редактировать",
-        "delete": "Удалить",
-        "registrations": "Регистрации"
+        "delete": "Удалить"
       },
       "modal": {
         "editTitle": "Редактирование кампании",
@@ -3152,9 +3059,7 @@
         "totalSpending": "Расход на подписки",
         "periodComparison": "Сравнение периодов",
         "vsLastWeek": "vs прошлая неделя",
-        "topRegistrations": "Топ регистрации",
-        "subscriptionsIssued": "Выдано подписок",
-        "tariffsIssued": "Выдано тарифов"
+        "topRegistrations": "Топ регистрации"
       },
       "users": {
         "title": "Пользователи кампании",
@@ -3178,10 +3083,7 @@
         "delete": "Удалить"
       },
       "loadError": "Не удалось загрузить кампанию",
-      "updateError": "Не удалось сохранить изменения",
-      "validation": {
-        "nameRequired": "Название обязательно"
-      }
+      "updateError": "Не удалось сохранить изменения"
     },
     "withdrawals": {
       "title": "Выводы средств",
@@ -3352,10 +3254,7 @@
         "createTitle": "Создать кампанию",
         "createSubtitle": "Кампания будет автоматически привязана к партнёру",
         "autoAssignNote": "Кампания будет автоматически привязана к партнёру {{name}}",
-        "createAndAssign": "Создать и привязать",
-        "earnings": "Доход",
-        "referrals": "Рефералы",
-        "registrations": "Регистрации"
+        "createAndAssign": "Создать и привязать"
       },
       "dangerZone": {
         "title": "Опасная зона",
@@ -3432,10 +3331,7 @@
         "firstPurchaseOnly": "Только для первой покупки",
         "cancel": "Отмена",
         "saving": "Сохранение...",
-        "save": "Сохранить",
-        "defaultTrialTariff": "Тариф триала по умолчанию",
-        "selectTariff": "Выберите тариф",
-        "tariff": "Тариф"
+        "save": "Сохранить"
       },
       "stats": {
         "title": "Статистика промокода",
@@ -3466,8 +3362,7 @@
         "totalPromocodes": "Всего промокодов",
         "activeCount": "Активных",
         "usagesCount": "Использований",
-        "exhausted": "Исчерпано",
-        "hoursValue": "{{count}} ч"
+        "exhausted": "Исчерпано"
       },
       "actions": {
         "stats": "Статистика",
@@ -3759,9 +3654,7 @@
           "expired": "истёк",
           "daysLeft": "дн. осталось",
           "deviceLimitUpdated": "Лимит устройств обновлён",
-          "invalidDays": "Введите корректное количество дней (больше 0)",
-          "backToList": "К списку подписок",
-          "createNew": "Создать новую"
+          "invalidDays": "Введите корректное количество дней (больше 0)"
         },
         "balance": {
           "current": "Текущий баланс",
@@ -3845,9 +3738,7 @@
           "alreadyReferred": "уже чей-то реферал",
           "noUsersFound": "Пользователи не найдены"
         }
-      },
-      "notFound": "Пользователь не найден",
-      "purchaseCount": "Покупок: {{count}}"
+      }
     },
     "promoOffers": {
       "title": "Промопредложения",
@@ -3857,8 +3748,7 @@
         "templates_one": "Шаблоны ({{count}} шаблон)",
         "templates_few": "Шаблоны ({{count}} шаблона)",
         "templates_many": "Шаблоны ({{count}} шаблонов)",
-        "logs": "Логи",
-        "templates": "Шаблоны"
+        "logs": "Логи"
       },
       "noData": {
         "templates": "Нет шаблонов",
@@ -3888,9 +3778,7 @@
         "activeDiscountHours": "Действие скидки (часы)",
         "discountDurationHint": "Сколько действует скидка после активации",
         "templateActive": "Шаблон активен",
-        "saving": "Сохранение...",
-        "noServers": "Нет серверов",
-        "testSquads": "Тестовые сквады"
+        "saving": "Сохранение..."
       },
       "send": {
         "title": "Отправка промопредложения",
@@ -3919,10 +3807,7 @@
         "notificationsFailed_one": "(не доставлено: {{count}})",
         "notificationsFailed_few": "(не доставлено: {{count}})",
         "notificationsFailed_many": "(не доставлено: {{count}})",
-        "sendError": "Не удалось отправить предложение",
-        "notificationsSent": "Отправлено уведомлений",
-        "offersCreated": "Создано офферов",
-        "notificationsFailed": "(не отправлено: {{count}})"
+        "sendError": "Не удалось отправить предложение"
       },
       "notFound": "Шаблон не найден",
       "noActiveTemplates": "Нет активных шаблонов",
@@ -3993,15 +3878,15 @@
         "deleteUser": "Удалить пользователей"
       },
       "deleteSubscription": {
-        "warning": "Выбранные подписки будут безвозвратно удалены из бота и панели Remnawave!",
+        "warning": "Выбранные подписки будут безвозвратно удалены из бота и панели RemnaWave!",
         "hint": "Пользователи потеряют доступ к VPN по удалённым подпискам. Это действие нельзя отменить.",
-        "activePaidWarning": "{{count}} из {{total}} выбранных подписок: активные платные",
+        "activePaidWarning": "{{count}} из {{total}} выбранных подписок — активные платные",
         "forceDeleteConfirm": "Подтверждаю удаление активных платных подписок"
       },
       "deleteUser": {
         "warning": "Выбранные пользователи будут безвозвратно удалены из бота! Все их подписки, баланс и данные будут потеряны!",
         "hint": "Это действие нельзя отменить. Пользователям придётся заново запустить бота для создания нового аккаунта.",
-        "deleteFromPanel": "Также удалить из панели Remnawave"
+        "deleteFromPanel": "Также удалить из панели RemnaWave"
       },
       "params": {
         "days": "Количество дней",
@@ -4032,7 +3917,7 @@
         "summaryErrors": "{{count}} ошибок"
       },
       "errors": {
-        "title": "{{count}} ошибок. Показать детали"
+        "title": "{{count}} ошибок — показать детали"
       },
       "filters": {
         "search": "Поиск по ID, нику, email",
@@ -4188,8 +4073,7 @@
         "selectedPermissions_many": "{{count}} разрешений выбрано",
         "cancel": "Отмена",
         "saving": "Сохранение...",
-        "save": "Сохранить",
-        "selectedPermissions": "Выбрано прав"
+        "save": "Сохранить"
       },
       "presets": {
         "moderator": "Модератор",
@@ -4209,9 +4093,7 @@
         "updateFailed": "Не удалось обновить роль",
         "nameRequired": "Укажите название роли",
         "deleteFailed": "Не удалось удалить роль"
-      },
-      "permissionsCount": "{{count}} прав",
-      "usersCount": "{{count}} пользователей"
+      }
     },
     "roleAssign": {
       "title": "Назначение ролей",
@@ -4265,8 +4147,7 @@
         "roleRequired": "Выберите роль",
         "assignFailed": "Не удалось назначить роль",
         "revokeFailed": "Не удалось отозвать роль"
-      },
-      "totalAssignments": "Всего назначений: {{count}}"
+      }
     },
     "policies": {
       "title": "Политики доступа",
@@ -4335,8 +4216,7 @@
         "day3": "Ср",
         "day4": "Чт",
         "day5": "Пт",
-        "day6": "Сб",
-        "ipCount": "Кол-во IP"
+        "day6": "Сб"
       },
       "confirm": {
         "title": "Удалить политику?",
@@ -4426,10 +4306,7 @@
         "hoursAgo_many": "{{count}} ч назад",
         "daysAgo_one": "{{count}} день назад",
         "daysAgo_few": "{{count}} дня назад",
-        "daysAgo_many": "{{count}} дней назад",
-        "daysAgo": "{{count}} дн назад",
-        "hoursAgo": "{{count}} ч назад",
-        "minutesAgo": "{{count}} мин назад"
+        "daysAgo_many": "{{count}} дней назад"
       },
       "pagination": {
         "pageSize": "На странице:",
@@ -4442,8 +4319,7 @@
       "errors": {
         "loadFailed": "Не удалось загрузить журнал аудита",
         "retry": "Попробовать снова"
-      },
-      "totalEntries": "Всего записей: {{count}}"
+      }
     },
     "landings": {
       "title": "Лендинги",
@@ -4528,12 +4404,6 @@
         "dailyChart": "Покупки и доход по дням",
         "tariffChart": "Распределение по тарифам",
         "giftBreakdown": "Подарки vs обычные",
-        "funnelTitle": "Воронка конверсии",
-        "giftClaimTitle": "Активация подарков",
-        "giftClaimLabel": "забрано / отправлено",
-        "dailyRevenue": "Выручка по дням",
-        "byPaymentMethod": "По способам оплаты",
-        "bySource": "Источники трафика",
         "purchases": "Покупки",
         "revenueLabel": "Доход",
         "gifts": "Подарки",
@@ -4543,8 +4413,7 @@
         "funnel": "Воронка",
         "loadError": "Не удалось загрузить статистику",
         "noPurchases": "Нет покупок",
-        "paid": "оплачено",
-        "dailyPurchases": "Покупок в день"
+        "paid": "оплачено"
       },
       "purchases": {
         "title": "Покупки",
@@ -4570,16 +4439,7 @@
         "page": "Стр. {{current}} из {{total}}",
         "prev": "Назад",
         "next": "Далее"
-      },
-      "methodCurrency": "Валюта",
-      "methodDescPlaceholder": "Краткое описание метода для пользователя",
-      "methodDescription": "Описание метода",
-      "methodDisplayName": "Отображаемое имя",
-      "methodIconUrl": "URL иконки",
-      "methodMaxAmount": "Максимальная сумма",
-      "methodMinAmount": "Минимальная сумма",
-      "methodReturnUrl": "URL возврата",
-      "stickyPayButton": "Закреплённая кнопка оплаты"
+      }
     },
     "infoPages": {
       "title": "Информационные страницы",
@@ -4692,8 +4552,7 @@
       "hide": "Скрыть ({{count}})",
       "showMore_one": "Показать еще {{count}} ноду",
       "showMore_few": "Показать еще {{count}} ноды",
-      "showMore_many": "Показать еще {{count}} нод",
-      "showMore": "Показать ещё"
+      "showMore_many": "Показать еще {{count}} нод"
     },
     "revenue": {
       "title": "Доходы",
@@ -4738,8 +4597,7 @@
       "byEarnings": "По доходу",
       "byInvited": "По пригл.",
       "invites": "пригл.",
-      "people": "чел.",
-      "stats": "реф., {{count}} приглашений"
+      "people": "чел."
     },
     "period": {
       "today": "Сегодня",
@@ -4751,8 +4609,7 @@
       "stats_one": "камп., {{count}} рег.",
       "stats_few": "камп., {{count}} рег.",
       "stats_many": "камп., {{count}} рег.",
-      "total": "Всего от РК",
-      "stats": "кампания, {{count}} регистр."
+      "total": "Всего от РК"
     },
     "recentPayments": {
       "title": "Последние платежи",
@@ -5149,15 +5006,8 @@
         "yandex": "Яндекс",
         "discord": "Discord",
         "vk": "VK"
-      },
-      "backToAccounts": "К списку аккаунтов"
-    },
-    "emailMergePasswordRequired": "Этот email уже привязан к другому аккаунту. Чтобы объединить аккаунты, введите пароль от него.",
-    "emailMergeCodeSent": "Код подтверждения отправлен на тот email.",
-    "emailMergeCodeDescription": "Этот email уже привязан к другому аккаунту. Мы отправили на него код — введите его, чтобы подтвердить владение и объединить аккаунты.",
-    "emailMergeCodeLabel": "Код из письма",
-    "emailMergeConfirm": "Подтвердить и объединить",
-    "emailMergeCodeInvalid": "Неверный или просроченный код"
+      }
+    }
   },
   "theme": {
     "colors": "Цвета темы",
@@ -5313,8 +5163,7 @@
       "warning": "Отменённый промокод нельзя будет использовать повторно. Скидка перестанет действовать немедленно.",
       "confirm": "Отменить",
       "deactivating": "Отмена...",
-      "error": "Не удалось отменить промокод. Попробуйте позже.",
-      "success": "Акция отключена"
+      "error": "Не удалось отменить промокод. Попробуйте позже."
     }
   },
   "telegramRedirect": {
@@ -5376,14 +5225,6 @@
       "openBot": "Открыть бота",
       "retry": "Я нажал /start, попробовать снова",
       "hint": "После /start вернитесь сюда и нажмите «Попробовать снова»."
-    },
-    "serviceUnavailable": {
-      "title": "Сервис недоступен",
-      "description": "Не удаётся подключиться к сервису. Возможно, идут технические работы или временные неполадки со связью.",
-      "retry": "Повторить попытку",
-      "checking": "Проверяем соединение...",
-      "hint": "Страница обновится автоматически, как только сервис снова станет доступен.",
-      "close": "Закрыть"
     }
   },
   "merge": {
@@ -5414,36 +5255,6 @@
     "merging": "Объединение..."
   },
   "landing": {
-    "giftClaim": {
-      "title": "Вам подарок!",
-      "error": "Не удалось активировать подарок.",
-      "notFoundTitle": "Подарок не найден",
-      "notFoundDesc": "Ссылка на подарок недействительна или больше недоступна.",
-      "alreadyTitle": "Подарок уже активирован",
-      "alreadyDesc": "Этот подарок уже забрали.",
-      "successTitle": "Подарок активирован!",
-      "connectDesc": "Используйте эту ссылку для подключения:",
-      "copyLink": "Скопировать ссылку",
-      "pendingTitle": "Почти готово…",
-      "pendingDesc": "Оплата ещё подтверждается. Страница обновится автоматически.",
-      "replaceWarning": "У вас уже есть подписка — активация подарка заменит её.",
-      "activateTelegram": "Активировать в Telegram",
-      "activateWeb": "Активировать по почте",
-      "emailLabel": "Ваш email",
-      "claimNow": "Получить подарок",
-      "failedTitle": "Подарок недоступен",
-      "failedDesc": "Оплата подарка не прошла, поэтому активировать его нельзя."
-    },
-    "giftLink": {
-      "shareText": "Дарю вам подписку! Активируйте здесь:",
-      "viaTelegram": "Telegram:",
-      "title": "Подарок готов!",
-      "subtitle": "Отправьте эту ссылку тому, кому предназначен подарок — он активирует его сам.",
-      "linkLabel": "Ссылка на подарок",
-      "telegramLabel": "Ссылка для Telegram",
-      "alsoSent": "Мы также отправили её на {{contact}}.",
-      "copyMessage": "Скопировать сообщение"
-    },
     "notFound": "Страница не найдена",
     "forMe": "Для себя",
     "asGift": "В подарок",
@@ -5482,6 +5293,7 @@
     "copy": "Скопировать",
     "copied": "Скопировано!",
     "copyLink": "Скопировать ссылку",
+    "consent": "Я согласен с <privacy>политикой обработки данных</privacy>, <offer>договором оферты</offer> и <recurrent>соглашением о рекуррентных платежах</recurrent>.",
     "giftToggleLabel": "Тип покупки",
     "pollTimedOut": "Занимает больше времени, чем ожидалось",
     "pollTimedOutDesc": "Обработка платежа занимает больше времени, чем обычно. Вы можете попробовать проверить ещё раз.",
@@ -5531,9 +5343,7 @@
       "nDays_many": "{{count}} дней",
       "nMonths_one": "{{count}} месяц",
       "nMonths_few": "{{count}} месяца",
-      "nMonths_many": "{{count}} месяцев",
-      "nDays": "{{count}} дн",
-      "nMonths": "{{count}} мес"
+      "nMonths_many": "{{count}} месяцев"
     }
   },
   "gift": {
@@ -5609,7 +5419,7 @@
     "activateButton": "Активировать подарок",
     "activating": "Активация...",
     "activateSuccess": "Подарок активирован!",
-    "activateSuccessDesc": "{{tariff}}: {{days}} дн. добавлено к вашей подписке",
+    "activateSuccessDesc": "{{tariff}} — {{days}} дн. добавлено к вашей подписке",
     "activateError": "Не удалось активировать подарок",
     "activateSelfError": "Нельзя активировать свой собственный подарок",
     "myGiftsEmpty": "У вас пока нет подарков",
@@ -5716,13 +5526,5 @@
         "linkUrlPrompt": "URL ссылки:"
       }
     }
-  },
-  "subscriptions": {
-    "buy": "Купить подписку",
-    "buyAnother": "Купить ещё подписку",
-    "browsePlans": "Посмотреть тарифы и купить подписку",
-    "empty": "У вас пока нет подписок",
-    "emptyDesc": "Выберите тариф, чтобы начать пользоваться сервисом",
-    "title": "Мои подписки"
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -29,16 +29,8 @@
     "collapse": "收起",
     "units": {
       "gb": "GB",
-      "perGb": "/GB",
-      "days": "天",
-      "mo": "月"
-    },
-    "balance": "余额",
-    "copied": "已复制",
-    "no_results": "无结果",
-    "ok": "确定",
-    "processing": "处理中…",
-    "rangeTo": "至"
+      "perGb": "/GB"
+    }
   },
   "nav": {
     "dashboard": "首页",
@@ -53,8 +45,7 @@
     "info": "信息",
     "wheel": "幸运转盘",
     "menu": "菜单",
-    "gift": "赠送",
-    "navigation": "导航"
+    "gift": "赠送"
   },
   "notifications": {
     "ticketNotifications": "工单通知",
@@ -151,17 +142,7 @@
     "tariff": "套餐",
     "validUntil": "有效期至",
     "goToSubscription": "查看订阅",
-    "goToBalance": "查看余额",
-    "devicesAdded": "+{{count}} 设备",
-    "devicesPurchased": {
-      "title": "设备已添加"
-    },
-    "totalDevices": "总设备数：{{count}}",
-    "totalTraffic": "总流量：{{value}}",
-    "trafficAdded": "+{{value}} 流量",
-    "trafficPurchased": {
-      "title": "流量已添加"
-    }
+    "goToBalance": "查看余额"
   },
   "auth": {
     "login": "登录",
@@ -262,38 +243,13 @@
       "tariffs": "套餐",
       "traffic": "流量",
       "devices": "设备",
-      "expiredDate": "过期时间",
-      "activeUntil": "已过期 — 至 {{date}}"
+      "expiredDate": "过期时间"
     },
     "deviceLimitReached": "断开设备以添加新设备",
     "suspended": {
       "title": "订阅已暂停",
       "resume": "恢复"
-    },
-    "manageAll": "全部管理",
-    "showAll": "全部显示",
-    "subscriptions": "订阅",
-    "connectDevice": "连接设备",
-    "devicesConnectedUnlimited": "已连接 {{count}} 台设备",
-    "devicesOfMax": "{{used}} / {{max}}",
-    "maxUsage": "最大",
-    "remaining": "剩余",
-    "stats": {
-      "balance": "余额",
-      "referrals": "推荐人"
-    },
-    "tariff": "套餐",
-    "trafficUsageTitle": "流量使用",
-    "trialOffer": {
-      "freeDesc": "免费试用 {{days}} 天 — 无需付款",
-      "freeTitle": "免费试用",
-      "paidDesc": "{{days}} 天试用，仅需 {{price}}",
-      "paidTitle": "付费试用"
-    },
-    "unlimited": "无限",
-    "usageLast14Days": "近 14 天使用情况",
-    "usedSuffix": "已用",
-    "validUntil": "有效期至 {{date}}"
+    }
   },
   "subscription": {
     "title": "订阅",
@@ -383,10 +339,7 @@
       "devices_other": "{{count}} 个设备",
       "price": "激活费用",
       "activate": "激活免费试用",
-      "unavailable": "试用不可用",
-      "insufficientBalance": "余额不足以激活试用",
-      "payAndActivate": "付费并激活",
-      "topUpToActivate": "充值以激活试用"
+      "unavailable": "试用不可用"
     },
     "connection": {
       "title": "连接VPN",
@@ -415,8 +368,7 @@
       "goToApps": "前往应用设置",
       "qrTitle": "订阅二维码",
       "qrScanHint": "使用相机扫描以连接",
-      "qrButton": "二维码",
-      "openQr": "打开二维码"
+      "qrButton": "二维码"
     },
     "additionalOptions": {
       "title": "附加选项",
@@ -429,26 +381,13 @@
       "buyTraffic": "购买更多流量",
       "currentTrafficLimit": "当前限制：{{limit}} GB（已使用 {{used}} GB）",
       "buyTrafficTitle": "购买更多流量",
-      "trafficWarning": "购买的流量将添加到当前限制，自购买之日起30天内有效",
+      "trafficWarning": "购买的流量将添加到当前限制，不会延续到下一个周期",
       "trafficUnavailable": "您的套餐不支持购买流量",
       "unlimited": "无限制",
       "buyTrafficGb": "购买 {{gb}} GB",
       "buyUnlimited": "购买无限流量",
       "manageServers": "小队管理",
-      "manageServersTitle": "小队管理",
-      "connectedDevices": "已连接设备",
-      "currentDeviceLimit": "当前设备限制",
-      "decrementDevices": "减少设备数量",
-      "disconnectDevicesFirst": "请先断开多余的设备",
-      "incrementDevices": "增加设备数量",
-      "minDeviceLimit": "最低设备限制",
-      "newDeviceLimit": "新设备限制",
-      "reduce": "减少",
-      "reduceDevices": "减少设备数量",
-      "reduceDevicesDescription": "调整您的设备限制。如有需要，请先断开多余设备的连接",
-      "reduceDevicesTitle": "减少设备数量",
-      "reduceUnavailable": "当前无法减少设备数量",
-      "reducing": "正在减少…"
+      "manageServersTitle": "小队管理"
     },
     "serverManagement": {
       "statusLegend": "✅ — 已连接 • ➕ — 将添加（付费）• ➖ — 将断开",
@@ -560,46 +499,6 @@
       "stopScan": "关闭摄像头",
       "noCamera": "无法访问摄像头",
       "codeFound": "找到代码"
-    },
-    "allTariffsPurchased": "所有套餐已购买",
-    "autopay": "自动续订",
-    "backToList": "返回订阅列表",
-    "confirmDelete": "删除订阅？",
-    "cta": {
-      "renewHint": "订阅已过期 — 续订以继续使用",
-      "activeHint": "订阅有效 — 您可以连接设备并使用 VPN",
-      "expiredHint": "订阅已过期 — 续订以继续使用",
-      "trialHint": "您正在试用中 — 升级到付费套餐以解锁所有功能"
-    },
-    "dailyAutoCharge": "每日自动扣费",
-    "defaultName": "订阅",
-    "delete": "删除",
-    "deleteTitle": "删除订阅",
-    "get_config": "获取配置",
-    "loadError": "加载订阅失败",
-    "newTariff": "新套餐",
-    "noOptionsAvailable": "暂无可用选项",
-    "noRenewalOptions": "无续订选项",
-    "notFound": "未找到订阅",
-    "notFoundDesc": "可能已被删除或尚未激活",
-    "servers": "服务器",
-    "statusActive": "已激活",
-    "statusExpired": "已过期",
-    "statusLimited": "受限",
-    "statusTrial": "试用",
-    "daysShort": "天",
-    "expiredBanner": {
-      "selectTariff": "选择套餐",
-      "title": "订阅已过期"
-    },
-    "trialInfo": {
-      "description": "免费试用我们的服务 {{days}} 天",
-      "remaining": "剩余 {{count}} 天",
-      "title": "试用期"
-    },
-    "trialUpgrade": {
-      "description": "升级到付费订阅以解锁所有功能并继续使用",
-      "title": "升级订阅"
     }
   },
   "balance": {
@@ -676,9 +575,7 @@
         "already_used_by_user": "您已使用过此优惠码",
         "user_not_found": "用户不存在",
         "server_error": "服务器错误"
-      },
-      "daysLeft": "剩余天数：{{count}}",
-      "selectSubscription": "选择订阅"
+      }
     },
     "minAmountError": "最小金额：{{amount}}",
     "maxAmountError": "最大金额：{{amount}}",
@@ -736,8 +633,7 @@
       "timeoutDesc": "付款处理时间比平时长。您可以再次检查状态。",
       "goToBalance": "查看余额",
       "tryAgain": "重试"
-    },
-    "top_up": "充值"
+    }
   },
   "referral": {
     "title": "推荐计划",
@@ -921,8 +817,7 @@
     "contactUs": "联系支持",
     "openSupport": "打开支持",
     "ticketsDisabled": "工单已禁用",
-    "useExternalLink": "请使用外部链接获取支持",
-    "create_ticket": "创建工单"
+    "useExternalLink": "请使用外部链接获取支持"
   },
   "wheel": {
     "title": "幸运转盘",
@@ -958,8 +853,7 @@
       "insufficientBalance": "余额不足",
       "topUpRequired": "请充值以支付抽奖费用",
       "starsNotAvailable": "Stars支付不可用。请通过Telegram打开应用。",
-      "noSubscription": "需要有效订阅才能转动轮盘。请先激活订阅。",
-      "selectSubscription": "请先选择订阅"
+      "noSubscription": "需要有效订阅才能转动轮盘。请先激活订阅。"
     },
     "payWithStars": "支付 {stars} Stars",
     "processingPayment": "处理中...",
@@ -974,8 +868,7 @@
       "title": "试试运气！",
       "description": "转动转盘赢取奖品：订阅天数、余额、流量等！",
       "button": "前往转盘"
-    },
-    "selectSubscription": "选择订阅"
+    }
   },
   "admin": {
     "backgrounds": {
@@ -1086,7 +979,7 @@
       "promoOffers": "促销优惠",
       "promocodes": "促销码",
       "promoGroups": "折扣组",
-      "remnawave": "Remnawave",
+      "remnawave": "RemnaWave",
       "users": "用户",
       "trafficUsage": "流量使用",
       "updates": "更新",
@@ -1155,9 +1048,6 @@
       "title": "销售统计",
       "subtitle": "收入、试用、订阅和续订",
       "period": {
-        "thisMonth": "本月",
-        "from": "从",
-        "to": "到",
         "week": "7天",
         "month": "30天",
         "quarter": "90天",
@@ -1169,15 +1059,13 @@
         "sales": "销售",
         "renewals": "续订",
         "addons": "附加服务",
-        "deposits": "充值",
-        "payment": "支付"
+        "deposits": "充值"
       },
       "summary": {
         "revenue": "收入",
         "activeSubs": "活跃订阅",
         "activeTrials": "活跃试用",
         "newTrials": "新试用",
-        "newPaid": "新增付费订阅",
         "conversion": "转化率",
         "renewals": "续订",
         "addonRevenue": "附加服务收入",
@@ -1188,13 +1076,13 @@
         "totalRegistrations": "注册数",
         "trialsIssued": "已发放试用",
         "conversion": "转化率",
+        "avgDuration": "平均时长",
         "byProvider": "按注册来源",
         "dailyChart": "每日注册与试用",
         "registrations": "注册"
       },
       "sales": {
         "totalSales": "总销售",
-        "totalRevenue": "订阅流水",
         "avgOrder": "平均订单",
         "topTariff": "热门套餐",
         "byTariff": "按套餐",
@@ -1233,12 +1121,6 @@
         "dailyChart": "每日充值",
         "dailyByMethod": "每日按支付方式充值",
         "revenue": "收入"
-      },
-      "payments": {
-        "successRate": "支付成功率",
-        "attempts": "支付尝试",
-        "failedPurchases": "失败购买",
-        "byGateway": "各网关成功率"
       },
       "loadError": "加载统计失败"
     },
@@ -1404,7 +1286,7 @@
       "methodEnabled": "方法已启用",
       "providerNotConfigured": "提供商未在env中配置",
       "openUrlDirect": "直接打开支付页面",
-      "openUrlDirectHint": "跳过链接面板:点击后提供商在 MiniApp/标签页内直接打开。支付完成后用户返回 /balance/top-up/result。Stars/CryptoBot 和其他 t.me/ 链接忽略此标志。",
+      "openUrlDirectHint": "跳过链接面板 — 点击后提供商在 MiniApp/标签页内直接打开。支付完成后用户返回 /balance/top-up/result。Stars/CryptoBot 和其他 t.me/ 链接忽略此标志。",
       "displayName": "显示名称",
       "displayNameHint": "留空以使用默认名称",
       "subOptions": "支付选项",
@@ -1427,8 +1309,7 @@
       "promoGroupsShort": "组",
       "noPromoGroups": "没有促销组",
       "cancelButton": "取消",
-      "saveButton": "保存",
-      "notFound": "未找到支付方式"
+      "saveButton": "保存"
     },
     "emailTemplates": {
       "title": "邮件模板",
@@ -1457,7 +1338,7 @@
       "description": "搜索和管理支付",
       "searchPlaceholder": "搜索：发票、TG ID、@用户名、邮箱...",
       "searchHint": "示例：SP-78291、@username、123456789、user@mail.ru",
-      "searchResults": "搜索结果:{{query}}。找到 {{count}} 条",
+      "searchResults": "搜索结果：{{query}} — 找到 {{count}} 条",
       "resetSearch": "重置",
       "statusAll": "全部",
       "statusPending": "待处理",
@@ -1509,8 +1390,7 @@
         "promoPrefix": "优惠码前缀",
         "spinCost": "旋转费用",
         "limitsAndRtp": "限制和RTP",
-        "promocodes": "促销码",
-        "promoValidityDays": "促销码有效期（天）"
+        "promocodes": "促销码"
       },
       "starsNotEnabledGlobally": "星星支付未在支付方式中启用。请在「支付方式」中启用「Telegram Stars」。",
       "prizes": {
@@ -1537,9 +1417,7 @@
           "emoji": "表情",
           "color": "颜色",
           "active": "启用",
-          "worth": "价值",
-          "probability": "手动概率 (0–1)",
-          "probabilityHint": "留空 = 按 RTP 自动"
+          "worth": "价值"
         },
         "promo": {
           "title": "优惠码设置",
@@ -1556,9 +1434,7 @@
         "prizeDistribution": "奖品分布",
         "times": "次",
         "times_other": "{{count}} 次",
-        "topWins": "最高奖品",
-        "loadError": "无法加载统计数据",
-        "empty": "暂无抽奖记录"
+        "topWins": "最高奖品"
       }
     },
     "broadcasts": {
@@ -1622,32 +1498,7 @@
       "customButtonTypeCallback": "回调",
       "customButtonTypeUrl": "链接",
       "customButtonCallbackPlaceholder": "callback_data（例如 back_to_menu）",
-      "customButtonUrlPlaceholder": "https://example.com",
-      "category": "类别",
-      "categoryNews": "新闻",
-      "categoryPromo": "促销",
-      "categorySystem": "系统",
-      "stopping": "正在停止…",
-      "btnBalance": "充值",
-      "btnConnect": "连接",
-      "btnHome": "主页",
-      "btnPartners": "推荐计划",
-      "btnPromocode": "优惠码",
-      "btnSubscription": "订阅",
-      "btnSupport": "客服支持",
-      "emailContent": "邮件内容",
-      "emailContentHint": "支持 HTML",
-      "emailContentPlaceholder": "<p>您好，{{user_name}}！</p>\n<p>您的消息内容...</p>",
-      "emailSection": "邮件群发",
-      "emailSubject": "邮件主题",
-      "emailSubjectPlaceholder": "请输入邮件主题...",
-      "emailVariables": "可用变量",
-      "preview": "预览",
-      "previewEmpty": "— 空 —",
-      "selectChannel": "群发渠道",
-      "selectEmailFilter": "选择邮件受众",
-      "selectEmailFilterPlaceholder": "选择筛选器...",
-      "telegramSection": "Telegram 群发"
+      "customButtonUrlPlaceholder": "https://example.com"
     },
     "pinnedMessages": {
       "title": "置顶消息",
@@ -1889,7 +1740,7 @@
         "db_sqlite": "SQLite",
         "db_redis": "Redis",
         "sys_core": "核心与调试",
-        "sys_remnawave": "Remnawave",
+        "sys_remnawave": "RemnaWave",
         "sys_webapi": "Web API",
         "sys_webhook": "Webhook",
         "sys_server": "服务器状态",
@@ -1912,8 +1763,8 @@
         "telegramOidcClientId": "Client ID（机器人 ID）",
         "telegramOidcClientSecret": "Client Secret"
       },
-      "offlineConv": "离线转化",
-      "apiKey": "API 密钥"
+      "offlineConv": "\u79bb\u7ebf\u8f6c\u5316",
+      "apiKey": "API \u5bc6\u94a5"
     },
     "buttons": {
       "color": "按钮颜色",
@@ -2007,22 +1858,19 @@
       "importError": "无效的JSON文件格式",
       "importPreview": "导入预览",
       "noAppsToImport": "没有可导入的应用",
-      "refreshRemnaWave": "从Remnawave刷新",
+      "refreshRemnaWave": "从RemnaWave刷新",
       "remnaWaveConfigUuid": "配置UUID",
-      "remnaWaveConfigUuidHint": "来自Remnawave面板的订阅页面配置UUID",
-      "remnaWaveMode": "显示来自Remnawave面板的应用。只读模式。",
-      "remnaWaveSettings": "Remnawave设置",
-      "remnaWaveToggle": "切换Remnawave源",
+      "remnaWaveConfigUuidHint": "来自RemnaWave面板的订阅页面配置UUID",
+      "remnaWaveMode": "显示来自RemnaWave面板的应用。只读模式。",
+      "remnaWaveSettings": "RemnaWave设置",
+      "remnaWaveToggle": "切换RemnaWave源",
       "tabs": {
         "basic": "基本",
         "installation": "安装",
         "subscription": "订阅",
         "connect": "连接",
         "additional": "附加"
-      },
-      "noConfigs": "未配置任何配置",
-      "remnaWaveConnected": "Remnawave 已连接",
-      "remnaWaveDisconnected": "Remnawave 未连接"
+      }
     },
     "tickets": {
       "title": "工单管理",
@@ -2073,13 +1921,7 @@
       "copyTelegramId": "点击复制Telegram ID",
       "viewUser": "用户",
       "userNotificationsEnabled": "用户通知",
-      "userNotificationsEnabledDesc": "向用户发送管理员回复通知",
-      "replyFailed": "发送回复失败",
-      "validation": {
-        "checkIntervalRange": "检查间隔必须在 1 到 1440 分钟之间",
-        "reminderCooldownRange": "提醒冷却时间必须在 0 到 1440 分钟之间",
-        "slaMinutesRange": "SLA 必须在 1 到 10080 分钟之间"
-      }
+      "userNotificationsEnabledDesc": "向用户发送管理员回复通知"
     },
     "tariffs": {
       "title": "套餐管理",
@@ -2113,7 +1955,7 @@
       "confirmDeleteText": "此操作不可撤销。套餐将被永久删除。",
       "confirmDeleteWithSubscriptions": "此套餐有 {{count}} 个活跃订阅。删除后，用户续订时需要选择新套餐。",
       "deleteSuccess": "套餐删除成功",
-      "deleteSuccessWithSubscriptions": "套餐已删除。{{count}} 个订阅已重置。用户续订时将选择新套餐。",
+      "deleteSuccessWithSubscriptions": "套餐已删除。{{count}} 个订阅已重置 — 用户续订时将选择新套餐。",
       "saveOrder": "保存排序",
       "orderSaved": "排序已保存",
       "dragToReorder": "拖动以重新排序",
@@ -2163,7 +2005,7 @@
       "daysShort": "天",
       "serversTitle": "服务器",
       "externalSquadTitle": "外部小组",
-      "externalSquadHint": "为此套餐的用户分配Remnawave外部小组。创建订阅时，用户将自动添加到所选小组。",
+      "externalSquadHint": "为此套餐的用户分配RemnaWave外部小组。创建订阅时，用户将自动添加到所选小组。",
       "noExternalSquad": "无外部小组",
       "externalSquadUsers": "用户",
       "serversTabHint": "选择此套餐上可用的服务器。",
@@ -2242,7 +2084,7 @@
       "sync": "同步",
       "syncing": "同步中...",
       "syncNow": "立即同步",
-      "noServers": "暂无服务器。请与Remnawave同步。",
+      "noServers": "暂无服务器。请与RemnaWave同步。",
       "edit": "编辑服务器",
       "originalName": "原始名称",
       "displayName": "显示名称",
@@ -2296,8 +2138,7 @@
         "deactivate": "停用",
         "activate": "启用",
         "edit": "编辑",
-        "delete": "删除",
-        "registrations": "注册"
+        "delete": "删除"
       },
       "modal": {
         "editTitle": "编辑活动",
@@ -2321,7 +2162,7 @@
         "notSelected": "未选择",
         "tariffOption": "{{traffic}} GB，{{devices}} 台设备",
         "durationDays": "时长（天）",
-        "noBonusDescription": "无奖励活动:仅用于跟踪点击和注册。",
+        "noBonusDescription": "无奖励活动——仅用于跟踪点击和注册。",
         "active": "启用",
         "cancel": "取消",
         "save": "保存",
@@ -2365,13 +2206,11 @@
         "totalSpending": "订阅支出",
         "periodComparison": "期间比较",
         "vsLastWeek": "与上周对比",
-        "topRegistrations": "热门注册",
-        "subscriptionsIssued": "已发放订阅",
-        "tariffsIssued": "已发放套餐"
+        "topRegistrations": "热门注册"
       },
       "users": {
         "title": "活动用户",
-        "campaignRegistrations": "{{name}}:{{count}} 次注册",
+        "campaignRegistrations": "{{name}} — {{count}} 次注册",
         "noUsers": "没有注册用户",
         "user": "用户",
         "bonus": "奖励",
@@ -2391,11 +2230,7 @@
         "delete": "删除"
       },
       "loadError": "加载活动失败",
-      "updateError": "保存更改失败",
-      "validation": {
-        "nameRequired": "名称为必填项"
-      },
-      "loadMore": "加载更多"
+      "updateError": "保存更改失败"
     },
     "withdrawals": {
       "title": "提现",
@@ -2502,30 +2337,7 @@
         "description": "拒绝来自 {{name}} 的合作伙伴申请",
         "commentLabel": "备注（可选）",
         "commentPlaceholder": "拒绝原因..."
-      },
-      "settings": "设置",
-      "settingsFields": {
-        "cooldownDays": "提款冷却期（天）",
-        "cooldownDaysDesc": "两次提款请求之间需间隔多少天",
-        "minAmount": "最小提款金额（戈比）",
-        "minAmountDesc": "提款请求的最低金额（100 戈比 = 1 ₽）",
-        "partnerVisible": "在面板中显示推荐部分",
-        "partnerVisibleDesc": "为用户显示/隐藏合作申请和提款部分",
-        "programEnabled": "推荐计划已启用",
-        "programEnabledDesc": "启用整个推荐人功能",
-        "requisitesText": "收款信息文本",
-        "requisitesTextDesc": "将在合作申请表单中向用户显示",
-        "requisitesTextPlaceholder": "请输入您的收款信息...",
-        "withdrawalEnabled": "允许提款",
-        "withdrawalEnabledDesc": "允许用户请求提款"
-      },
-      "settingsLoadError": "加载推荐设置失败",
-      "settingsSection": {
-        "referralProgram": "推荐计划",
-        "withdrawalSettings": "提款设置"
-      },
-      "settingsSubtitle": "推荐计划和合作伙伴提款设置",
-      "settingsUpdateError": "保存推荐设置失败"
+      }
     },
     "partnerDetail": {
       "title": "合作伙伴详情",
@@ -2566,10 +2378,7 @@
         "createTitle": "创建活动",
         "createSubtitle": "活动将自动分配给合作伙伴",
         "autoAssignNote": "活动将自动分配给合作伙伴 {{name}}",
-        "createAndAssign": "创建并分配",
-        "earnings": "收入",
-        "referrals": "推荐人",
-        "registrations": "注册"
+        "createAndAssign": "创建并分配"
       },
       "dangerZone": {
         "title": "危险操作",
@@ -2642,10 +2451,7 @@
         "firstPurchaseOnly": "仅限首次购买",
         "cancel": "取消",
         "saving": "保存中...",
-        "save": "保存",
-        "defaultTrialTariff": "默认试用套餐",
-        "selectTariff": "选择套餐",
-        "tariff": "套餐"
+        "save": "保存"
       },
       "stats": {
         "title": "促销码统计",
@@ -2674,8 +2480,7 @@
         "totalPromocodes": "促销码总数",
         "activeCount": "活跃的",
         "usagesCount": "使用次数",
-        "exhausted": "已用完",
-        "hoursValue": "{{count}}小时"
+        "exhausted": "已用完"
       },
       "actions": {
         "stats": "统计",
@@ -2930,9 +2735,7 @@
           "expired": "已过期",
           "daysLeft": "天剩余",
           "deviceLimitUpdated": "设备限制已更新",
-          "invalidDays": "请输入有效天数（大于0）",
-          "backToList": "返回订阅列表",
-          "createNew": "新建"
+          "invalidDays": "请输入有效天数（大于0）"
         },
         "balance": {
           "current": "当前余额",
@@ -3015,26 +2818,6 @@
           "searchPlaceholder": "按名称、邮箱或 Telegram ID 搜索...",
           "alreadyReferred": "已有推荐人",
           "noUsersFound": "未找到用户"
-        },
-        "actions": {
-          "areYouSure": "确定要继续？",
-          "title": "操作"
-        },
-        "noVpnData": "无 VPN 数据"
-      },
-      "notFound": "未找到用户",
-      "purchaseCount": "购买次数：{{count}}",
-      "userActions": {
-        "delete": "删除用户",
-        "disable": "禁用",
-        "error": "操作失败",
-        "resetSubscription": "重置订阅",
-        "resetTrial": "重置试用",
-        "success": {
-          "delete": "用户已删除",
-          "disable": "用户已禁用",
-          "resetSubscription": "订阅已重置",
-          "resetTrial": "试用已重置"
         }
       }
     },
@@ -3044,8 +2827,7 @@
       "sendButton": "发送",
       "tabs": {
         "templates_other": "模板 ({{count}})",
-        "logs": "日志",
-        "templates": "模板"
+        "logs": "日志"
       },
       "noData": {
         "templates": "没有模板",
@@ -3075,9 +2857,7 @@
         "activeDiscountHours": "折扣有效期（小时）",
         "discountDurationHint": "激活后折扣持续多长时间",
         "templateActive": "模板已激活",
-        "saving": "保存中...",
-        "noServers": "无服务器",
-        "testSquads": "测试小队"
+        "saving": "保存中..."
       },
       "send": {
         "title": "发送促销优惠",
@@ -3100,9 +2880,7 @@
         "offersCreated_other": "已创建优惠: {{count}}",
         "notificationsSent_other": "已发送通知: {{count}}",
         "notificationsFailed": "（失败: {{count}}）",
-        "sendError": "发送优惠失败",
-        "notificationsSent": "已发送通知",
-        "offersCreated": "已创建优惠"
+        "sendError": "发送优惠失败"
       },
       "notFound": "未找到模板",
       "noActiveTemplates": "没有活跃的模板",
@@ -3162,7 +2940,7 @@
       "connected": "已连接",
       "disconnected": "未配置",
       "noData": "加载数据失败",
-      "title": "Remnawave",
+      "title": "RemnaWave",
       "subtitle": "面板管理和统计",
       "tabs": {
         "overview": "概览",
@@ -3200,8 +2978,7 @@
           "offline": "离线",
           "disabled": "已禁用",
           "users": "用户"
-        },
-        "usersOnlineCount": "{{count}} 在线"
+        }
       },
       "overview": {
         "bandwidth": "实时带宽",
@@ -3252,9 +3029,7 @@
         "localSettings": "本地设置",
         "trialEligible": "可试用",
         "price": "价格",
-        "users": "用户",
-        "inboundsCount": "{{count}} 入站",
-        "membersCount": "{{count}} 成员"
+        "users": "用户"
       },
       "sync": {
         "autoSync": "自动同步",
@@ -3270,9 +3045,9 @@
         "success": "成功",
         "runAutoSyncNow": "立即运行自动同步",
         "fromPanel": "从面板",
-        "fromPanelDesc": "从Remnawave导入用户到机器人",
+        "fromPanelDesc": "从RemnaWave导入用户到机器人",
         "toPanel": "到面板",
-        "toPanelDesc": "从机器人导出用户到Remnawave"
+        "toPanelDesc": "从机器人导出用户到RemnaWave"
       }
     },
     "roles": {
@@ -3370,8 +3145,7 @@
         "selectedPermissions_other": "已选择 {{count}} 个权限",
         "cancel": "取消",
         "saving": "保存中...",
-        "save": "保存",
-        "selectedPermissions": "已选权限"
+        "save": "保存"
       },
       "presets": {
         "moderator": "版主",
@@ -3391,9 +3165,7 @@
         "updateFailed": "更新角色失败",
         "nameRequired": "请输入角色名称",
         "deleteFailed": "删除角色失败"
-      },
-      "permissionsCount": "{{count}} 项权限",
-      "usersCount": "{{count}} 个用户"
+      }
     },
     "roleAssign": {
       "title": "角色分配",
@@ -3445,8 +3217,7 @@
         "roleRequired": "请选择角色",
         "assignFailed": "角色分配失败",
         "revokeFailed": "角色撤销失败"
-      },
-      "totalAssignments": "总分配数：{{count}}"
+      }
     },
     "policies": {
       "title": "访问策略",
@@ -3513,8 +3284,7 @@
         "day3": "三",
         "day4": "四",
         "day5": "五",
-        "day6": "六",
-        "ipCount": "IP 数量"
+        "day6": "六"
       },
       "confirm": {
         "title": "删除策略？",
@@ -3596,10 +3366,7 @@
         "justNow": "刚刚",
         "minutesAgo_other": "{{count}} 分钟前",
         "hoursAgo_other": "{{count}} 小时前",
-        "daysAgo_other": "{{count}} 天前",
-        "daysAgo": "{{count}}天前",
-        "hoursAgo": "{{count}}小时前",
-        "minutesAgo": "{{count}}分钟前"
+        "daysAgo_other": "{{count}} 天前"
       },
       "pagination": {
         "pageSize": "每页：",
@@ -3612,8 +3379,7 @@
       "errors": {
         "loadFailed": "加载审计日志失败",
         "retry": "重试"
-      },
-      "totalEntries": "总条目数：{{count}}"
+      }
     },
     "landings": {
       "title": "落地页",
@@ -3698,12 +3464,6 @@
         "dailyChart": "每日购买与收入",
         "tariffChart": "套餐分布",
         "giftBreakdown": "礼物 vs 普通",
-        "funnelTitle": "转化漏斗",
-        "giftClaimTitle": "礼物激活",
-        "giftClaimLabel": "已领取 / 已发送",
-        "dailyRevenue": "每日收入",
-        "byPaymentMethod": "按支付方式",
-        "bySource": "流量来源",
         "purchases": "购买",
         "revenueLabel": "收入",
         "gifts": "礼物",
@@ -3713,8 +3473,7 @@
         "funnel": "漏斗",
         "loadError": "加载统计失败",
         "noPurchases": "无购买记录",
-        "paid": "已支付",
-        "dailyPurchases": "每日购买量"
+        "paid": "已支付"
       },
       "purchases": {
         "title": "购买记录",
@@ -3740,16 +3499,7 @@
         "page": "第 {{current}} 页，共 {{total}} 页",
         "prev": "上一页",
         "next": "下一页"
-      },
-      "methodCurrency": "货币",
-      "methodDescPlaceholder": "向用户显示的简短说明",
-      "methodDescription": "方法描述",
-      "methodDisplayName": "显示名称",
-      "methodIconUrl": "图标 URL",
-      "methodMaxAmount": "最大金额",
-      "methodMinAmount": "最小金额",
-      "methodReturnUrl": "回调 URL",
-      "stickyPayButton": "固定支付按钮"
+      }
     },
     "infoPages": {
       "title": "信息页面",
@@ -3845,15 +3595,13 @@
         "deleteUser": "删除用户"
       },
       "deleteSubscription": {
-        "warning": "选中的订阅将从机器人和Remnawave面板中永久删除！",
-        "hint": "用户将失去已删除订阅的VPN访问权限。此操作无法撤销。",
-        "activePaidWarning": "所选订阅中有 {{count}} / {{total}} 是有效的付费订阅",
-        "forceDeleteConfirm": "我确认删除有效的付费订阅"
+        "warning": "选中的订阅将从机器人和RemnaWave面板中永久删除！",
+        "hint": "用户将失去已删除订阅的VPN访问权限。此操作无法撤销。"
       },
       "deleteUser": {
         "warning": "选中的用户将从机器人中永久删除！他们的所有订阅、余额和数据将丢失！",
         "hint": "此操作无法撤销。用户需要重新启动机器人以创建新账户。",
-        "deleteFromPanel": "同时从Remnawave面板删除"
+        "deleteFromPanel": "同时从RemnaWave面板删除"
       },
       "params": {
         "days": "天数",
@@ -3884,7 +3632,7 @@
         "summaryErrors": "{{count}} 错误"
       },
       "errors": {
-        "title": "{{count}} 个错误。显示详情"
+        "title": "{{count}} 个错误 — 显示详情"
       },
       "filters": {
         "search": "按ID、用户名、邮箱搜索",
@@ -3969,8 +3717,7 @@
       "enable": "启用",
       "disable": "禁用",
       "hide": "隐藏 ({{count}})",
-      "showMore_other": "显示更多 {{count}} 个节点",
-      "showMore": "显示更多"
+      "showMore_other": "显示更多 {{count}} 个节点"
     },
     "revenue": {
       "title": "收入",
@@ -4034,16 +3781,6 @@
       "uptime": "运行时间",
       "users": "用户",
       "activeSubs": "订阅"
-    },
-    "tariffs": {
-      "activeSubscriptions": "活跃订阅",
-      "purchasedMonth": "本月已售出",
-      "purchasedToday": "今日已售出",
-      "purchasedWeek": "本周已售出",
-      "subtitle": "各套餐统计",
-      "tariffName": "套餐名称",
-      "title": "套餐统计",
-      "trialSubscriptions": "试用订阅"
     }
   },
   "profile": {
@@ -4141,15 +3878,8 @@
         "yandex": "Yandex",
         "discord": "Discord",
         "vk": "VK"
-      },
-      "backToAccounts": "返回账户列表"
-    },
-    "emailMergePasswordRequired": "该邮箱已属于另一个账户。要合并账户，请输入该账户的密码。",
-    "emailMergeCodeSent": "确认码已发送至该邮箱。",
-    "emailMergeCodeDescription": "该邮箱已属于另一个账户。我们已向其发送验证码——请输入以确认所有权并合并账户。",
-    "emailMergeCodeLabel": "邮件中的验证码",
-    "emailMergeConfirm": "确认并合并",
-    "emailMergeCodeInvalid": "验证码无效或已过期"
+      }
+    }
   },
   "theme": {
     "colors": "主题颜色",
@@ -4299,8 +4029,7 @@
       "warning": "已取消的优惠码无法重新使用。折扣将立即失效。",
       "confirm": "取消折扣",
       "deactivating": "取消中...",
-      "error": "取消优惠码失败，请稍后重试。",
-      "success": "活动已停用"
+      "error": "取消优惠码失败，请稍后重试。"
     }
   },
   "telegramRedirect": {
@@ -4362,14 +4091,6 @@
       "openBot": "打开机器人",
       "retry": "我已按 /start，重试",
       "hint": "运行 /start 后，返回此处并点击「重试」。"
-    },
-    "serviceUnavailable": {
-      "title": "服务不可用",
-      "description": "暂时无法连接到服务。可能正在进行维护，或存在临时的网络问题。",
-      "retry": "重试",
-      "checking": "正在检查连接...",
-      "hint": "服务恢复后，本页面将自动刷新。",
-      "close": "关闭"
     }
   },
   "banSystem": {
@@ -4518,36 +4239,6 @@
     "merging": "合并中..."
   },
   "landing": {
-    "giftClaim": {
-      "title": "您收到一份礼物！",
-      "error": "无法激活礼物。",
-      "notFoundTitle": "未找到礼物",
-      "notFoundDesc": "此礼物链接无效或已不可用。",
-      "alreadyTitle": "礼物已激活",
-      "alreadyDesc": "此礼物已被领取。",
-      "successTitle": "礼物已激活！",
-      "connectDesc": "使用此链接连接：",
-      "copyLink": "复制链接",
-      "pendingTitle": "即将完成…",
-      "pendingDesc": "付款仍在确认中。本页面将自动更新。",
-      "replaceWarning": "您已有订阅——激活此礼物将替换它。",
-      "activateTelegram": "在 Telegram 中激活",
-      "activateWeb": "通过邮箱激活",
-      "emailLabel": "您的邮箱",
-      "claimNow": "领取礼物",
-      "failedTitle": "礼物不可用",
-      "failedDesc": "此礼物的付款未成功，无法激活。"
-    },
-    "giftLink": {
-      "shareText": "我送您一份订阅！在此激活：",
-      "viaTelegram": "Telegram：",
-      "title": "礼物已就绪！",
-      "subtitle": "将此链接发送给您想赠送的人——他们自行激活。",
-      "linkLabel": "礼物链接",
-      "telegramLabel": "Telegram 链接",
-      "alsoSent": "我们也已发送到 {{contact}}。",
-      "copyMessage": "复制消息"
-    },
     "notFound": "页面未找到",
     "forMe": "为自己",
     "asGift": "作为礼物",
@@ -4586,6 +4277,7 @@
     "copy": "复制",
     "copied": "已复制！",
     "copyLink": "复制链接",
+    "consent": "我同意<privacy>隐私政策</privacy>、<offer>服务条款</offer>和<recurrent>定期付款协议</recurrent>。",
     "giftToggleLabel": "购买类型",
     "pollTimedOut": "处理时间较长",
     "pollTimedOutDesc": "付款处理时间比平时长。您可以尝试再次检查。",
@@ -4626,12 +4318,6 @@
       "d456": "1年3个月",
       "nDays": "{{count}}天",
       "nMonths": "{{count}}个月"
-    },
-    "discount": {
-      "days": "天",
-      "hours": "小时",
-      "minutes": "分钟",
-      "seconds": "秒"
     }
   },
   "gift": {
@@ -4690,43 +4376,7 @@
     },
     "warning": {
       "telegram_unresolvable": "无法验证此 Telegram 用户名。收件人可能不会收到礼物通知。"
-    },
-    "activateButton": "激活",
-    "activateCodePlaceholder": "输入礼物代码",
-    "activatedBy": "由 {{name}} 激活",
-    "activateDescription": "输入您收到的礼物代码以激活订阅",
-    "activatedGiftsTitle": "已激活的礼物",
-    "activateError": "激活礼物失败",
-    "activateSelfError": "您不能激活自己的礼物",
-    "activateSuccess": "礼物已激活！",
-    "activateSuccessDesc": "订阅已添加到您的账户",
-    "activateTitle": "激活礼物",
-    "activeGiftsTitle": "活跃的礼物",
-    "codeLabel": "礼物代码",
-    "codeReadyTitle": "您的礼物代码已就绪",
-    "copyMessage": "复制消息",
-    "daysShort": "天",
-    "deviceCount": "设备数",
-    "devicesShort": "台",
-    "gbShort": "GB",
-    "myGiftsEmpty": "暂无礼物",
-    "myGiftsEmptyDesc": "您发送或收到的礼物将显示在这里",
-    "pageTitle": "礼物",
-    "receivedGiftsTitle": "已收到的礼物",
-    "selectPeriod": "选择时长",
-    "selectTariff": "选择套餐",
-    "sentTo": "已发送给 {{name}}",
-    "shareGift": "分享礼物",
-    "shareModalActivateVia": "通过以下方式激活",
-    "shareModalActivateViaCabinet": "通过个人中心",
-    "shareText": "我为您准备了一份 Bedolaga VPN 礼物：{{code}}",
-    "shareToastCopied": "链接已复制",
-    "statusActivated": "已激活",
-    "statusAvailable": "可激活",
-    "tabActivate": "激活",
-    "tabBuy": "购买",
-    "tabMyGifts": "我的礼物",
-    "unlimitedTraffic": "无限流量"
+    }
   },
   "news": {
     "title": "新闻与更新",
@@ -4787,13 +4437,5 @@
         "linkUrlPrompt": "URL："
       }
     }
-  },
-  "subscriptions": {
-    "buy": "购买订阅",
-    "buyAnother": "再购买一个订阅",
-    "browsePlans": "查看套餐并订阅",
-    "empty": "您还没有订阅",
-    "emptyDesc": "选择套餐以开始使用",
-    "title": "我的订阅"
   }
 }

--- a/src/pages/Info.tsx
+++ b/src/pages/Info.tsx
@@ -1,19 +1,75 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { PiCaretDown } from 'react-icons/pi';
 import DOMPurify from 'dompurify';
 import { infoApi, FaqPage } from '../api/info';
 import { infoPagesApi } from '../api/infoPages';
 import { promoApi, LoyaltyTierInfo } from '../api/promo';
 import type { FaqItem, ReplacesTab } from '../api/infoPages';
-import { DocumentIcon, InfoIcon, QuestionIcon, ShieldIcon, StarIcon } from '@/components/icons';
 
-const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
-  <PiCaretDown className={`h-5 w-5 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+const InfoIcon = () => (
+  <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+    />
+  </svg>
 );
 
-const BUILTIN_TABS = new Set<string>(['faq', 'rules', 'privacy', 'offer', 'loyalty']);
+const QuestionIcon = () => (
+  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+    />
+  </svg>
+);
+
+const DocumentIcon = () => (
+  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+    />
+  </svg>
+);
+
+const ShieldIcon = () => (
+  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+    />
+  </svg>
+);
+
+const StarIcon = () => (
+  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+    />
+  </svg>
+);
+
+const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
+  <svg
+    className={`h-5 w-5 transition-transform ${expanded ? 'rotate-180' : ''}`}
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={1.5}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+  </svg>
+);
+
+const BUILTIN_TABS = new Set<string>(['faq', 'rules', 'privacy', 'offer', 'recurrent', 'loyalty']);
 
 // Sanitize HTML content to prevent XSS
 const sanitizeHtml = (html: string): string => {
@@ -417,6 +473,14 @@ export default function Info() {
     refetchOnMount: 'always',
   });
 
+  const { data: recurrent, isLoading: recurrentLoading } = useQuery({
+    queryKey: ['recurrent-payments'],
+    queryFn: infoApi.getRecurrentPaymentsAgreement,
+    enabled: activeTab === 'recurrent' && !currentTabSlug && replacementsLoaded,
+    staleTime: 0,
+    refetchOnMount: 'always',
+  });
+
   const { data: loyaltyData, isLoading: loyaltyLoading } = useQuery({
     queryKey: ['loyalty-tiers'],
     queryFn: promoApi.getLoyaltyTiers,
@@ -430,6 +494,7 @@ export default function Info() {
     { id: 'rules', label: t('info.rules'), icon: DocumentIcon },
     { id: 'privacy', label: t('info.privacy'), icon: ShieldIcon },
     { id: 'offer', label: t('info.offer'), icon: DocumentIcon },
+    { id: 'recurrent', label: t('info.recurrent', 'Рекурренты'), icon: DocumentIcon },
     { id: 'loyalty', label: t('info.loyalty'), icon: StarIcon },
   ];
 
@@ -580,6 +645,32 @@ export default function Info() {
           {privacy.updated_at && (
             <p className="mt-6 border-t border-dark-700 pt-4 text-sm text-dark-400">
               {t('info.updatedAt')}: {new Date(privacy.updated_at).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      );
+    }
+
+    if (activeTab === 'recurrent') {
+      if (recurrentLoading) {
+        return (
+          <div className="flex justify-center py-8">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-accent-500 border-t-transparent" />
+          </div>
+        );
+      }
+
+      if (!recurrent?.content) {
+        return <div className="py-8 text-center text-dark-400">{t('info.noContent')}</div>;
+      }
+
+      const recurrentHtml = formatContent(recurrent.content);
+      return (
+        <div className="bento-card prose prose-invert max-w-none">
+          <div className="overflow-x-auto" dangerouslySetInnerHTML={{ __html: recurrentHtml }} />
+          {recurrent.updated_at && (
+            <p className="mt-6 border-t border-dark-700 pt-4 text-sm text-dark-400">
+              {t('info.updatedAt')}: {new Date(recurrent.updated_at).toLocaleDateString()}
             </p>
           )}
         </div>
@@ -804,7 +895,7 @@ export default function Info() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
-        <InfoIcon className="h-6 w-6" />
+        <InfoIcon />
         <h1 className="text-2xl font-bold text-dark-50 sm:text-3xl">{t('info.title')}</h1>
       </div>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -23,7 +23,6 @@ import TelegramLoginButton from '../components/TelegramLoginButton';
 import OAuthProviderIcon from '../components/OAuthProviderIcon';
 import { saveOAuthState } from '../utils/oauth';
 import { getPendingReferralCode } from '../utils/referral';
-import { UsersIcon, EmailIcon, RefreshIcon, ChevronDownIcon } from '@/components/icons';
 
 export default function Login() {
   const { t } = useTranslation();
@@ -222,7 +221,7 @@ export default function Login() {
     }
   };
 
-  const handleEmailSubmit = async (e: React.SyntheticEvent) => {
+  const handleEmailSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
 
@@ -283,7 +282,7 @@ export default function Login() {
     }
   };
 
-  const handleForgotPassword = async (e: React.SyntheticEvent) => {
+  const handleForgotPassword = async (e: React.FormEvent) => {
     e.preventDefault();
     setForgotPasswordError('');
 
@@ -322,10 +321,9 @@ export default function Login() {
           safeBottom > 0 ? `${safeBottom + 16}px` : 'calc(1rem + env(safe-area-inset-bottom, 0px))',
       }}
     >
-      {/* Flat background — the previous two layered gradients (linear
-          + accent radial halo) read as the airdrop / crypto aesthetic
-          PRODUCT.md explicitly anti-references. Body bg-dark-950 carries
-          the surface alone. */}
+      {/* Background gradient */}
+      <div className="fixed inset-0 bg-gradient-to-br from-dark-950 via-dark-900 to-dark-950" />
+      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-accent-500/10 via-transparent to-transparent" />
 
       {/* Language switcher */}
       <div
@@ -363,7 +361,19 @@ export default function Login() {
           {referralCode && isEmailAuthEnabled && (
             <div className="mt-3 rounded-xl border border-accent-500/30 bg-accent-500/10 p-2.5">
               <div className="flex items-center justify-center gap-2 text-accent-400">
-                <UsersIcon className="h-4 w-4 flex-shrink-0" />
+                <svg
+                  className="h-4 w-4 flex-shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+                  />
+                </svg>
                 <span className="text-xs font-medium">{t('auth.referralInvite')}</span>
               </div>
             </div>
@@ -374,7 +384,19 @@ export default function Login() {
         {registeredEmail ? (
           <div className="card text-center">
             <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-success-500/20">
-              <EmailIcon className="h-7 w-7 text-success-400" />
+              <svg
+                className="h-7 w-7 text-success-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+                />
+              </svg>
             </div>
             <h2 className="mb-2 text-lg font-bold text-dark-50">
               {t('auth.checkEmail', 'Check your email')}
@@ -403,10 +425,7 @@ export default function Login() {
           /* Main auth card */
           <div className="card">
             {error && (
-              <div
-                role="alert"
-                className="mb-4 rounded-xl border border-error-500/30 bg-error-500/10 px-4 py-2.5 text-sm text-error-400"
-              >
+              <div className="mb-4 rounded-xl border border-error-500/30 bg-error-500/10 px-4 py-2.5 text-sm text-error-400">
                 {error}
               </div>
             )}
@@ -424,7 +443,19 @@ export default function Login() {
                     onClick={handleRetryTelegramAuth}
                     className="btn-primary mx-auto flex items-center gap-2 px-5 py-2.5"
                   >
-                    <RefreshIcon className="h-4 w-4" />
+                    <svg
+                      className="h-4 w-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+                      />
+                    </svg>
                     {t('auth.tryAgain')}
                   </button>
                   <p className="text-xs text-dark-500">
@@ -481,11 +512,29 @@ export default function Login() {
                     onClick={() => setShowEmailForm(!showEmailForm)}
                     className="flex items-center gap-1.5 rounded-full border border-dark-700 bg-dark-800/60 px-3.5 py-1.5 text-xs font-medium text-dark-300 transition-all hover:border-dark-600 hover:bg-dark-700 hover:text-dark-200"
                   >
-                    <EmailIcon className="h-3.5 w-3.5 text-dark-400" />
+                    <svg
+                      className="h-3.5 w-3.5 text-dark-400"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+                      />
+                    </svg>
                     <span>{t('auth.loginWithEmail')}</span>
-                    <ChevronDownIcon
+                    <svg
                       className={`h-3 w-3 text-dark-400 transition-transform duration-300 ${showEmailForm ? 'rotate-180' : ''}`}
-                    />
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2.5}
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                    </svg>
                   </button>
                   <div className="h-px flex-1 bg-dark-700" />
                 </div>
@@ -504,7 +553,19 @@ export default function Login() {
                         forgotPasswordSent ? (
                           <div className="space-y-4 text-center">
                             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-success-500/20">
-                              <EmailIcon className="h-6 w-6 text-success-400" />
+                              <svg
+                                className="h-6 w-6 text-success-400"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={1.5}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+                                />
+                              </svg>
                             </div>
                             <p className="text-sm font-medium text-dark-100">
                               {t('auth.checkEmail', 'Check your email')}

--- a/src/pages/PublicLegalDoc.tsx
+++ b/src/pages/PublicLegalDoc.tsx
@@ -1,0 +1,168 @@
+import { useEffect } from 'react';
+import { Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import DOMPurify from 'dompurify';
+
+import { infoApi } from '../api/info';
+
+type DocType = 'privacy' | 'offer' | 'recurrent';
+
+const DOC_META: Record<
+  DocType,
+  {
+    title: string;
+    queryKey: string;
+    fetcher: () => Promise<{ content: string; updated_at: string | null }>;
+  }
+> = {
+  privacy: {
+    title: 'Политика конфиденциальности',
+    queryKey: 'public-privacy-policy',
+    fetcher: () => infoApi.getPrivacyPolicy(),
+  },
+  offer: {
+    title: 'Публичная оферта',
+    queryKey: 'public-offer',
+    fetcher: () => infoApi.getPublicOffer(),
+  },
+  recurrent: {
+    title: 'Соглашение о рекуррентных платежах',
+    queryKey: 'public-recurrent-payments',
+    fetcher: () => infoApi.getRecurrentPaymentsAgreement(),
+  },
+};
+
+const SANITIZE_CONFIG = {
+  ALLOWED_TAGS: [
+    'p',
+    'br',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'b',
+    'strong',
+    'i',
+    'em',
+    'u',
+    'code',
+    'a',
+    'ul',
+    'ol',
+    'li',
+    'blockquote',
+  ],
+  ALLOWED_ATTR: ['href', 'target', 'rel'],
+};
+
+const formatContent = (content: string): string => {
+  if (!content) return '';
+
+  const hasBlockHtml = /<(p|div|h[1-6]|ul|ol|blockquote)\b/i.test(content);
+  if (hasBlockHtml) return DOMPurify.sanitize(content, SANITIZE_CONFIG);
+
+  const result = content
+    .split(/\n\n+/)
+    .map((paragraph) => {
+      const trimmed = paragraph.trim();
+      if (!trimmed) return '';
+
+      if (/^#{1,4}\s/.test(trimmed)) {
+        const level = trimmed.match(/^(#{1,4})/)?.[1].length || 1;
+        const text = trimmed.replace(/^#{1,4}\s*/, '');
+        return `<h${level}>${text}</h${level}>`;
+      }
+
+      if (/^[-•]\s/.test(trimmed) || /^\d+[.)]\s/.test(trimmed)) {
+        const lines = trimmed.split('\n');
+        const isOrdered = /^\d+[.)]\s/.test(lines[0]);
+        const startNum = isOrdered ? parseInt(lines[0].match(/^(\d+)/)?.[1] || '1', 10) : 1;
+        const listItems = lines
+          .map((line) => line.replace(/^[-•]\s*/, '').replace(/^\d+[.)]\s*/, ''))
+          .filter((line) => line.trim())
+          .map((line) => `<li>${line}</li>`)
+          .join('');
+        return isOrdered ? `<ol start="${startNum}">${listItems}</ol>` : `<ul>${listItems}</ul>`;
+      }
+
+      const formatted = trimmed.split('\n').join('<br/>');
+      return `<p>${formatted}</p>`;
+    })
+    .filter(Boolean)
+    .join('');
+
+  return DOMPurify.sanitize(result, SANITIZE_CONFIG);
+};
+
+function PublicLegalDocInternal({ docType }: { docType: DocType }) {
+  const meta = DOC_META[docType];
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: [meta.queryKey],
+    queryFn: meta.fetcher,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  useEffect(() => {
+    document.title = `${meta.title} — Matrixxx VPN`;
+  }, [meta.title]);
+
+  const updatedAt = data?.updated_at ? new Date(data.updated_at).toLocaleDateString('ru-RU') : null;
+  const html = data?.content ? formatContent(data.content) : '';
+
+  return (
+    <div className="min-h-screen bg-dark-950 px-4 py-8 text-dark-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        <Link
+          to="/"
+          className="inline-flex items-center text-sm font-medium text-accent-400 transition-colors hover:text-accent-300"
+        >
+          ← Matrixxx VPN
+        </Link>
+
+        <h1 className="mt-6 flex items-center gap-2 text-3xl font-bold text-white">{meta.title}</h1>
+
+        {updatedAt && <p className="mt-2 text-sm text-dark-400">Обновлено: {updatedAt}</p>}
+
+        <div className="mt-8">
+          {isLoading && (
+            <div className="bento-card flex justify-center py-12">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-accent-500 border-t-transparent" />
+            </div>
+          )}
+          {isError && (
+            <div className="bento-card text-center text-red-400">
+              Не удалось загрузить документ.
+            </div>
+          )}
+          {html && (
+            <div className="bento-card prose prose-invert max-w-none">
+              <div className="overflow-x-auto" dangerouslySetInnerHTML={{ __html: html }} />
+            </div>
+          )}
+        </div>
+
+        <div className="mt-12 text-center text-xs text-dark-500">
+          <p>
+            Smedia Pro LTD · Reg. No. 15645745
+            <br />7 Bell Yard, London, UK, WC2A 2JR
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PublicLegalDocInternal;
+
+export function PublicPrivacyPage() {
+  return <PublicLegalDocInternal docType="privacy" />;
+}
+
+export function PublicOfferPage() {
+  return <PublicLegalDocInternal docType="offer" />;
+}
+
+export function PublicRecurrentPaymentsPage() {
+  return <PublicLegalDocInternal docType="recurrent" />;
+}


### PR DESCRIPTION
Управление юридическими документами в кабинете.

**Что добавляет:**
- Публичные страницы: `/privacy`, `/offer`, `/recurrent-payments` (вкладка в Info + отдельные роуты)
- Страница входа: модалки юр-документов + `LegalFooter` (ссылки на оферту/политику/рекуррент, тумблер через branding-настройки)
- Админка: редактор юр-документов (в BrandingTab)
- Усиление DOMPurify allowlist для legal-HTML (XSS-защита)
- i18n ключи (ru/en/fa/zh)

Юр-требование для приёма платежей (особенно рекуррентных): пользователь должен видеть оферту/политику/согласие на рекуррент.

Реализовано и работает в проде у нас. Готовы доработать под ваши паттерны.