### PR TITLE
feat: причина отклонения платежа на карточке (админ-панель)

### DIFF
--- a/src/pages/AdminPayments.tsx
+++ b/src/pages/AdminPayments.tsx
@@ -438,6 +438,14 @@ export default function AdminPayments() {
                         <code className="font-mono text-accent-400">{payment.identifier}</code>
                       </div>
 
+                      {/* Decline reason */}
+                      {payment.decline_reason && (
+                        <div className="mt-1.5 flex items-start gap-1.5 rounded-lg bg-red-500/10 px-2.5 py-1.5 text-xs text-red-300">
+                          <span className="shrink-0">⚠️</span>
+                          <span>{payment.decline_reason}</span>
+                        </div>
+                      )}
+
                       {/* User info */}
                       {(payment.user_username ||
                         payment.user_telegram_id ||

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -618,6 +618,7 @@ export interface PendingPayment {
   user_telegram_id?: number;
   user_username?: string | null;
   user_email?: string | null;
+  decline_reason?: string | null;
 }
 
 export interface ManualCheckResponse {


### PR DESCRIPTION
## Что

Показывает причину отклонения платежа красным блоком под номером счёта на карточке в `admin/payments`. Текст из нового поля `decline_reason` ответа API.

## Зачем

Оператор сразу видит **почему платёж отклонён** — особенно для рекуррентных автосписаний:
- ⚠️ Insufficient funds on customer account (код 20105)
- ⚠️ Payment ID already exists (код 3041)

Раньше причину можно было узнать только из БД.

## Изменения

- `AdminPayments.tsx`: условный красный блок с ⚠️ под Invoice ID (показывается только если `decline_reason` есть)
- `types/index.ts`: `decline_reason?: string | null` в `PendingPayment`

Требует бэкенд-часть: BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#3015---

### 🔗 Связанные PR (EtoPlatezhi / платежи)

Части общей работы над платежами/рекуррентами EtoPlatezhi, ревьюятся независимо:

**Бот:** #2949 (recurring движок + EtoPlatezhi) · #3014 (white-label описание метода) · #3015 (причина отклонения)
**Кабинет:** smediainfo/bedolaga-cabinet#433 (recurring consent gate) · #465 (white-label UI) · #466 (причина отклонения UI)