### PR TITLE
fix(ui): stagger-анимация скрывала контент, пришедший из API после монтирования (пустые страницы после F5)

### DIFF
--- a/src/pages/Balance.tsx
+++ b/src/pages/Balance.tsx
@@ -308,9 +308,11 @@ export default function Balance() {
         </Card>
       </motion.div>
 
-      {/* Payment Methods */}
+      {/* Payment Methods — self-animated: mounts after its query resolves, when
+          the parent stagger orchestration has already finished and would leave
+          it stuck at opacity 0 */}
       {paymentMethods && paymentMethods.length > 0 && (
-        <motion.div variants={staggerItem}>
+        <motion.div variants={staggerItem} initial="initial" animate="animate">
           <Card>
             <h2 className="mb-4 text-lg font-semibold text-dark-100">
               {t('balance.topUpBalance')}
@@ -474,9 +476,10 @@ export default function Balance() {
         </Card>
       </motion.div>
 
-      {/* Saved Cards Navigation */}
+      {/* Saved Cards Navigation — self-animated: mounts after its query resolves
+          (see Payment Methods above) */}
       {savedCardsData?.recurrent_enabled && (
-        <motion.div variants={staggerItem}>
+        <motion.div variants={staggerItem} initial="initial" animate="animate">
           <Card interactive onClick={() => navigate('/balance/saved-cards')}>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">

--- a/src/pages/ConnectedAccounts.tsx
+++ b/src/pages/ConnectedAccounts.tsx
@@ -639,7 +639,11 @@ export default function ConnectedAccounts() {
   };
 
   return (
+    // key: remount the container when loading resolves — stagger orchestration
+    // runs once on mount, so provider cards arriving from the API later would
+    // otherwise stay stuck at their initial variant (opacity 0) after a hard refresh
     <motion.div
+      key={isLoading ? 'loading' : 'ready'}
       className="space-y-6"
       variants={staggerContainer}
       initial="initial"

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -324,9 +324,11 @@ export default function Profile() {
         </Card>
       </motion.div>
 
-      {/* Referral Link Widget */}
+      {/* Referral Link Widget — self-animated: mounts after the referral queries
+          resolve, when the parent stagger orchestration has already finished and
+          would leave it stuck at opacity 0 */}
       {referralTerms?.is_enabled && referralLink && (
-        <motion.div variants={staggerItem}>
+        <motion.div variants={staggerItem} initial="initial" animate="animate">
           <Card>
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-semibold text-dark-100">{t('referral.yourLink')}</h2>

--- a/src/pages/SavedCards.tsx
+++ b/src/pages/SavedCards.tsx
@@ -73,7 +73,11 @@ export default function SavedCards() {
   };
 
   return (
+    // key: remount the container when loading resolves — stagger orchestration
+    // runs once on mount, so cards arriving from the API later would otherwise
+    // stay stuck at their initial variant (opacity 0) after a hard refresh
     <motion.div
+      key={isLoading ? 'loading' : 'ready'}
       className="space-y-6"
       variants={staggerContainer}
       initial="initial"

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -348,9 +348,11 @@ export default function Support() {
         </Button>
       </motion.div>
 
-      {/* Contact support card for "both" mode */}
+      {/* Contact support card for "both" mode — self-animated: mounts after the
+          config query resolves, when the parent stagger orchestration has already
+          finished and would leave it stuck at opacity 0 */}
       {supportConfig?.support_type === 'both' && supportConfig.support_username && (
-        <motion.div variants={staggerItem}>
+        <motion.div variants={staggerItem} initial="initial" animate="animate">
           <Card className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-dark-800">

--- a/src/pages/Wheel.tsx
+++ b/src/pages/Wheel.tsx
@@ -774,10 +774,13 @@ export default function Wheel() {
             >
               <div className="border-t border-dark-700/30 px-4 pb-4 pt-2">
                 {history && history.items.length > 0 ? (
+                  // "hidden"/"show" don't exist in staggerContainer/staggerItem
+                  // (their keys are initial/animate/exit), so the stagger here
+                  // was silently a no-op
                   <motion.div
                     variants={staggerContainer}
-                    initial="hidden"
-                    animate="show"
+                    initial="initial"
+                    animate="animate"
                     className="space-y-2"
                   >
                     {history.items.map((item: SpinHistoryItem) => (


### PR DESCRIPTION
## Симптом

После жёсткой перезагрузки (F5) или захода по прямой ссылке страница выглядит пустой: виден только заголовок, а весь контент из API отсутствует. При этом навигация внутри SPA работает нормально. Пример — `/profile/accounts`:

- SPA-переход: карточки Telegram/Email на месте;
- F5 на том же роуте: только заголовок «Привязанные аккаунты», дальше пусто. Карточки при этом **есть в DOM**, но с `opacity: 0`.

## Причина

Оркестрация `staggerContainer`/`staggerItem` у framer-motion раздаёт детям команду «показаться» **один раз — когда родитель проигрывает свою анимацию при монтировании**. Окно, в которое ребёнок должен успеть смонтироваться, ~300–400 мс (`delayChildren + staggerChildren × N + duration`).

Дети, смонтированные позже — когда resolve'ится запрос react-query, — в оркестрацию уже не попадают и навсегда остаются в своём `initial` (`opacity: 0, y: 8`).

Отсюда и разница сценариев:

- **SPA-навигация**: кэш react-query тёплый, `data` есть уже при первом рендере, дети монтируются вместе с родителем → каскад отрабатывает.
- **F5 / прямой заход**: кэш пуст, контейнер монтируется с одним заголовком (и скелетоном), данные приходят после бутстрапа авторизации (чтение токена → getMe → при протухшем access ещё 401 → refresh → повтор) — это серия последовательных roundtrip'ов, стабильно позже окна анимации → контент невидим.

На проде баг маскируется удачным таймингом: нет StrictMode (двойное монтирование в dev дополнительно схлопывает окно), same-origin API без CORS-preflight, тёплые кэши. Но иммунитета нет — пользователь на медленной сети, зашедший по прямой ссылке, получает тот же пустой экран.

## Решение

Две техники — по форме страницы:

**1. `key={isLoading ? 'loading' : 'ready'}` на контейнере** — после загрузки контейнер перемонтируется и stagger проигрывается заново уже со всеми детьми. Для страниц, где весь контент асинхронный: каскадная анимация полностью сохраняется и в холодном, и в тёплом сценарии.

- `ConnectedAccounts.tsx` — карточки провайдеров
- `SavedCards.tsx` — список сохранённых карт

**2. Явные `initial="initial" animate="animate"` на условном `staggerItem`** — элемент с явными пропсами выходит из-под оркестрации родителя и анимирует себя сам при монтировании. Для страниц, где асинхронны только 1–2 опциональные карточки: не перезапускает анимацию всей страницы на каждый resolve (на Balance таких запроса два — было бы два перемонтирования подряд).

- `Balance.tsx` — блок «Способы пополнения» и ссылка «Сохранённые карты»
- `Support.tsx` — карточка «Написать нам» (`support_type='both'`)
- `Profile.tsx` — реферальный виджет

**Попутная находка:** в `Wheel.tsx` у контейнера истории спинов стояли варианты `initial="hidden" animate="show"`, которых в `staggerContainer`/`staggerItem` не существует (их ключи — `initial`/`animate`/`exit`), поэтому stagger там молча не работал вовсе. Имена исправлены; контейнер самоанимирующийся, так что поздний mount ему не страшен.

## Проверено и не требует правок

- `TopUpAmount.tsx` — early-return со спиннером до загрузки методов, контейнер монтируется уже с данными;
- `TopUpMethodSelect.tsx`, `MergeAccounts.tsx` — динамический контент это обычный HTML внутри всегда смонтированных `staggerItem` (или страница целиком за early-return);
- вложенный контейнер транзакций в `Balance.tsx` — монтируется после загрузки со своими `initial`/`animate`, самоанимируется.

## Как тестировать

На каждом роуте важен именно **жёсткий F5 / прямой заход по URL**, не SPA-переход:

1. `/profile/accounts` — карточки провайдеров видны сразу после загрузки;
2. `/balance` — блок способов пополнения виден; при включённом recurrent — и ссылка «Сохранённые карты»;
3. `/profile` — при включённой рефералке виден виджет реферальной ссылки;
4. `/support` — при `support_type='both'` видна карточка «Написать нам»;
5. страница сохранённых карт — список виден;
6. колесо: история спинов теперь появляется каскадом (раньше — без анимации).

`tsc --noEmit` чистый; линтеры по изменённым файлам — без новых замечаний (все существующие предупреждения в этих файлах были до правок и не на изменённых строках).
