### PR TITLE
fix(docker): слушать IPv6 в nginx — healthcheck на localhost уводил контейнер в unhealthy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,9 @@ services:
       # Внутри контейнера nginx слушает на порту 80
       - '${CABINET_PORT:-3020}:80'
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:80/']
+      # 127.0.0.1 вместо localhost: localhost может резолвиться в [::1], и на
+      # образах, где nginx слушает только IPv4, healthcheck ложно падает
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:80/']
       interval: 30s
       timeout: 3s
       retries: 3

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,9 @@
 server {
     listen 80;
+    # Слушаем и IPv6: healthcheck ходит на localhost, который в контейнере
+    # резолвится в [::1] — без этой строки wget получает Connection refused
+    # и контейнер стабильно уходит в unhealthy (#3024 в репозитории бота).
+    listen [::]:80;
     server_name _;
 
     root /usr/share/nginx/html;


### PR DESCRIPTION
## 📝 Описание

Контейнер `cabinet_frontend` стабильно уходил в `unhealthy`, хотя приложение работало: встроенный nginx слушал только IPv4 (`listen 80;`), а healthcheck ходит на `http://localhost:80/`, где `localhost` внутри контейнера резолвится в IPv6 `[::1]` → `Connection refused`.

Исправление (репорт: BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#3024):

- `nginx.conf`: добавлен `listen [::]:80;` — nginx отвечает и на `[::1]` (корень проблемы);
- `docker-compose.yml`: healthcheck ходит на `127.0.0.1` вместо `localhost` — страховка, лечит в том числе уже собранные образы со старым конфигом.

## 🎯 Мотивация

Ложный `unhealthy` ломает мониторинг/оркестрацию (restart-политики, зависимые сервисы) и шумит в логах, хотя кабинет полностью работоспособен.

## 🔧 Тип изменений

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Чеклист

- [x] Код соответствует стандартам проекта
- [ ] Добавлены/обновлены тесты (инфраструктурный конфиг; проверено живым контейнером, см. ниже)
- [x] Документация обновлена (не требуется)

## 🧪 Тестирование

- `nginx -t` на патченном конфиге в `nginx:alpine` — syntax ok / test successful;
- живой контейнер `nginx:alpine` с этим конфигом: `wget --spider http://localhost:80/` изнутри контейнера (ровно падавшая команда из репорта, `([::1]:80) Connection refused`) — теперь OK; `http://127.0.0.1:80/` — OK.
