### PR TITLE
style: единый дизайн-язык по всему фронту

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "recharts": "^3.7.0",
         "sigma": "^3.0.2",
         "simplex-noise": "^4.0.3",
-        "tailwind-merge": "^3.4.0",
+        "tailwind-merge": "^3.6.0",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -7493,9 +7493,9 @@
       }
     },
     "node_modules/tailwind-merge": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
-      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "recharts": "^3.7.0",
     "sigma": "^3.0.2",
     "simplex-noise": "^4.0.3",
-    "tailwind-merge": "^3.4.0",
+    "tailwind-merge": "^3.6.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/src/components/PromoOffersSection.tsx
+++ b/src/components/PromoOffersSection.tsx
@@ -282,7 +282,7 @@ export default function PromoOffersSection({ className = '' }: PromoOffersSectio
                   <div className="mb-1 flex items-center gap-2">
                     <h3 className="font-semibold text-dark-100">{getOfferTitle(offer, t)}</h3>
                     {offer.effect_type === 'test_access' && (
-                      <span className="rounded bg-purple-500/20 px-2 py-0.5 text-xs text-purple-400">
+                      <span className="rounded bg-accent-500/20 px-2 py-0.5 text-xs text-accent-400">
                         {t('promo.offers.test')}
                       </span>
                     )}

--- a/src/components/SuccessNotificationModal.tsx
+++ b/src/components/SuccessNotificationModal.tsx
@@ -117,19 +117,19 @@ export default function SuccessNotificationModal() {
     } else if (data.type === 'subscription_activated') {
       title = t('successNotification.subscriptionActivated.title', 'Subscription activated!');
       icon = <RocketIcon className="h-8 w-8" />;
-      gradientClass = 'from-accent-500 to-purple-600';
+      gradientClass = 'from-accent-500 to-accent-600';
     } else if (data.type === 'subscription_renewed') {
       title = t('successNotification.subscriptionRenewed.title', 'Subscription renewed!');
       icon = <RocketIcon className="h-8 w-8" />;
-      gradientClass = 'from-accent-500 to-purple-600';
+      gradientClass = 'from-accent-500 to-accent-600';
     } else if (data.type === 'subscription_purchased') {
       title = t('successNotification.subscriptionPurchased.title', 'Subscription purchased!');
       icon = <RocketIcon className="h-8 w-8" />;
-      gradientClass = 'from-accent-500 to-purple-600';
+      gradientClass = 'from-accent-500 to-accent-600';
     } else if (data.type === 'devices_purchased') {
       title = t('successNotification.devicesPurchased.title', 'Devices added!');
       icon = <DevicesIcon className="h-8 w-8" />;
-      gradientClass = 'from-blue-500 to-cyan-600';
+      gradientClass = 'from-accent-500 to-accent-600';
     } else if (data.type === 'traffic_purchased') {
       title = t('successNotification.trafficPurchased.title', 'Traffic added!');
       icon = <TrafficIcon className="h-8 w-8" />;
@@ -212,7 +212,7 @@ export default function SuccessNotificationModal() {
               <span className="text-dark-400">
                 {t('successNotification.devicesAdded', 'Devices added')}
               </span>
-              <span className="text-lg font-bold text-blue-400">+{data.devicesAdded}</span>
+              <span className="text-lg font-bold text-accent-400">+{data.devicesAdded}</span>
             </div>
           )}
 

--- a/src/components/SuccessNotificationModal.tsx
+++ b/src/components/SuccessNotificationModal.tsx
@@ -281,7 +281,7 @@ export default function SuccessNotificationModal() {
             {isSubscription && (
               <button
                 onClick={handleGoToSubscription}
-                className="flex w-full items-center justify-center gap-2 rounded-xl bg-accent-500 py-3.5 font-bold text-on-accent shadow-lg shadow-accent-500/25 transition-colors hover:bg-accent-400 active:bg-accent-600"
+                className="flex w-full items-center justify-center gap-2 rounded-xl bg-accent-500 py-3.5 text-sm font-bold text-on-accent shadow-lg shadow-accent-500/25 transition-colors hover:bg-accent-400 active:bg-accent-600"
               >
                 <RocketIcon className="h-8 w-8" />
                 <span>{t('successNotification.goToSubscription', 'Go to Subscription')}</span>
@@ -301,7 +301,7 @@ export default function SuccessNotificationModal() {
             {isDevicesPurchased && (
               <button
                 onClick={handleGoToSubscription}
-                className="flex w-full items-center justify-center gap-2 rounded-xl bg-accent-500 py-3.5 font-bold text-on-accent shadow-lg shadow-accent-500/25 transition-colors hover:bg-accent-400 active:bg-accent-600"
+                className="flex w-full items-center justify-center gap-2 rounded-xl bg-accent-500 py-3.5 text-sm font-bold text-on-accent shadow-lg shadow-accent-500/25 transition-colors hover:bg-accent-400 active:bg-accent-600"
               >
                 <DevicesIcon className="h-8 w-8" />
                 <span>{t('successNotification.goToSubscription', 'Go to Subscription')}</span>

--- a/src/components/admin/AnalyticsTab.tsx
+++ b/src/components/admin/AnalyticsTab.tsx
@@ -114,7 +114,7 @@ export function AnalyticsTab() {
               <button
                 onClick={handleSaveYandex}
                 disabled={updateMutation.isPending}
-                className="rounded-xl bg-accent-500 px-4 py-2.5 text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
+                className="rounded-xl bg-accent-500 px-4 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
               >
                 <CheckIcon />
               </button>
@@ -253,7 +253,7 @@ export function AnalyticsTab() {
                 <button
                   onClick={handleSaveGoogleId}
                   disabled={updateMutation.isPending}
-                  className="rounded-xl bg-accent-500 px-4 py-2.5 text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
+                  className="rounded-xl bg-accent-500 px-4 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
                 >
                   <CheckIcon />
                 </button>
@@ -307,7 +307,7 @@ export function AnalyticsTab() {
                 <button
                   onClick={handleSaveGoogleLabel}
                   disabled={updateMutation.isPending}
-                  className="rounded-xl bg-accent-500 px-4 py-2.5 text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
+                  className="rounded-xl bg-accent-500 px-4 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
                 >
                   <CheckIcon />
                 </button>

--- a/src/components/admin/ColoredItemCombobox.tsx
+++ b/src/components/admin/ColoredItemCombobox.tsx
@@ -346,7 +346,7 @@ export function ColoredItemCombobox({
                 type="button"
                 onClick={handleCreate}
                 disabled={isCreating}
-                className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded-lg bg-accent-500 px-4 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex min-h-[44px] w-full items-center justify-center gap-2 rounded-xl bg-accent-500 px-4 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isCreating ? (
                   <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />

--- a/src/components/admin/MenuEditorTab.tsx
+++ b/src/components/admin/MenuEditorTab.tsx
@@ -18,7 +18,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { PiCaretDown } from 'react-icons/pi';
+import { ChevronDownIcon } from '@/components/icons';
 import {
   GripIcon,
   TrashIcon,
@@ -41,7 +41,7 @@ import { useNotify } from '../../platform/hooks/useNotify';
 import { useNativeDialog } from '../../platform/hooks/useNativeDialog';
 
 const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
-  <PiCaretDown className={`h-3.5 w-3.5 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+  <ChevronDownIcon className={`h-3.5 w-3.5 transition-transform ${expanded ? 'rotate-180' : ''}`} />
 );
 
 function generateId(): string {

--- a/src/components/admin/SettingInput.tsx
+++ b/src/components/admin/SettingInput.tsx
@@ -122,7 +122,7 @@ export function SettingInput({ setting, onUpdate, disabled }: SettingInputProps)
             </button>
             <button
               onClick={handleSave}
-              className="flex items-center gap-1.5 rounded-lg bg-accent-500 px-3 py-1.5 text-sm text-on-accent transition-colors hover:bg-accent-600"
+              className="flex items-center gap-1.5 rounded-xl bg-accent-500 px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600"
             >
               <CheckIcon />
               {t('admin.settings.saveButton')}
@@ -159,7 +159,7 @@ export function SettingInput({ setting, onUpdate, disabled }: SettingInputProps)
         />
         <button
           onClick={handleSave}
-          className="rounded-lg bg-accent-500 p-2 text-on-accent transition-colors hover:bg-accent-600"
+          className="rounded-xl bg-accent-500 p-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600"
           title={t('admin.settings.saveHint')}
         >
           <CheckIcon />

--- a/src/components/admin/SettingsTableRow.tsx
+++ b/src/components/admin/SettingsTableRow.tsx
@@ -87,7 +87,7 @@ export function SettingsTableRow({
             )}
 
             {setting.has_override && !locked && (
-              <span className="rounded-full bg-sky-500/20 px-1.5 py-0.5 text-[10px] leading-none font-medium text-sky-400">
+              <span className="rounded-full bg-accent-500/20 px-1.5 py-0.5 text-[10px] leading-none font-medium text-accent-400">
                 {t('admin.settings.badgeDb')}
               </span>
             )}

--- a/src/components/admin/SortableSelectedMethodCard.tsx
+++ b/src/components/admin/SortableSelectedMethodCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
-import { PiCaretDown } from 'react-icons/pi';
+import { ChevronDownIcon as ChevronDownGlyph } from '@/components/icons';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '../../lib/utils';
 import { CheckIcon } from '@/components/icons';
@@ -12,7 +12,7 @@ import type { PaymentMethodSubOptionInfo } from '../../types';
 export type MethodWithId = AdminLandingPaymentMethod & { _id: string };
 
 const ChevronDownIcon = ({ open }: { open: boolean }) => (
-  <PiCaretDown className={cn('h-5 w-5 transition-transform', open && 'rotate-180')} />
+  <ChevronDownGlyph className={cn('h-5 w-5 transition-transform', open && 'rotate-180')} />
 );
 
 interface SortableSelectedMethodProps {

--- a/src/components/admin/trafficUsage/TrafficIcons.tsx
+++ b/src/components/admin/trafficUsage/TrafficIcons.tsx
@@ -6,7 +6,7 @@
 // thin local wrapper over the panel's Phosphor caret icons.
 // ──────────────────────────────────────────────────────────────────
 
-import { PiCaretDown, PiCaretUpDown, PiCaretUp } from 'react-icons/pi';
+import { ChevronDownIcon, ChevronExpandIcon, ChevronUpIcon } from '@/components/icons';
 
 export {
   CalendarIcon,
@@ -27,9 +27,9 @@ export {
 
 export const SortIcon = ({ direction }: { direction: false | 'asc' | 'desc' }) =>
   direction === 'asc' ? (
-    <PiCaretUp className="ml-1 inline h-3 w-3" />
+    <ChevronUpIcon className="ml-1 inline h-3 w-3" />
   ) : direction === 'desc' ? (
-    <PiCaretDown className="ml-1 inline h-3 w-3" />
+    <ChevronDownIcon className="ml-1 inline h-3 w-3" />
   ) : (
-    <PiCaretUpDown className="ml-1 inline h-3 w-3" />
+    <ChevronExpandIcon className="ml-1 inline h-3 w-3" />
   );

--- a/src/components/admin/userDetail/InfoTab.tsx
+++ b/src/components/admin/userDetail/InfoTab.tsx
@@ -514,8 +514,8 @@ export function InfoTab(props: InfoTabProps) {
             disabled={actionLoading}
             className={`rounded-lg px-3 py-2 text-sm font-medium transition-all disabled:opacity-50 ${
               confirmingAction === 'fullDelete'
-                ? 'bg-rose-500 text-white'
-                : 'bg-rose-500/15 text-rose-400 hover:bg-rose-500/25'
+                ? 'bg-error-500 text-white'
+                : 'bg-error-500/15 text-error-400 hover:bg-error-500/25'
             }`}
           >
             {confirmingAction === 'fullDelete'

--- a/src/components/admin/userDetail/InfoTab.tsx
+++ b/src/components/admin/userDetail/InfoTab.tsx
@@ -378,7 +378,7 @@ export function InfoTab(props: InfoTabProps) {
                 <button
                   onClick={onUpdateReferralCommission}
                   disabled={actionLoading}
-                  className="w-full rounded-lg bg-accent-500 px-2 py-1 text-xs text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
+                  className="w-full rounded-xl bg-accent-500 px-2 py-1 text-xs font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
                 >
                   {actionLoading ? t('common.loading') : t('common.save')}
                 </button>

--- a/src/components/admin/userDetail/TicketsTab.tsx
+++ b/src/components/admin/userDetail/TicketsTab.tsx
@@ -348,7 +348,7 @@ function ChatView({
             onClick={onReply}
             disabled={!replyText.trim() || replySending}
             aria-label={t('admin.tickets.sendReply', 'Send reply')}
-            className="min-h-[44px] min-w-[44px] shrink-0 self-end rounded-lg bg-accent-500 px-4 py-2 text-sm text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50 sm:min-h-0 sm:min-w-0"
+            className="min-h-[44px] min-w-[44px] shrink-0 self-end rounded-xl bg-accent-500 px-4 py-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50 sm:min-h-0 sm:min-w-0"
           >
             {replySending ? (
               <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />

--- a/src/components/connection/InstallationGuide.tsx
+++ b/src/components/connection/InstallationGuide.tsx
@@ -222,7 +222,7 @@ export default function InstallationGuide({
             <BackIcon className="h-6 w-6" />
           </button>
         )}
-        <h2 className="flex-1 text-lg font-bold text-dark-100">
+        <h2 className="flex-1 text-lg font-semibold text-dark-100">
           {getBaseTranslation('installationGuideHeader', 'subscription.connection.title')}
         </h2>
         {appConfig.subscriptionUrl && onOpenQR && (

--- a/src/components/dashboard/PendingGiftCard.tsx
+++ b/src/components/dashboard/PendingGiftCard.tsx
@@ -21,7 +21,7 @@ export default function PendingGiftCard({ gifts, className }: PendingGiftCardPro
           key={gift.token}
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
-          className="relative overflow-hidden rounded-2xl border border-accent-500/30 bg-linear-to-r from-accent-500/10 via-purple-500/10 to-accent-500/10 p-5"
+          className="relative overflow-hidden rounded-2xl border border-accent-500/30 bg-linear-to-r from-accent-500/10 via-accent-500/10 to-accent-500/10 p-5"
         >
           {/* Subtle glow effect */}
           <div className="absolute -top-8 -right-8 h-24 w-24 rounded-full bg-accent-500/10 blur-2xl" />

--- a/src/components/dashboard/SubscriptionCardActive.tsx
+++ b/src/components/dashboard/SubscriptionCardActive.tsx
@@ -116,7 +116,7 @@ export default function SubscriptionCardActive({
           </div>
 
           {/* Title */}
-          <h2 className="text-lg font-bold tracking-tight text-dark-50">
+          <h2 className="text-lg font-semibold tracking-tight text-dark-50">
             {t('dashboard.trafficUsageTitle')}
           </h2>
         </div>

--- a/src/components/dashboard/SubscriptionCardExpired.tsx
+++ b/src/components/dashboard/SubscriptionCardExpired.tsx
@@ -177,7 +177,7 @@ export default function SubscriptionCardExpired({
             <ClockIcon className="h-[22px] w-[22px]" />
           )}
         </div>
-        <h2 className="text-lg font-bold tracking-tight text-dark-50">
+        <h2 className="text-lg font-semibold tracking-tight text-dark-50">
           {isLimited
             ? t('subscription.trafficLimitedTitle')
             : isDisabledDaily

--- a/src/components/partner/CampaignCard.tsx
+++ b/src/components/partner/CampaignCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PiCaretDown } from 'react-icons/pi';
+import { ChevronDownIcon } from '@/components/icons';
 
 import { CheckIcon, CopyIcon } from '@/components/icons';
 import type { PartnerCampaignInfo } from '../../api/partners';
@@ -12,7 +12,7 @@ import { CampaignDetailStats } from './CampaignDetailStats';
 import { StatCard } from '../stats/StatCard';
 
 const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
-  <PiCaretDown className={`h-5 w-5 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+  <ChevronDownIcon className={`h-5 w-5 transition-transform ${expanded ? 'rotate-180' : ''}`} />
 );
 
 interface CampaignCardProps {

--- a/src/components/tickets/MessageMediaGrid.tsx
+++ b/src/components/tickets/MessageMediaGrid.tsx
@@ -172,7 +172,7 @@ export function MessageMediaGrid({
           >
             <button
               type="button"
-              className="absolute top-4 right-4 z-10 flex h-12 w-12 items-center justify-center rounded-full bg-white text-black shadow-xl transition-colors hover:bg-gray-200"
+              className="absolute top-4 right-4 z-10 flex h-12 w-12 items-center justify-center rounded-full bg-white text-black shadow-xl transition-colors hover:bg-dark-700"
               onClick={closeFullscreen}
             >
               <XIcon className="h-5 w-5" />

--- a/src/pages/AdminApplicationReview.tsx
+++ b/src/pages/AdminApplicationReview.tsx
@@ -53,7 +53,7 @@ export default function AdminApplicationReview() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/partners" />
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {t('admin.partners.approveDialog.title')}
           </h1>
         </div>
@@ -72,9 +72,7 @@ export default function AdminApplicationReview() {
       <div className="mb-6 flex items-center gap-3">
         <AdminBackButton to="/admin/partners" />
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">
-            {t('admin.partners.actions.review')}
-          </h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.partners.actions.review')}</h1>
           <p className="text-sm text-dark-400">{displayName}</p>
         </div>
       </div>

--- a/src/pages/AdminApps.tsx
+++ b/src/pages/AdminApps.tsx
@@ -49,7 +49,7 @@ export default function AdminApps() {
             <BackIcon className="h-5 w-5 text-dark-400" />
           </button>
         )}
-        <h1 className="text-2xl font-bold text-dark-50 sm:text-3xl">{t('admin.apps.title')}</h1>
+        <h1 className="text-xl font-bold text-dark-100">{t('admin.apps.title')}</h1>
       </div>
 
       {/* Status card */}

--- a/src/pages/AdminAuditLog.tsx
+++ b/src/pages/AdminAuditLog.tsx
@@ -505,7 +505,7 @@ export default function AdminAuditLog() {
             </button>
           )}
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.auditLog.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.auditLog.title')}</h1>
             <p className="text-sm text-dark-400">{t('admin.auditLog.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/AdminAuditLog.tsx
+++ b/src/pages/AdminAuditLog.tsx
@@ -734,7 +734,7 @@ export default function AdminAuditLog() {
             <div className="mt-4 flex items-center gap-3">
               <button
                 onClick={handleApplyFilters}
-                className="rounded-lg bg-accent-500 px-4 py-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600"
+                className="rounded-xl bg-accent-500 px-4 py-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600"
               >
                 {t('admin.auditLog.filters.apply')}
               </button>

--- a/src/pages/AdminBanSystem.tsx
+++ b/src/pages/AdminBanSystem.tsx
@@ -379,7 +379,7 @@ export default function AdminBanSystem() {
             </div>
 
             {/* Title */}
-            <h2 className="mb-2 text-xl font-bold text-dark-100">{t('banSystem.title')}</h2>
+            <h2 className="mb-2 text-lg font-semibold text-dark-100">{t('banSystem.title')}</h2>
 
             {/* Error message */}
             <p className="mb-2 font-medium text-error-400">{error}</p>
@@ -433,7 +433,7 @@ export default function AdminBanSystem() {
             <ShieldIcon className="h-6 w-6" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold text-dark-100">{t('banSystem.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('banSystem.title')}</h1>
             <p className="text-dark-400">{t('banSystem.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/AdminBroadcastDetail.tsx
+++ b/src/pages/AdminBroadcastDetail.tsx
@@ -31,7 +31,7 @@ function ChannelBadge({ channel }: { channel?: BroadcastChannel }) {
 
   if (channel === 'email') {
     return (
-      <span className="flex items-center gap-1 rounded-full bg-purple-500/20 px-2 py-0.5 text-xs text-purple-400">
+      <span className="flex items-center gap-1 rounded-full bg-accent-500/20 px-2 py-0.5 text-xs text-accent-400">
         <EmailIcon />
         <span className="hidden sm:inline">Email</span>
       </span>

--- a/src/pages/AdminBulkActions.tsx
+++ b/src/pages/AdminBulkActions.tsx
@@ -20,7 +20,7 @@ import {
   type BulkActionType,
   type BulkActionParams,
 } from '../api/adminBulkActions';
-import { PiCaretDown } from 'react-icons/pi';
+import { ChevronDownIcon } from '@/components/icons';
 import { usePlatform } from '../platform/hooks/usePlatform';
 import { useCurrency } from '../hooks/useCurrency';
 import { cn } from '@/lib/utils';
@@ -56,7 +56,7 @@ type SubscriptionStatusFilter = '' | 'active' | 'expired' | 'trial' | 'limited' 
 // className-only API), so it stays local as a thin wrapper over the panel's
 // Phosphor caret, preserving the rotate-on-expand behavior.
 const ChevronExpandIcon = ({ expanded }: { expanded: boolean }) => (
-  <PiCaretDown
+  <ChevronDownIcon
     className={cn('h-4 w-4 text-white transition-transform duration-200', expanded && 'rotate-180')}
   />
 );

--- a/src/pages/AdminCampaignEdit.tsx
+++ b/src/pages/AdminCampaignEdit.tsx
@@ -315,7 +315,7 @@ export default function AdminCampaignEdit() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/campaigns" />
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {t('admin.campaigns.modal.editTitle')}
           </h1>
         </div>

--- a/src/pages/AdminCampaignStats.tsx
+++ b/src/pages/AdminCampaignStats.tsx
@@ -29,8 +29,8 @@ const bonusTypeConfig: Record<
   },
   tariff: {
     labelKey: 'admin.campaigns.bonusType.tariff',
-    color: 'text-purple-400',
-    bgColor: 'bg-purple-500/20',
+    color: 'text-accent-400',
+    bgColor: 'bg-accent-500/20',
   },
   none: {
     labelKey: 'admin.campaigns.bonusType.none',
@@ -141,9 +141,7 @@ export default function AdminCampaignStats() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/campaigns" />
-          <h1 className="text-xl font-semibold text-dark-100">
-            {t('admin.campaigns.stats.title')}
-          </h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.campaigns.stats.title')}</h1>
         </div>
         <div className="rounded-xl border border-error-500/30 bg-error-500/10 p-6 text-center">
           <p className="text-error-400">{t('admin.campaigns.stats.loadError')}</p>
@@ -168,7 +166,7 @@ export default function AdminCampaignStats() {
             <ChartIcon className="h-6 w-6" />
           </div>
           <div className="min-w-0">
-            <h1 className="truncate text-xl font-semibold text-dark-100">{stats.name}</h1>
+            <h1 className="truncate text-xl font-bold text-dark-100">{stats.name}</h1>
             <div className="mt-1 flex items-center gap-2">
               <span
                 className={`rounded px-2 py-0.5 text-xs ${bonusTypeConfig[stats.bonus_type].bgColor} ${bonusTypeConfig[stats.bonus_type].color}`}

--- a/src/pages/AdminCampaigns.tsx
+++ b/src/pages/AdminCampaigns.tsx
@@ -130,7 +130,7 @@ export default function AdminCampaigns() {
             </button>
           )}
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.campaigns.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.campaigns.title')}</h1>
             <p className="text-sm text-dark-400">{t('admin.campaigns.subtitle')}</p>
           </div>
         </div>
@@ -201,7 +201,7 @@ export default function AdminCampaigns() {
                       {t(bonusTypeConfig[campaign.bonus_type].labelKey)}
                     </span>
                     {campaign.partner_name && (
-                      <span className="rounded bg-purple-500/20 px-2 py-0.5 text-xs text-purple-400">
+                      <span className="rounded bg-accent-500/20 px-2 py-0.5 text-xs text-accent-400">
                         {campaign.partner_name}
                       </span>
                     )}

--- a/src/pages/AdminChannelSubscriptions.tsx
+++ b/src/pages/AdminChannelSubscriptions.tsx
@@ -424,7 +424,7 @@ function AddChannelForm({
           <button
             onClick={handleSubmit}
             disabled={!channelId.trim() || isLoading}
-            className="flex items-center gap-2 rounded-lg bg-accent-500 px-4 py-2 text-sm text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex items-center gap-2 rounded-xl bg-accent-500 px-4 py-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <CheckIcon />
             {t('admin.channelSubscriptions.form.submit')}
@@ -499,7 +499,7 @@ function EditChannelForm({
           <button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="flex items-center gap-2 rounded-lg bg-accent-500 px-4 py-2 text-sm text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex items-center gap-2 rounded-xl bg-accent-500 px-4 py-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <CheckIcon />
             {t('admin.channelSubscriptions.form.save')}

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -293,7 +293,7 @@ export default function AdminDashboard() {
             </button>
           )}
           <div>
-            <h1 className="text-2xl font-bold text-dark-100">{t('adminDashboard.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('adminDashboard.title')}</h1>
             <p className="text-dark-400">{t('adminDashboard.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/AdminEmailTemplates.tsx
+++ b/src/pages/AdminEmailTemplates.tsx
@@ -523,7 +523,7 @@ export default function AdminEmailTemplates() {
             <MailIcon className="h-6 w-6" />
           </div>
           <div className="min-w-0">
-            <h1 className="truncate text-lg font-bold text-dark-100 sm:text-xl">
+            <h1 className="truncate text-xl font-bold text-dark-100 sm:text-xl">
               {t('admin.emailTemplates.title')}
             </h1>
             <p className="truncate text-xs text-dark-400">

--- a/src/pages/AdminInfoPageEditor.tsx
+++ b/src/pages/AdminInfoPageEditor.tsx
@@ -1027,7 +1027,7 @@ export default function AdminInfoPageEditor() {
         <button
           onClick={handleSave}
           disabled={saveMutation.isPending || !slug.trim()}
-          className="min-h-[44px] rounded-lg bg-accent-500 px-6 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-[44px] rounded-xl bg-accent-500 px-6 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {saveMutation.isPending ? t('admin.infoPages.saving') : t('admin.infoPages.save')}
         </button>
@@ -1415,7 +1415,7 @@ export default function AdminInfoPageEditor() {
         <button
           onClick={handleSave}
           disabled={saveMutation.isPending || !slug.trim()}
-          className="min-h-[44px] w-full rounded-lg bg-accent-500 py-3 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-[44px] w-full rounded-xl bg-accent-500 py-3 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {saveMutation.isPending ? t('admin.infoPages.saving') : t('admin.infoPages.save')}
         </button>

--- a/src/pages/AdminInfoPages.tsx
+++ b/src/pages/AdminInfoPages.tsx
@@ -59,7 +59,7 @@ const PageRow = memo(function PageRow({
               {page.is_active ? t('admin.infoPages.active') : t('admin.infoPages.inactive')}
             </span>
             {page.replaces_tab && (
-              <span className="rounded-full bg-purple-500/20 px-2 py-0.5 text-[10px] font-medium text-purple-400">
+              <span className="rounded-full bg-accent-500/20 px-2 py-0.5 text-[10px] font-medium text-accent-400">
                 {t(`admin.infoPages.replacesTabOptions.${page.replaces_tab}`)}
               </span>
             )}

--- a/src/pages/AdminLandingEditor.tsx
+++ b/src/pages/AdminLandingEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { PiCaretDown } from 'react-icons/pi';
+import { ChevronDownIcon as ChevronDownGlyph } from '@/components/icons';
 import { useNavigate, useParams } from 'react-router';
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -53,7 +53,7 @@ function isoToDatetimeLocal(iso: string): string {
 }
 
 const ChevronDownIcon = ({ open }: { open: boolean }) => (
-  <PiCaretDown className={cn('h-5 w-5 transition-transform', open && 'rotate-180')} />
+  <ChevronDownGlyph className={cn('h-5 w-5 transition-transform', open && 'rotate-180')} />
 );
 
 // ============ Collapsible Section ============
@@ -574,7 +574,7 @@ export default function AdminLandingEditor() {
               <BackIcon />
             </button>
           )}
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {isEdit ? t('admin.landings.edit') : t('admin.landings.create')}
           </h1>
         </div>

--- a/src/pages/AdminLandingStats.tsx
+++ b/src/pages/AdminLandingStats.tsx
@@ -147,7 +147,7 @@ function PurchaseCard({ item, formatPrice, lang, t }: PurchaseCardProps) {
         {/* Gift badge */}
         {item.is_gift && (
           <div className="shrink-0">
-            <span className="inline-flex items-center gap-1 rounded-md bg-purple-500/20 px-1.5 py-0.5 text-xs text-purple-400">
+            <span className="inline-flex items-center gap-1 rounded-md bg-accent-500/20 px-1.5 py-0.5 text-xs text-accent-400">
               <GiftIcon className="h-3.5 w-3.5" />
               {t('admin.landings.purchases.gift')}
             </span>
@@ -302,7 +302,7 @@ export default function AdminLandingStats() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/landings" />
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.landings.stats.title')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.landings.stats.title')}</h1>
         </div>
         <div className="rounded-xl border border-error-500/30 bg-error-500/10 p-6 text-center">
           <p className="text-error-400">{t('admin.landings.stats.loadError')}</p>
@@ -332,7 +332,7 @@ export default function AdminLandingStats() {
             <ChartIcon className="h-6 w-6" />
           </div>
           <div className="min-w-0">
-            <h1 className="truncate text-xl font-semibold text-dark-100">{landingTitle}</h1>
+            <h1 className="truncate text-xl font-bold text-dark-100">{landingTitle}</h1>
             <div className="mt-1 flex items-center gap-2">
               {landing?.is_active ? (
                 <span className="rounded bg-success-500/20 px-2 py-0.5 text-xs text-success-400">

--- a/src/pages/AdminLandings.tsx
+++ b/src/pages/AdminLandings.tsx
@@ -403,7 +403,7 @@ export default function AdminLandings() {
             </button>
           )}
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.landings.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.landings.title')}</h1>
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/src/pages/AdminNewsCreate.tsx
+++ b/src/pages/AdminNewsCreate.tsx
@@ -558,7 +558,7 @@ export default function AdminNewsCreate() {
         <button
           onClick={handleSave}
           disabled={saveMutation.isPending || !title.trim() || !slug.trim() || !selectedCategory}
-          className="min-h-[44px] rounded-lg bg-accent-500 px-6 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-[44px] rounded-xl bg-accent-500 px-6 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {saveMutation.isPending ? t('news.admin.saving') : t('news.admin.save')}
         </button>
@@ -912,7 +912,7 @@ export default function AdminNewsCreate() {
         <button
           onClick={handleSave}
           disabled={saveMutation.isPending || !title.trim() || !slug.trim() || !selectedCategory}
-          className="min-h-[44px] w-full rounded-lg bg-accent-500 py-3 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-[44px] w-full rounded-xl bg-accent-500 py-3 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {saveMutation.isPending ? t('news.admin.saving') : t('news.admin.save')}
         </button>

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -692,7 +692,7 @@ export default function AdminPanel() {
 
         {/* Hero + Search */}
         <div className="flex shrink-0 flex-wrap items-center gap-3">
-          <h1 className="text-lg font-bold tracking-tight text-dark-50 sm:text-xl light:text-champagne-900">
+          <h1 className="text-xl font-bold tracking-tight text-dark-100 sm:text-xl light:text-champagne-900">
             {t('admin.panel.title')}
           </h1>
           <div className="flex items-center gap-1.5 text-xs text-dark-400 light:text-champagne-500">

--- a/src/pages/AdminPartnerCampaignAssign.tsx
+++ b/src/pages/AdminPartnerCampaignAssign.tsx
@@ -50,7 +50,7 @@ export default function AdminPartnerCampaignAssign() {
       <div className="mb-6 flex items-center gap-3">
         <AdminBackButton to={`/admin/partners/${userId}`} />
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {t('admin.partnerDetail.campaigns.assignTitle')}
           </h1>
           {partnerName && <p className="text-sm text-dark-400">{partnerName}</p>}
@@ -118,7 +118,7 @@ export default function AdminPartnerCampaignAssign() {
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-dark-300">{campaign.name}</span>
-                    <span className="rounded bg-purple-500/20 px-1.5 py-0.5 text-xs text-purple-400">
+                    <span className="rounded bg-accent-500/20 px-1.5 py-0.5 text-xs text-accent-400">
                       {campaign.partner_name}
                     </span>
                   </div>

--- a/src/pages/AdminPartnerCommission.tsx
+++ b/src/pages/AdminPartnerCommission.tsx
@@ -46,7 +46,7 @@ export default function AdminPartnerCommission() {
       {/* Header */}
       <div className="mb-6 flex items-center gap-3">
         <AdminBackButton to={`/admin/partners/${userId}`} />
-        <h1 className="text-xl font-semibold text-dark-100">
+        <h1 className="text-xl font-bold text-dark-100">
           {t('admin.partnerDetail.commissionDialog.title')}
         </h1>
       </div>

--- a/src/pages/AdminPartnerDetail.tsx
+++ b/src/pages/AdminPartnerDetail.tsx
@@ -85,7 +85,7 @@ export default function AdminPartnerDetail() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/partners" />
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.partnerDetail.title')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.partnerDetail.title')}</h1>
         </div>
         <div className="rounded-xl border border-error-500/30 bg-error-500/10 p-6 text-center">
           <p className="text-error-400">{t('admin.partnerDetail.loadError')}</p>
@@ -109,7 +109,7 @@ export default function AdminPartnerDetail() {
         <AdminBackButton to="/admin/partners" />
         <div>
           <div className="flex items-center gap-2">
-            <h1 className="text-xl font-semibold text-dark-100">
+            <h1 className="text-xl font-bold text-dark-100">
               {partner.first_name || partner.username || `#${partner.user_id}`}
             </h1>
             <span className={`rounded px-2 py-0.5 text-xs ${badge.bgColor} ${badge.color}`}>

--- a/src/pages/AdminPartnerRevoke.tsx
+++ b/src/pages/AdminPartnerRevoke.tsx
@@ -25,7 +25,7 @@ export default function AdminPartnerRevoke() {
       {/* Header */}
       <div className="mb-6 flex items-center gap-3">
         <AdminBackButton to={`/admin/partners/${userId}`} />
-        <h1 className="text-xl font-semibold text-dark-100">
+        <h1 className="text-xl font-bold text-dark-100">
           {t('admin.partnerDetail.revokeDialog.title')}
         </h1>
       </div>

--- a/src/pages/AdminPartnerSettings.tsx
+++ b/src/pages/AdminPartnerSettings.tsx
@@ -95,7 +95,7 @@ export default function AdminPartnerSettings() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/partners" />
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.partners.settings')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.partners.settings')}</h1>
         </div>
         <div className="rounded-xl border border-error-500/30 bg-error-500/10 p-6 text-center">
           <p className="text-error-400">{t('admin.partners.settingsLoadError')}</p>
@@ -119,7 +119,7 @@ export default function AdminPartnerSettings() {
           <SettingsIcon className="h-6 w-6" />
         </div>
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.partners.settings')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.partners.settings')}</h1>
           <p className="text-sm text-dark-400">{t('admin.partners.settingsSubtitle')}</p>
         </div>
       </div>

--- a/src/pages/AdminPartners.tsx
+++ b/src/pages/AdminPartners.tsx
@@ -51,7 +51,7 @@ export default function AdminPartners() {
       <div className="mb-6 flex items-center gap-3">
         <AdminBackButton to="/admin" />
         <div className="flex-1">
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.partners.title')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.partners.title')}</h1>
           <p className="text-sm text-dark-400">{t('admin.partners.subtitle')}</p>
         </div>
         <button

--- a/src/pages/AdminPaymentMethodEdit.tsx
+++ b/src/pages/AdminPaymentMethodEdit.tsx
@@ -170,7 +170,7 @@ export default function AdminPaymentMethodEdit() {
               <BackIcon />
             </button>
           )}
-          <h1 className="text-2xl font-bold text-dark-50">
+          <h1 className="text-xl font-bold text-dark-100">
             {t('admin.paymentMethods.notFound', 'Payment method not found')}
           </h1>
         </div>
@@ -194,7 +194,7 @@ export default function AdminPaymentMethodEdit() {
           </button>
         )}
         <div>
-          <h1 className="text-2xl font-bold text-dark-50">{displayName}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{displayName}</h1>
           <p className="text-sm text-dark-500">
             {METHOD_LABELS[config.method_id] || config.method_id}
           </p>

--- a/src/pages/AdminPolicies.tsx
+++ b/src/pages/AdminPolicies.tsx
@@ -221,7 +221,7 @@ export default function AdminPolicies() {
             </button>
           )}
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.policies.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.policies.title')}</h1>
             <p className="text-sm text-dark-400">{t('admin.policies.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/AdminPolicyEdit.tsx
+++ b/src/pages/AdminPolicyEdit.tsx
@@ -381,7 +381,7 @@ export default function AdminPolicyEdit() {
       <div className="flex items-center gap-3">
         <AdminBackButton to="/admin/policies" />
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {isEdit ? t('admin.policies.modal.editTitle') : t('admin.policies.modal.createTitle')}
           </h1>
         </div>

--- a/src/pages/AdminPolicyEdit.tsx
+++ b/src/pages/AdminPolicyEdit.tsx
@@ -757,7 +757,7 @@ export default function AdminPolicyEdit() {
             <button
               type="submit"
               disabled={isSaving}
-              className="rounded-lg bg-accent-500 px-4 py-2 text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
+              className="rounded-xl bg-accent-500 px-4 py-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
             >
               {isSaving ? t('admin.policies.form.saving') : t('admin.policies.form.save')}
             </button>

--- a/src/pages/AdminPromoGroups.tsx
+++ b/src/pages/AdminPromoGroups.tsx
@@ -59,7 +59,7 @@ export default function AdminPromoGroups() {
             </button>
           )}
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.promoGroups.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.promoGroups.title')}</h1>
             <p className="text-sm text-dark-400">{t('admin.promoGroups.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/AdminPromoOfferSend.tsx
+++ b/src/pages/AdminPromoOfferSend.tsx
@@ -226,9 +226,7 @@ export default function AdminPromoOfferSend() {
           <div className="rounded-lg bg-accent-500/20 p-2">
             <SendIcon />
           </div>
-          <h1 className="text-xl font-semibold text-dark-100">
-            {t('admin.promoOffers.send.title')}
-          </h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.promoOffers.send.title')}</h1>
         </div>
       </div>
 

--- a/src/pages/AdminPromoOfferTemplateEdit.tsx
+++ b/src/pages/AdminPromoOfferTemplateEdit.tsx
@@ -109,7 +109,7 @@ export default function AdminPromoOfferTemplateEdit() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/promo-offers" />
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {t('admin.promoOffers.form.editTemplate')}
           </h1>
         </div>
@@ -127,7 +127,7 @@ export default function AdminPromoOfferTemplateEdit() {
         <AdminBackButton to="/admin/promo-offers" />
         <div className="flex items-center gap-3">
           <span className="text-2xl">{getOfferTypeIcon(template.offer_type)}</span>
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {t('admin.promoOffers.form.editTemplate')}
           </h1>
         </div>

--- a/src/pages/AdminPromoOffers.tsx
+++ b/src/pages/AdminPromoOffers.tsx
@@ -87,7 +87,7 @@ export default function AdminPromoOffers() {
             </button>
           )}
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.promoOffers.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.promoOffers.title')}</h1>
             <p className="text-sm text-dark-400">{t('admin.promoOffers.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/AdminPromocodeStats.tsx
+++ b/src/pages/AdminPromocodeStats.tsx
@@ -32,7 +32,7 @@ const getTypeColor = (type: PromoCodeType): string => {
     subscription_days: 'bg-accent-500/20 text-accent-400',
     trial_subscription: 'bg-accent-500/20 text-accent-400',
     promo_group: 'bg-warning-500/20 text-warning-400',
-    discount: 'bg-pink-500/20 text-pink-400',
+    discount: 'bg-error-500/20 text-error-400',
   };
   return colors[type] || 'bg-dark-600 text-dark-300';
 };
@@ -89,9 +89,7 @@ export default function AdminPromocodeStats() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/promocodes" />
-          <h1 className="text-xl font-semibold text-dark-100">
-            {t('admin.promocodes.stats.title')}
-          </h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.promocodes.stats.title')}</h1>
         </div>
         <div className="py-12 text-center">
           <p className="text-error-400">{t('admin.promocodes.stats.notFound')}</p>
@@ -183,11 +181,11 @@ export default function AdminPromocodeStats() {
                   <span className="text-dark-400">
                     {t('admin.promocodes.stats.discountLabel')}:
                   </span>
-                  <span className="text-pink-400">-{promocode.balance_bonus_kopeks}%</span>
+                  <span className="text-error-400">-{promocode.balance_bonus_kopeks}%</span>
                 </div>
                 <div className="flex justify-between rounded-lg bg-dark-700/50 p-3">
                   <span className="text-dark-400">{t('admin.promocodes.stats.validFor')}:</span>
-                  <span className="text-pink-400">
+                  <span className="text-error-400">
                     {t('admin.promocodes.stats.hoursValue', {
                       count: promocode.subscription_days,
                     })}

--- a/src/pages/AdminPromocodes.tsx
+++ b/src/pages/AdminPromocodes.tsx
@@ -39,7 +39,7 @@ const getTypeColor = (type: PromoCodeType): string => {
     subscription_days: 'bg-accent-500/20 text-accent-400',
     trial_subscription: 'bg-accent-500/20 text-accent-400',
     promo_group: 'bg-warning-500/20 text-warning-400',
-    discount: 'bg-pink-500/20 text-pink-400',
+    discount: 'bg-error-500/20 text-error-400',
   };
   return colors[type] || 'bg-dark-600 text-dark-300';
 };
@@ -206,7 +206,7 @@ export default function AdminPromocodes() {
                       </span>
                     )}
                     {promo.type === 'discount' && (
-                      <span className="text-pink-400">
+                      <span className="text-error-400">
                         {t('admin.promocodes.discountForHours', {
                           percent: promo.balance_bonus_kopeks,
                           hours: promo.subscription_days,

--- a/src/pages/AdminRemnawave.tsx
+++ b/src/pages/AdminRemnawave.tsx
@@ -1549,7 +1549,7 @@ export default function AdminRemnawave() {
             <RemnawaveIcon className="h-6 w-6 text-accent-400" />
           </div>
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">
+            <h1 className="text-xl font-bold text-dark-100">
               {t('admin.remnawave.title', 'Remnawave')}
             </h1>
             <p className="text-sm text-dark-400">

--- a/src/pages/AdminRemnawaveSquadDetail.tsx
+++ b/src/pages/AdminRemnawaveSquadDetail.tsx
@@ -45,7 +45,7 @@ export default function AdminRemnawaveSquadDetail() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/remnawave" />
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {t('admin.remnawave.squads.detail', 'Squad Details')}
           </h1>
         </div>
@@ -76,7 +76,7 @@ export default function AdminRemnawaveSquadDetail() {
           </div>
         </div>
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             <Twemoji options={{ className: 'twemoji', folder: 'svg', ext: '.svg' }}>
               {squad.display_name || squad.name}
             </Twemoji>

--- a/src/pages/AdminRoleAssign.tsx
+++ b/src/pages/AdminRoleAssign.tsx
@@ -346,7 +346,7 @@ export default function AdminRoleAssign() {
           </button>
         )}
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.roleAssign.title')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.roleAssign.title')}</h1>
           <p className="text-sm text-dark-400">{t('admin.roleAssign.subtitle')}</p>
         </div>
       </div>

--- a/src/pages/AdminRoleAssign.tsx
+++ b/src/pages/AdminRoleAssign.tsx
@@ -432,7 +432,7 @@ export default function AdminRoleAssign() {
               <button
                 type="submit"
                 disabled={assignMutation.isPending || !selectedUser || !selectedRoleId}
-                className="flex items-center gap-2 rounded-lg bg-accent-500 px-5 py-2 text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex items-center gap-2 rounded-xl bg-accent-500 px-5 py-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {assignMutation.isPending
                   ? t('admin.roleAssign.assigning')

--- a/src/pages/AdminRoleEdit.tsx
+++ b/src/pages/AdminRoleEdit.tsx
@@ -364,7 +364,7 @@ export default function AdminRoleEdit() {
       <div className="flex items-center gap-3">
         <AdminBackButton to="/admin/roles" />
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {isEdit ? t('admin.roles.modal.editTitle') : t('admin.roles.modal.createTitle')}
           </h1>
         </div>

--- a/src/pages/AdminRoleEdit.tsx
+++ b/src/pages/AdminRoleEdit.tsx
@@ -514,7 +514,7 @@ export default function AdminRoleEdit() {
             <button
               type="submit"
               disabled={isSaving}
-              className="rounded-lg bg-accent-500 px-4 py-2 text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
+              className="rounded-xl bg-accent-500 px-4 py-2 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600 disabled:opacity-50"
             >
               {isSaving ? t('admin.roles.form.saving') : t('admin.roles.form.save')}
             </button>

--- a/src/pages/AdminRoles.tsx
+++ b/src/pages/AdminRoles.tsx
@@ -74,7 +74,7 @@ export default function AdminRoles() {
             </button>
           )}
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.roles.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.roles.title')}</h1>
             <p className="text-sm text-dark-400">{t('admin.roles.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/AdminSalesStats.tsx
+++ b/src/pages/AdminSalesStats.tsx
@@ -149,9 +149,7 @@ export default function AdminSalesStats() {
       <div className="flex items-center gap-3">
         <AdminBackButton />
         <div>
-          <h1 className="text-xl font-bold text-dark-100 sm:text-2xl">
-            {t('admin.salesStats.title')}
-          </h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.salesStats.title')}</h1>
           <p className="text-sm text-dark-400">{t('admin.salesStats.subtitle')}</p>
         </div>
       </div>

--- a/src/pages/AdminServerEdit.tsx
+++ b/src/pages/AdminServerEdit.tsx
@@ -80,7 +80,7 @@ export default function AdminServerEdit() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/servers" />
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.servers.edit')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.servers.edit')}</h1>
         </div>
         <div className="rounded-xl border border-error-500/30 bg-error-500/10 p-6 text-center">
           <p className="text-error-400">{t('admin.servers.loadError')}</p>
@@ -107,7 +107,7 @@ export default function AdminServerEdit() {
           </div>
         </div>
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.servers.edit')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.servers.edit')}</h1>
           <p className="text-sm text-dark-400">
             <Twemoji options={{ className: 'twemoji', folder: 'svg', ext: '.svg' }}>
               {server.display_name}

--- a/src/pages/AdminServers.tsx
+++ b/src/pages/AdminServers.tsx
@@ -69,7 +69,7 @@ export default function AdminServers() {
             </button>
           )}
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.servers.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.servers.title')}</h1>
             <p className="text-sm text-dark-400">{t('admin.servers.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/AdminSettings.tsx
+++ b/src/pages/AdminSettings.tsx
@@ -282,7 +282,7 @@ export default function AdminSettings() {
 
           {/* Title + count badges */}
           <div className="mb-4 flex items-center gap-3">
-            <h2 className="truncate text-xl font-semibold text-dark-100">{sectionTitle}</h2>
+            <h2 className="truncate text-lg font-semibold text-dark-100">{sectionTitle}</h2>
             {totalCount > 0 && !searchQuery.trim() && activeTreeInfo && (
               <div className="flex items-center gap-2">
                 <span className="rounded-full bg-dark-700/50 px-2 py-0.5 text-xs text-dark-400">

--- a/src/pages/AdminTariffs.tsx
+++ b/src/pages/AdminTariffs.tsx
@@ -104,7 +104,7 @@ function SortableTariffCard({
                   </span>
                 )}
                 {tariff.show_in_gift && (
-                  <span className="inline-flex items-center gap-1 rounded bg-purple-500/20 px-2 py-0.5 text-xs text-purple-400">
+                  <span className="inline-flex items-center gap-1 rounded bg-accent-500/20 px-2 py-0.5 text-xs text-accent-400">
                     <GiftIcon className="h-3 w-3" />
                     {t('admin.tariffs.giftBadge')}
                   </span>

--- a/src/pages/AdminTicketSettings.tsx
+++ b/src/pages/AdminTicketSettings.tsx
@@ -101,7 +101,7 @@ export default function AdminTicketSettings() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/tickets" />
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.tickets.settings')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.tickets.settings')}</h1>
         </div>
         <div className="rounded-xl border border-error-500/30 bg-error-500/10 p-6 text-center">
           <p className="text-error-400">{t('admin.tickets.settingsLoadError')}</p>
@@ -125,7 +125,7 @@ export default function AdminTicketSettings() {
           <SettingsIcon className="h-6 w-6" />
         </div>
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">{t('admin.tickets.settings')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.tickets.settings')}</h1>
           <p className="text-sm text-dark-400">{t('admin.tickets.settingsSubtitle')}</p>
         </div>
       </div>

--- a/src/pages/AdminUpdates.tsx
+++ b/src/pages/AdminUpdates.tsx
@@ -131,7 +131,7 @@ function ReleaseCard({ release }: { release: ReleaseItem }) {
           <span className="text-sm text-dark-400">{release.name}</span>
         )}
         {release.prerelease && (
-          <span className="rounded-full bg-violet-500/20 px-2 py-0.5 text-[10px] font-medium text-violet-400">
+          <span className="rounded-full bg-accent-500/20 px-2 py-0.5 text-[10px] font-medium text-accent-400">
             {t('adminUpdates.prerelease')}
           </span>
         )}

--- a/src/pages/AdminWheel.tsx
+++ b/src/pages/AdminWheel.tsx
@@ -393,7 +393,7 @@ export default function AdminWheel() {
               <BackIcon />
             </button>
           )}
-          <h1 className="text-xl font-bold text-dark-50 sm:text-2xl">{t('admin.wheel.title')}</h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.wheel.title')}</h1>
         </div>
         <div className="flex items-center gap-2">
           <span

--- a/src/pages/AdminWithdrawalDetail.tsx
+++ b/src/pages/AdminWithdrawalDetail.tsx
@@ -72,9 +72,7 @@ export default function AdminWithdrawalDetail() {
       <div className="animate-fade-in">
         <div className="mb-6 flex items-center gap-3">
           <AdminBackButton to="/admin/withdrawals" />
-          <h1 className="text-xl font-semibold text-dark-100">
-            {t('admin.withdrawals.detail.title')}
-          </h1>
+          <h1 className="text-xl font-bold text-dark-100">{t('admin.withdrawals.detail.title')}</h1>
         </div>
         <div className="rounded-xl border border-error-500/30 bg-error-500/10 p-6 text-center">
           <p className="text-error-400">{t('admin.withdrawals.detail.loadError')}</p>
@@ -106,7 +104,7 @@ export default function AdminWithdrawalDetail() {
         <div className="flex items-center gap-3">
           <AdminBackButton to="/admin/withdrawals" />
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">
+            <h1 className="text-xl font-bold text-dark-100">
               {t('admin.withdrawals.detail.title')} #{detail.id}
             </h1>
             <div className="mt-1 flex items-center gap-2">

--- a/src/pages/AdminWithdrawalReject.tsx
+++ b/src/pages/AdminWithdrawalReject.tsx
@@ -43,7 +43,7 @@ export default function AdminWithdrawalReject() {
       <div className="mb-6 flex items-center gap-3">
         <AdminBackButton to={`/admin/withdrawals/${id}`} />
         <div>
-          <h1 className="text-xl font-semibold text-dark-100">
+          <h1 className="text-xl font-bold text-dark-100">
             {t('admin.withdrawals.detail.rejectTitle')}
           </h1>
           {passedDetail?.amountKopeks != null && passedDetail.amountKopeks > 0 && (

--- a/src/pages/AdminWithdrawals.tsx
+++ b/src/pages/AdminWithdrawals.tsx
@@ -49,7 +49,7 @@ export default function AdminWithdrawals() {
         <div className="flex items-center gap-3">
           <AdminBackButton to="/admin" />
           <div>
-            <h1 className="text-xl font-semibold text-dark-100">{t('admin.withdrawals.title')}</h1>
+            <h1 className="text-xl font-bold text-dark-100">{t('admin.withdrawals.title')}</h1>
             <p className="text-sm text-dark-400">{t('admin.withdrawals.subtitle')}</p>
           </div>
         </div>

--- a/src/pages/ConnectionQR.tsx
+++ b/src/pages/ConnectionQR.tsx
@@ -42,7 +42,7 @@ export default function ConnectionQR() {
     <div className="animate-fade-in">
       <div className="mb-6 flex items-center gap-3">
         <AdminBackButton to={connectionPath} replace />
-        <h1 className="text-2xl font-bold text-dark-100">{t('subscription.connection.qrTitle')}</h1>
+        <h1 className="text-2xl font-bold text-dark-50">{t('subscription.connection.qrTitle')}</h1>
       </div>
 
       <div className="flex flex-col items-center">

--- a/src/pages/Contests.tsx
+++ b/src/pages/Contests.tsx
@@ -85,7 +85,7 @@ export default function Contests() {
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 flex items-center justify-between">
-              <h2 className="text-xl font-bold">{selectedContest.name}</h2>
+              <h2 className="text-lg font-semibold">{selectedContest.name}</h2>
               <button onClick={handleCloseGame} className="text-dark-400 hover:text-dark-200">
                 <XIcon className="h-6 w-6" />
               </button>

--- a/src/pages/GiftClaim.tsx
+++ b/src/pages/GiftClaim.tsx
@@ -111,7 +111,7 @@ export default function GiftClaim() {
     return (
       <Shell>
         <div className="flex flex-col items-center gap-3 py-6 text-center">
-          <h1 className="text-lg font-semibold text-dark-50">
+          <h1 className="text-2xl font-bold text-dark-50">
             {t('landing.giftClaim.notFoundTitle', 'Gift not found')}
           </h1>
           <p className="text-sm text-dark-400">
@@ -147,7 +147,7 @@ export default function GiftClaim() {
     return (
       <Shell>
         <div className="flex flex-col items-center gap-3 py-6 text-center">
-          <h1 className="text-lg font-semibold text-dark-50">
+          <h1 className="text-2xl font-bold text-dark-50">
             {t('landing.giftClaim.failedTitle', 'Gift unavailable')}
           </h1>
           <p className="text-sm text-dark-400">
@@ -210,7 +210,7 @@ export default function GiftClaim() {
       <Shell>
         <div className="flex flex-col items-center gap-4 py-6 text-center">
           <Spinner className="h-12 w-12 border-[3px]" />
-          <h1 className="text-lg font-semibold text-dark-50">
+          <h1 className="text-2xl font-bold text-dark-50">
             {t('landing.giftClaim.pendingTitle', 'Almost ready...')}
           </h1>
           <p className="text-sm text-dark-400">

--- a/src/pages/GiftSubscription.tsx
+++ b/src/pages/GiftSubscription.tsx
@@ -774,7 +774,7 @@ function ActivateTabContent({ initialCode }: { initialCode?: string | null }) {
         <div className="flex h-16 w-16 items-center justify-center rounded-full bg-accent-500/20">
           <CheckCircleIcon className="h-8 w-8 text-accent-400" />
         </div>
-        <h2 className="text-xl font-bold text-dark-50">{t('gift.activateSuccess')}</h2>
+        <h2 className="text-lg font-semibold text-dark-50">{t('gift.activateSuccess')}</h2>
         <p className="text-sm text-dark-300">
           {t('gift.activateSuccessDesc', {
             tariff: result.tariff_name ?? '',
@@ -792,7 +792,7 @@ function ActivateTabContent({ initialCode }: { initialCode?: string | null }) {
         <div className="flex h-16 w-16 items-center justify-center rounded-full bg-accent-500/20">
           <KeyIcon className="h-8 w-8 text-accent-400" />
         </div>
-        <h2 className="text-xl font-bold text-dark-50">{t('gift.activateTitle')}</h2>
+        <h2 className="text-lg font-semibold text-dark-50">{t('gift.activateTitle')}</h2>
         <p className="max-w-xs text-sm text-dark-400">{t('gift.activateDescription')}</p>
       </div>
 

--- a/src/pages/Info.tsx
+++ b/src/pages/Info.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { PiCaretDown } from 'react-icons/pi';
+import { ChevronDownIcon } from '@/components/icons';
 import DOMPurify from 'dompurify';
 import { infoApi, FaqPage, InfoVisibility } from '../api/info';
 import { infoPagesApi } from '../api/infoPages';
@@ -10,7 +10,7 @@ import type { FaqItem, ReplacesTab } from '../api/infoPages';
 import { DocumentIcon, InfoIcon, QuestionIcon, ShieldIcon, StarIcon } from '@/components/icons';
 
 const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
-  <PiCaretDown className={`h-5 w-5 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+  <ChevronDownIcon className={`h-5 w-5 transition-transform ${expanded ? 'rotate-180' : ''}`} />
 );
 
 const BUILTIN_TABS = new Set<string>(['faq', 'rules', 'privacy', 'offer', 'loyalty']);

--- a/src/pages/InfoPageView.tsx
+++ b/src/pages/InfoPageView.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
-import { PiCaretDown } from 'react-icons/pi';
+import { ChevronDownIcon } from '@/components/icons';
 import { BackIcon, SearchIcon } from '@/components/icons';
 import { infoPagesApi } from '../api/infoPages';
 import { usePlatform } from '../platform/hooks/usePlatform';
@@ -160,7 +160,7 @@ function sanitizeHtml(html: string): string {
 
 // --- FAQ Accordion ---
 const ChevronIcon = ({ open }: { open: boolean }) => (
-  <PiCaretDown
+  <ChevronDownIcon
     className={`h-5 w-5 text-dark-400 transition-transform duration-300 ${open ? 'rotate-180' : ''}`}
   />
 );
@@ -391,7 +391,7 @@ export default function InfoPageView() {
       {/* Page header */}
       <div>
         {page.icon && <span className="mb-2 inline-block text-3xl">{page.icon}</span>}
-        <h1 className="text-2xl leading-tight font-extrabold text-dark-50 sm:text-3xl">
+        <h1 className="text-2xl leading-tight font-bold text-dark-50 sm:text-3xl">
           {resolvedTitle}
         </h1>
       </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -376,7 +376,7 @@ export default function Login() {
             <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-success-500/20">
               <EmailIcon className="h-7 w-7 text-success-400" />
             </div>
-            <h2 className="mb-2 text-lg font-bold text-dark-50">
+            <h2 className="mb-2 text-lg font-semibold text-dark-50">
               {t('auth.checkEmail', 'Check your email')}
             </h2>
             <p className="mb-3 text-sm text-dark-400">

--- a/src/pages/NewsArticle.tsx
+++ b/src/pages/NewsArticle.tsx
@@ -346,7 +346,7 @@ export default function NewsArticlePage() {
         </div>
 
         {/* Title */}
-        <h1 className="mb-4 text-2xl leading-tight font-extrabold text-dark-50 sm:text-3xl">
+        <h1 className="mb-4 text-2xl leading-tight font-bold text-dark-50 sm:text-3xl">
           {article.title}
         </h1>
 

--- a/src/pages/Referral.tsx
+++ b/src/pages/Referral.tsx
@@ -226,7 +226,7 @@ export default function Referral() {
           <UsersIcon className="h-12 w-12 text-dark-500" />
         </div>
         <div className="text-center">
-          <h1 className="mb-2 text-2xl font-bold text-dark-100">{t('referral.title')}</h1>
+          <h1 className="mb-2 text-2xl font-bold text-dark-50">{t('referral.title')}</h1>
           <p className="text-dark-400">{t('referral.disabled')}</p>
         </div>
       </div>

--- a/src/pages/ReferralNetwork/ReferralNetwork.tsx
+++ b/src/pages/ReferralNetwork/ReferralNetwork.tsx
@@ -54,7 +54,7 @@ export function ReferralNetwork() {
         <div className="flex flex-col gap-1.5 px-3 py-2 sm:flex-row sm:items-center sm:gap-3 sm:px-4 sm:py-3">
           <div className="flex items-center gap-2">
             <AdminBackButton />
-            <h1 className="shrink-0 text-sm font-bold text-dark-100 sm:text-base">
+            <h1 className="shrink-0 text-base font-bold text-dark-50 sm:text-lg">
               {t('admin.referralNetwork.title')}
             </h1>
           </div>

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -67,7 +67,7 @@ export default function ResetPassword() {
         <div className="relative w-full max-w-md text-center">
           <div className="card">
             <div className="mb-4 text-5xl text-error-400">!</div>
-            <h2 className="mb-2 text-xl font-semibold text-dark-50">
+            <h2 className="mb-2 text-lg font-semibold text-dark-50">
               {t('resetPassword.invalidToken', 'Invalid reset link')}
             </h2>
             <p className="mb-6 text-dark-400">
@@ -100,7 +100,7 @@ export default function ResetPassword() {
               <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-success-500/20">
                 <CheckIcon className="h-8 w-8 text-success-400" />
               </div>
-              <h2 className="mb-2 text-xl font-bold text-dark-50">
+              <h2 className="mb-2 text-lg font-semibold text-dark-50">
                 {t('resetPassword.success', 'Password changed!')}
               </h2>
               <p className="mb-4 text-dark-400">
@@ -110,7 +110,7 @@ export default function ResetPassword() {
             </div>
           ) : (
             <>
-              <h2 className="mb-2 text-center text-xl font-bold text-dark-50">
+              <h2 className="mb-2 text-center text-lg font-semibold text-dark-50">
                 {t('resetPassword.title', 'Set new password')}
               </h2>
               <p className="mb-6 text-center text-dark-400">

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -507,7 +507,7 @@ export default function Subscription() {
     return (
       <div className="mx-auto max-w-lg p-4 text-center">
         <div className="mb-4 text-4xl">😕</div>
-        <h2 className="mb-2 text-xl font-bold text-dark-50">
+        <h2 className="mb-2 text-lg font-semibold text-dark-50">
           {t('subscription.notFound', 'Подписка не найдена')}
         </h2>
         <p className="mb-4 text-sm text-dark-50/60">
@@ -592,7 +592,7 @@ export default function Subscription() {
                   </div>
 
                   {/* Plan name */}
-                  <h2 className="text-lg font-bold tracking-tight text-dark-50">
+                  <h2 className="text-lg font-semibold tracking-tight text-dark-50">
                     {subscription.tariff_name || t('subscription.currentPlan')}
                   </h2>
                 </div>

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -268,7 +268,7 @@ export default function Support() {
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-dark-800">
             <ChatIcon className="h-8 w-8 text-dark-400" />
           </div>
-          <h2 className="mb-2 text-xl font-semibold text-dark-100">{supportMessage.title}</h2>
+          <h2 className="mb-2 text-lg font-semibold text-dark-100">{supportMessage.title}</h2>
           <p className="mb-6 text-dark-400">{supportMessage.message}</p>
           <Button onClick={supportMessage.buttonAction} fullWidth>
             {supportMessage.buttonText}

--- a/src/pages/Wheel.tsx
+++ b/src/pages/Wheel.tsx
@@ -10,13 +10,13 @@ import { Card } from '@/components/data-display/Card/Card';
 import { Button } from '@/components/primitives/Button/Button';
 import { motion, AnimatePresence } from 'framer-motion';
 import { staggerContainer, staggerItem } from '@/components/motion/transitions';
-import { PiCaretDown } from 'react-icons/pi';
+import { ChevronDownIcon } from '@/components/icons';
 import { StarIcon, CalendarIcon, HistoryIcon, CloseIcon } from '@/components/icons';
 import { cn } from '@/lib/utils';
 
 // Icons
 const ChevronIcon = ({ expanded }: { expanded: boolean }) => (
-  <PiCaretDown
+  <ChevronDownIcon
     className={cn('h-5 w-5 transition-transform duration-200', expanded && 'rotate-180')}
   />
 );
@@ -488,7 +488,7 @@ export default function Wheel() {
           <span className="text-5xl">🎡</span>
         </div>
         <div className="text-center">
-          <h1 className="mb-2 text-2xl font-bold text-dark-100">{t('wheel.title')}</h1>
+          <h1 className="mb-2 text-2xl font-bold text-dark-50">{t('wheel.title')}</h1>
           <p className="text-dark-400">{t('wheel.disabled')}</p>
         </div>
       </div>

--- a/src/pages/Wheel.tsx
+++ b/src/pages/Wheel.tsx
@@ -632,7 +632,7 @@ export default function Wheel() {
                     </button>
                     <button
                       onClick={handleDirectStarsPay}
-                      className="rounded-lg bg-accent-500 px-4 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600"
+                      className="rounded-xl bg-accent-500 px-4 py-2.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-600"
                     >
                       {t('wheel.payStars', { count: config.spin_cost_stars ?? 0 })}
                     </button>


### PR DESCRIPTION
Поверх #458 (миграция Tailwind v4). Вливать после неё (или сменить base на dev, когда #458 смержится).

## Перепись и нормализация

Прогнал программную перепись всех стилевых паттернов src и привёл выбросы к канону:

### Типографика
- **47 заголовков** с `font-semibold`/`font-extrabold` и пляской размеров (`text-sm`…`text-3xl`) приведены к двум канонам: юзер-страницы `text-2xl font-bold text-dark-50 sm:text-3xl`, админка `text-xl font-bold text-dark-100` (57 файлов). Исключение — hero гостевого лендинга QuickPurchase.
- H2 секций: `text-lg font-semibold`.

### Цвета
- 56 употреблений стоковых tailwind-цветов мимо операторской палитры (purple/pink/rose/violet/sky/gray в 16 файлах — админ-плитки, модалка успеха, плейсхолдеры) → токены `accent`/`error`/`dark`.
- Бренд-исключения сохранены осознанно: Telegram-синий (логин-кнопки, мокап чата в превью рассылок), золото Telegram Stars на топапе.

### Иконки
- Все 9 прямых импортов `react-icons/pi` → баррель `@/components/icons`. Рукописные `<svg>` остались только у бренд-логотипов (платёжки, OAuth, Telegram) и декоративных фонов.

### Прочее
- `tailwind-merge` 3.4 → 3.6 (корректное слияние свежих v4-утилит в `cn()`).
- **Дизайн-канон записан в CLAUDE.md** — типографика, запрет стоковых цветов и сырых хексов, `text-on-*` вместо `text-white`, трёхуровневая иерархия радиусов (bento 24px — карточки страниц / 2xl — панели / xl — контролы), btn-классы, иконки. Теперь каждое ревью PR держит к этому канону.

## Проверено
- Рендер юзер- и админ-страниц в тёмной теме после правок
- tsc / eslint / build зелёные
- Радиусы НЕ переколачивались массово: перепись показала, что иерархия bento/2xl/xl уже существует и осмысленна — она зафиксирована как норма вместо слепой унификации.