### PR TITLE
fix(support): открывать внешний хелпдеск вместо битой t.me-ссылки

### DIFF
--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -16,6 +16,7 @@ import { staggerContainer, staggerItem } from '@/components/motion/transitions';
 import { ChatIcon, CloseIcon, ImageIcon, PlusIcon, SendIcon } from '@/components/icons';
 import { usePlatform } from '@/platform';
 import { linkifyText } from '../utils/linkify';
+import { resolveSupportLink } from '../utils/supportLink';
 
 const log = logger.createLogger('Support');
 
@@ -195,69 +196,36 @@ export default function Support() {
     );
   }
 
+  const link = resolveSupportLink(supportConfig);
+
   // If tickets are disabled, show redirect message
   if (supportConfig && !supportConfig.tickets_enabled) {
-    log.debug('Tickets disabled, config:', supportConfig);
+    log.debug('Tickets disabled, config:', supportConfig, 'link:', link);
 
     const getSupportMessage = () => {
-      log.debug('Getting support message for type:', supportConfig.support_type);
+      const title = isAdmin ? t('support.ticketsDisabled') : t('support.title');
 
-      if (supportConfig.support_type === 'profile') {
-        const supportUsername = supportConfig.support_username || '@support';
-        log.debug('Opening profile:', supportUsername);
-        return {
-          title: isAdmin ? t('support.ticketsDisabled') : t('support.title'),
-          message: t('support.contactSupport', { username: supportUsername }),
-          buttonText: t('support.contactUs'),
-          buttonAction: () => {
-            log.debug('Button clicked, opening:', supportUsername);
-
-            // Extract username without @
-            const username = supportUsername.startsWith('@')
-              ? supportUsername.slice(1)
-              : supportUsername;
-
-            const webUrl = `https://t.me/${username}`;
-            log.debug('Web URL:', webUrl);
-
-            // Use platform's openTelegramLink
-            openTelegramLink(webUrl);
-          },
-        };
+      if (!link) {
+        // Контакт не настроен или не прошёл проверку — кнопку не показываем.
+        return { title, message: t('support.contactSupport', { username: '—' }), action: null };
       }
 
-      if (supportConfig.support_type === 'url' && supportConfig.support_url) {
+      if (!link.isTelegram) {
         return {
-          title: isAdmin ? t('support.ticketsDisabled') : t('support.title'),
+          title,
           message: t('support.useExternalLink'),
           buttonText: t('support.openSupport'),
-          buttonAction: () => {
-            openLink(supportConfig.support_url!, { tryInstantView: false });
-          },
+          action: () => openLink(link.url, { tryInstantView: false }),
         };
       }
 
-      // Fallback: contact support (should not normally happen if config is correct)
-      const supportUsername = supportConfig.support_username || '@support';
-      log.debug('Fallback: Opening profile:', supportUsername);
       return {
-        title: isAdmin ? t('support.ticketsDisabled') : t('support.title'),
-        message: t('support.contactSupport', { username: supportUsername }),
+        title,
+        message: t('support.contactSupport', {
+          username: supportConfig.support_username || link.url,
+        }),
         buttonText: t('support.contactUs'),
-        buttonAction: () => {
-          log.debug('Fallback button clicked, opening:', supportUsername);
-
-          // Extract username without @
-          const username = supportUsername.startsWith('@')
-            ? supportUsername.slice(1)
-            : supportUsername;
-
-          const webUrl = `https://t.me/${username}`;
-          log.debug('Fallback opening URL:', webUrl);
-
-          // Use platform's openTelegramLink
-          openTelegramLink(webUrl);
-        },
+        action: () => openTelegramLink(link.url),
       };
     };
 
@@ -271,9 +239,11 @@ export default function Support() {
           </div>
           <h2 className="mb-2 text-xl font-semibold text-dark-100">{supportMessage.title}</h2>
           <p className="mb-6 text-dark-400">{supportMessage.message}</p>
-          <Button onClick={supportMessage.buttonAction} fullWidth>
-            {supportMessage.buttonText}
-          </Button>
+          {supportMessage.action && (
+            <Button onClick={supportMessage.action} fullWidth>
+              {supportMessage.buttonText}
+            </Button>
+          )}
         </Card>
       </div>
     );
@@ -352,7 +322,7 @@ export default function Support() {
       {/* Contact support card for "both" mode — self-animated: mounts after the
           config query resolves, when the parent stagger orchestration has already
           finished and would leave it stuck at opacity 0 */}
-      {supportConfig?.support_type === 'both' && supportConfig.support_username && (
+      {supportConfig?.support_type === 'both' && link && (
         <motion.div variants={staggerItem} initial="initial" animate="animate">
           <Card className="flex items-center justify-between">
             <div className="flex items-center gap-3">
@@ -361,17 +331,20 @@ export default function Support() {
               </div>
               <div>
                 <div className="text-sm font-medium text-dark-100">{t('support.contactUs')}</div>
-                <div className="text-xs text-dark-400">{supportConfig.support_username}</div>
+                <div className="text-xs text-dark-400">
+                  {supportConfig.support_username || link.url}
+                </div>
               </div>
             </div>
             <Button
               variant="secondary"
               className="shrink-0 whitespace-nowrap"
               onClick={() => {
-                const username = supportConfig.support_username!.startsWith('@')
-                  ? supportConfig.support_username!.slice(1)
-                  : supportConfig.support_username!;
-                openTelegramLink(`https://t.me/${username}`);
+                if (link.isTelegram) {
+                  openTelegramLink(link.url);
+                } else {
+                  openLink(link.url, { tryInstantView: false });
+                }
               }}
             >
               {t('support.writeButton', 'Написать')}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -530,6 +530,8 @@ export interface SupportConfig {
   support_type: 'tickets' | 'profile' | 'url' | 'both';
   support_url?: string | null;
   support_username?: string | null;
+  /** Ссылка ведёт в Telegram — открывать через openTelegramLink. Нет у старых бэкендов. */
+  contact_is_telegram?: boolean;
 }
 
 // Paginated response

--- a/src/utils/supportLink.test.ts
+++ b/src/utils/supportLink.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSupportLink } from './supportLink';
+
+describe('resolveSupportLink', () => {
+  it('returns null when there is nothing to open', () => {
+    expect(resolveSupportLink(null)).toBeNull();
+    expect(resolveSupportLink(undefined)).toBeNull();
+    expect(resolveSupportLink({})).toBeNull();
+    expect(resolveSupportLink({ support_username: '   ' })).toBeNull();
+  });
+
+  it('prefers the server-resolved url over the username', () => {
+    expect(
+      resolveSupportLink({
+        support_url: 'https://help.example.com',
+        support_username: '@help',
+        contact_is_telegram: false,
+      }),
+    ).toEqual({ url: 'https://help.example.com', isTelegram: false });
+  });
+
+  it('marks telegram links so they open natively', () => {
+    expect(
+      resolveSupportLink({
+        support_url: 'https://t.me/help',
+        support_username: '@help',
+        contact_is_telegram: true,
+      }),
+    ).toEqual({ url: 'https://t.me/help', isTelegram: true });
+  });
+
+  it('accepts tg:// deep links', () => {
+    expect(
+      resolveSupportLink({ support_url: 'tg://resolve?domain=help', contact_is_telegram: true }),
+    ).toEqual({ url: 'tg://resolve?domain=help', isTelegram: true });
+  });
+
+  it('treats a missing contact_is_telegram as external', () => {
+    expect(resolveSupportLink({ support_url: 'https://help.example.com' })).toEqual({
+      url: 'https://help.example.com',
+      isTelegram: false,
+    });
+  });
+
+  it('rejects exotic schemes', () => {
+    expect(resolveSupportLink({ support_url: 'javascript:alert(1)' })).toBeNull();
+    expect(resolveSupportLink({ support_url: 'data:text/html,x' })).toBeNull();
+    expect(resolveSupportLink({ support_url: 'not a url' })).toBeNull();
+  });
+
+  it('falls back to building a t.me link for older backends', () => {
+    expect(resolveSupportLink({ support_username: '@help' })).toEqual({
+      url: 'https://t.me/help',
+      isTelegram: true,
+    });
+    expect(resolveSupportLink({ support_username: 'help' })).toEqual({
+      url: 'https://t.me/help',
+      isTelegram: true,
+    });
+  });
+
+  it('does not build t.me links out of url-shaped usernames', () => {
+    expect(resolveSupportLink({ support_username: 'https://help.example.com' })).toBeNull();
+    expect(resolveSupportLink({ support_username: 'help.example.com' })).toBeNull();
+  });
+});

--- a/src/utils/supportLink.ts
+++ b/src/utils/supportLink.ts
@@ -1,0 +1,58 @@
+import type { SupportConfig } from '../types';
+
+export interface ResolvedSupportLink {
+  url: string;
+  isTelegram: boolean;
+}
+
+const ALLOWED_SCHEMES = ['http:', 'https:', 'tg:'];
+
+function isAllowedScheme(url: string): boolean {
+  try {
+    return ALLOWED_SCHEMES.includes(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the support contact into a link the page can open.
+ *
+ * `SUPPORT_USERNAME` on the backend accepts both `@username` and a bare URL, so the
+ * server resolves it for us and reports which flavour it is. Older backends send
+ * neither `support_url` nor `contact_is_telegram` — there we keep the previous
+ * behaviour and build a `t.me` link out of the username.
+ *
+ * Returns null when there is nothing safe to open, in which case the caller should
+ * render no button at all.
+ */
+export function resolveSupportLink(
+  config:
+    | Pick<SupportConfig, 'support_url' | 'support_username' | 'contact_is_telegram'>
+    | null
+    | undefined,
+): ResolvedSupportLink | null {
+  if (!config) return null;
+
+  const serverUrl = config.support_url?.trim();
+
+  if (serverUrl) {
+    // The URL is admin-supplied; refuse exotic schemes rather than handing
+    // `javascript:` straight to the platform opener.
+    if (!isAllowedScheme(serverUrl)) return null;
+
+    return { url: serverUrl, isTelegram: config.contact_is_telegram === true };
+  }
+
+  const username = config.support_username?.trim();
+
+  if (!username) return null;
+
+  // Legacy path: a bare URL here would produce `t.me/https://…`, so only usernames
+  // are accepted — anything URL-shaped is left to the backend to resolve.
+  const handle = username.startsWith('@') ? username.slice(1) : username;
+
+  if (!/^[A-Za-z0-9_]{3,}$/.test(handle)) return null;
+
+  return { url: `https://t.me/${handle}`, isTelegram: true };
+}


### PR DESCRIPTION
## 📝 Описание

`SUPPORT_USERNAME` на бэкенде принимает не только `@username`, но и произвольный URL. Страница поддержки в трёх местах собирала ссылку самостоятельно — `https://t.me/` + значение из `support_username`, — поэтому для внешнего хелпдеска получалось `https://t.me/https://help.example.com` и кнопка вела в никуда.

Парный PR в бот: BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#3099 (там `/cabinet/info/support-config` начинает отдавать резолвнутый `support_url` и новый флаг `contact_is_telegram`).

## 🎯 Мотивация

Одна и та же настройка работает в боте и не работала в кабинете. Побочно оживает ветка `support_type === 'url'`, которая здесь уже была реализована, но до которой бэкенд никогда не доводил, потому что жёстко отдавал `support_url: null`.

## 🔧 Что изменилось

- Новый `src/utils/supportLink.ts` — `resolveSupportLink()` возвращает `{ url, isTelegram }` либо `null`.
- `Support.tsx`: три места, собиравшие `t.me`-ссылку вручную, заменены одним вызовом утилиты. Режим `both` раньше **всегда** звал `openTelegramLink` — он ломался даже при полностью корректном конфиге.
- `SupportConfig` дополнен необязательным `contact_is_telegram`.

Логика намеренно не парсит хост на фронте: какой это контакт — знает бэкенд, и дублирование этого разбора завело бы ровно то расхождение, которое здесь чинится.

## 🔄 Совместимость

Старые бэкенды не присылают ни `support_url`, ни `contact_is_telegram` — для них поведение прежнее, ссылка по-прежнему собирается из `support_username`. То есть PR можно мержить независимо от #3099, в любом порядке.

## ⚠️ Изменения поведения

Два намеренных отличия от текущего кода:

1. **URL-образные значения в `support_username` больше не превращаются в `t.me`-ссылку** — они отбрасываются. Собрать `t.me/https://…` и было исходным багом; с новым бэкендом такие значения приходят уже в `support_url`.
2. **Кнопка не рендерится, если контакт не настроен или не прошёл проверку.** Раньше в этом случае молча открывался `https://t.me/support` — дефолт из кода, не имеющий отношения к конкретной инсталляции.

Схемы ограничены `http`/`https`/`tg`, чтобы не передавать `javascript:` в платформенный опенер. Значение админское, но проверка копеечная и повторяет подход `safeRedirect.ts`.

## ✅ Чеклист

- [x] `npm test` — 42 passed (9 файлов), из них 8 новых на `resolveSupportLink`
- [x] `npm run type-check` — чисто
- [x] `npx biome check` — ошибок нет
- [x] Обратная совместимость со старым бэкендом покрыта тестом
