### PR TITLE
fix(i18n): добавить недостающие английские переводы resetPassword и expiredDate_trial

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -238,6 +238,15 @@
     "failed": "Verification Failed",
     "goToLogin": "Go to Login"
   },
+  "resetPassword": {
+    "title": "Set new password",
+    "enterNewPassword": "Enter your new password below.",
+    "success": "Password changed!",
+    "redirectingToLogin": "Redirecting to login...",
+    "setPassword": "Set new password",
+    "invalidToken": "Invalid reset link",
+    "tokenExpiredOrInvalid": "This password reset link is invalid or has expired."
+  },
   "dashboard": {
     "title": "Dashboard",
     "welcome": "Welcome, {{name}}!",
@@ -291,6 +300,7 @@
       "traffic": "Traffic",
       "devices": "Devices",
       "expiredDate": "Expired",
+      "expiredDate_trial": "Expired",
       "activeUntil": "Active until"
     },
     "suspended": {
@@ -5004,7 +5014,7 @@
       "test": "Test",
       "activating": "Activating...",
       "activate": "Activate",
-      "serverAccess": "Server access"
+      "serverAccess": "Access to {{count}} servers"
     },
     "deactivate": {
       "button": "Cancel promo code",


### PR DESCRIPTION
## 📝 Описание

Три пробела локализации, из-за которых англоязычные пользователи видели русский текст (i18next настроен с `fallbackLng: 'ru'` — при отсутствии ключа в `en.json` отдаётся русское значение, инлайн-дефолты из кода не используются):

- **`resetPassword.*` (7 ключей)** — namespace целиком отсутствовал в `en.json`: весь экран сброса пароля (`src/pages/ResetPassword.tsx`) показывался по-русски («Новый пароль», «Установить пароль», «Недействительная ссылка»). Английские значения взяты из инлайн-дефолтов в коде страницы.
- **`dashboard.expired.expiredDate_trial`** — context-вариант для истёкшего триала (`SubscriptionCardExpired.tsx` вызывает `t('dashboard.expired.expiredDate', { context: 'trial' })`) отсутствовал в EN → на карточке истёкшей пробной подписки светилось «Истёк».
- **`promo.offers.serverAccess`** — базовое EN-значение не содержало `{{count}}`, в отличие от RU («Доступ к {{count}} серверам») и собственных плюральных форм EN. Выровнено: `"Access to {{count}} servers"`.

## 🎯 Мотивация

Пользователь с языком EN получал русский интерфейс на экране сброса пароля и карточке истёкшего триала.

## 🔧 Тип изменений

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист

- [x] Код соответствует стандартам проекта
- [ ] Добавлены/обновлены тесты — изменение только JSON-локалей; систематический vitest-чек синхронности en/ru ключей будет отдельным PR
- [ ] Документация обновлена

## 🧪 Тестирование

- `npm run test` — 19 passed;
- `npm run type-check` — чисто;
- `npx biome check src/locales/en.json` — чисто;
- `npm run build` — успешно;
- вручную сверено использование всех трёх ключей: `ResetPassword.tsx`, `SubscriptionCardExpired.tsx:211` (context-вариант), `PromoOffersSection.tsx:66` (вызов с `{ count }`).
