### PR TITLE
fix(support): ужесточить resolveSupportContact — схема, legacy-username, null-путь

### DIFF
--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -41,6 +41,7 @@ export default function Support() {
   const openSupportContact = useCallback(
     (config: SupportConfig) => {
       const target = resolveSupportContact(config);
+      if (!target) return;
       if (target.kind === 'external') {
         openLink(target.url, { tryInstantView: false });
       } else {
@@ -212,45 +213,29 @@ export default function Support() {
   if (supportConfig && !supportConfig.tickets_enabled) {
     log.debug('Tickets disabled, config:', supportConfig);
 
+    // Куда и чем открывать контакт — один резолв на весь блок. null → открывать
+    // нечего (пустой/битый конфиг), и кнопку тогда не рендерим вовсе.
+    const contact = resolveSupportContact(supportConfig);
+
     const getSupportMessage = () => {
       log.debug('Getting support message for type:', supportConfig.support_type);
 
-      if (supportConfig.support_type === 'profile') {
-        const supportUsername = supportConfig.support_username || '@support';
-        log.debug('Opening profile:', supportUsername);
-        return {
-          title: isAdmin ? t('support.ticketsDisabled') : t('support.title'),
-          message: t('support.contactSupport', { username: supportUsername }),
-          buttonText: t('support.contactUs'),
-          buttonAction: () => {
-            log.debug('Button clicked, opening:', supportUsername);
-            openSupportContact(supportConfig);
-          },
-        };
-      }
+      const title = isAdmin ? t('support.ticketsDisabled') : t('support.title');
 
       if (supportConfig.support_type === 'url' && supportConfig.support_url) {
         return {
-          title: isAdmin ? t('support.ticketsDisabled') : t('support.title'),
+          title,
           message: t('support.useExternalLink'),
           buttonText: t('support.openSupport'),
-          buttonAction: () => {
-            openLink(supportConfig.support_url!, { tryInstantView: false });
-          },
         };
       }
 
-      // Fallback: contact support (should not normally happen if config is correct)
+      // profile и любой fallback — контакт в телеграме
       const supportUsername = supportConfig.support_username || '@support';
-      log.debug('Fallback: Opening profile:', supportUsername);
       return {
-        title: isAdmin ? t('support.ticketsDisabled') : t('support.title'),
+        title,
         message: t('support.contactSupport', { username: supportUsername }),
         buttonText: t('support.contactUs'),
-        buttonAction: () => {
-          log.debug('Fallback button clicked, opening:', supportUsername);
-          openSupportContact(supportConfig);
-        },
       };
     };
 
@@ -264,9 +249,11 @@ export default function Support() {
           </div>
           <h2 className="mb-2 text-xl font-semibold text-dark-100">{supportMessage.title}</h2>
           <p className="mb-6 text-dark-400">{supportMessage.message}</p>
-          <Button onClick={supportMessage.buttonAction} fullWidth>
-            {supportMessage.buttonText}
-          </Button>
+          {contact && (
+            <Button onClick={() => openSupportContact(supportConfig)} fullWidth>
+              {supportMessage.buttonText}
+            </Button>
+          )}
         </Card>
       </div>
     );
@@ -345,28 +332,30 @@ export default function Support() {
       {/* Contact support card for "both" mode — self-animated: mounts after the
           config query resolves, when the parent stagger orchestration has already
           finished and would leave it stuck at opacity 0 */}
-      {supportConfig?.support_type === 'both' && supportConfig.support_username && (
-        <motion.div variants={staggerItem} initial="initial" animate="animate">
-          <Card className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-dark-800">
-                <ChatIcon className="h-5 w-5 text-dark-400" />
+      {supportConfig?.support_type === 'both' &&
+        supportConfig.support_username &&
+        resolveSupportContact(supportConfig) && (
+          <motion.div variants={staggerItem} initial="initial" animate="animate">
+            <Card className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-dark-800">
+                  <ChatIcon className="h-5 w-5 text-dark-400" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-dark-100">{t('support.contactUs')}</div>
+                  <div className="text-xs text-dark-400">{supportConfig.support_username}</div>
+                </div>
               </div>
-              <div>
-                <div className="text-sm font-medium text-dark-100">{t('support.contactUs')}</div>
-                <div className="text-xs text-dark-400">{supportConfig.support_username}</div>
-              </div>
-            </div>
-            <Button
-              variant="secondary"
-              className="shrink-0 whitespace-nowrap"
-              onClick={() => openSupportContact(supportConfig)}
-            >
-              {t('support.writeButton', 'Написать')}
-            </Button>
-          </Card>
-        </motion.div>
-      )}
+              <Button
+                variant="secondary"
+                className="shrink-0 whitespace-nowrap"
+                onClick={() => openSupportContact(supportConfig)}
+              >
+                {t('support.writeButton', 'Написать')}
+              </Button>
+            </Card>
+          </motion.div>
+        )}
 
       <motion.div variants={staggerItem} className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         {/* Tickets List */}

--- a/src/utils/supportContact.test.ts
+++ b/src/utils/supportContact.test.ts
@@ -7,6 +7,10 @@ import { resolveSupportContact } from './supportContact';
  * SUPPORT_USERNAME принимает и `@user`, и произвольный URL, поэтому из
  * `https://help.example.com` получалось `https://t.me/https://help.example.com`.
  * Бэк отдаёт контакт уже разрезолвленным — клеить на клиенте больше нечего.
+ *
+ * resolveSupportContact дополнительно защищается от битого конфига: чужие схемы
+ * (`javascript:` и т.п.) и URL-образный legacy-username не уводят в опенер, а
+ * возвращают null — кнопку в таком случае не рендерим.
  */
 
 const config = (overrides: Partial<SupportConfig>): SupportConfig => ({
@@ -26,7 +30,7 @@ describe('resolveSupportContact', () => {
     );
 
     expect(target).toEqual({ kind: 'external', url: 'https://help.example.com' });
-    expect(target.url).not.toContain('t.me');
+    expect(target?.url).not.toContain('t.me');
   });
 
   it('телеграм-контакт открывается через telegram-ссылку', () => {
@@ -41,6 +45,24 @@ describe('resolveSupportContact', () => {
     expect(target).toEqual({ kind: 'telegram', url: 'https://t.me/help' });
   });
 
+  it('tg:// deep link — валидная схема', () => {
+    const target = resolveSupportContact(
+      config({ support_url: 'tg://resolve?domain=help', contact_is_telegram: true }),
+    );
+
+    expect(target).toEqual({ kind: 'telegram', url: 'tg://resolve?domain=help' });
+  });
+
+  describe('чужие схемы в support_url отсекаются', () => {
+    it.each([
+      'javascript:alert(1)',
+      'data:text/html,x',
+      'not a url',
+    ])('%s -> null', (support_url) => {
+      expect(resolveSupportContact(config({ support_url }))).toBeNull();
+    });
+  });
+
   describe('старый бэк без support_url — прежнее поведение', () => {
     it.each([
       ['@help', 'https://t.me/help'],
@@ -51,11 +73,17 @@ describe('resolveSupportContact', () => {
       expect(target).toEqual({ kind: 'telegram', url: expected });
     });
 
-    it('контакт вообще не задан — дефолтный @support', () => {
-      expect(resolveSupportContact(config({}))).toEqual({
-        kind: 'telegram',
-        url: 'https://t.me/support',
-      });
+    it.each([
+      'https://help.example.com',
+      'help.example.com',
+      't.me/help',
+    ])('URL-образный legacy username (%s) не клеится в t.me — null', (support_username) => {
+      expect(resolveSupportContact(config({ support_username }))).toBeNull();
+    });
+
+    it('контакт вообще не задан — кнопки нет (null, без дефолта @support)', () => {
+      expect(resolveSupportContact(config({}))).toBeNull();
+      expect(resolveSupportContact(config({ support_username: '   ' }))).toBeNull();
     });
   });
 
@@ -64,6 +92,6 @@ describe('resolveSupportContact', () => {
     // поведение, а не в переход по внешней ссылке.
     const target = resolveSupportContact(config({ support_url: 'https://t.me/help' }));
 
-    expect(target.kind).toBe('telegram');
+    expect(target?.kind).toBe('telegram');
   });
 });

--- a/src/utils/supportContact.ts
+++ b/src/utils/supportContact.ts
@@ -10,6 +10,19 @@ export type SupportContactTarget = {
   url: string;
 };
 
+// Открываем только то, что реально ведёт в браузер/телеграм. support_url приходит
+// из админского SUPPORT_USERNAME — чужую схему (`javascript:`, `data:` и т.п.)
+// нельзя пускать в опенер как есть.
+const ALLOWED_SCHEMES = ['http:', 'https:', 'tg:'];
+
+function isAllowedScheme(url: string): boolean {
+  try {
+    return ALLOWED_SCHEMES.includes(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Резолвит контакт поддержки из конфига.
  *
@@ -20,17 +33,31 @@ export type SupportContactTarget = {
  *
  * Старый бэк не отдаёт `support_url`; для него сохранено прежнее поведение,
  * иначе новый фронт сломался бы на неподнятом бэкенде.
+ *
+ * Возвращает `null`, когда открывать нечего (пустой/битый конфиг, чужая схема,
+ * URL-образный legacy username) — вызывающий в этом случае не рендерит кнопку,
+ * а не уводит пользователя по мусорной ссылке.
  */
-export function resolveSupportContact(config: SupportConfig): SupportContactTarget {
-  if (config.support_url) {
+export function resolveSupportContact(config: SupportConfig): SupportContactTarget | null {
+  const serverUrl = config.support_url?.trim();
+
+  if (serverUrl) {
+    if (!isAllowedScheme(serverUrl)) return null;
+
     // contact_is_telegram отсутствует только у старого бэка, а он не шлёт и
     // support_url — так что явная проверка на false, а не на truthy.
     const kind = config.contact_is_telegram === false ? 'external' : 'telegram';
-    return { kind, url: config.support_url };
+    return { kind, url: serverUrl };
   }
 
-  const raw = config.support_username || '@support';
+  const raw = config.support_username?.trim();
+  if (!raw) return null;
+
   const username = raw.startsWith('@') ? raw.slice(1) : raw;
+
+  // Legacy-путь: голый URL здесь дал бы `t.me/https://…`, поэтому клеим t.me
+  // только из настоящего юзернейма — всё URL-образное отдаём резолвить бэку.
+  if (!/^[A-Za-z0-9_]{3,}$/.test(username)) return null;
 
   return { kind: 'telegram', url: `https://t.me/${username}` };
 }


### PR DESCRIPTION
Инкремент поверх `f04675b`, как договорились в #501 (мой PR был технически перекрыт этим коммитом). Три улучшения из моего варианта переношу в существующий `resolveSupportContact` вместо параллельной утилиты — ревью обещало быть быстрым.

## Что меняется

Всё в `resolveSupportContact` (+ вызовы в `Support.tsx`). Функция теперь возвращает `SupportContactTarget | null`.

1. **Валидация схемы `support_url`** — открываем только `http`/`https`/`tg`. Чужая схема (`javascript:`, `data:` и т.п.) больше не уходит в опенер как есть, а даёт `null`. Раньше `support_url` шёл в опенер без проверки.
2. **Валидация legacy username** регуляркой `^[A-Za-z0-9_]{3,}$` — старый бэк с URL-образным `SUPPORT_USERNAME` больше не собирает битый `t.me/https://…`. Валидные телеграм-юзернеймы проходят, отбрасывается только URL-образное и `bare-t.me/x`.
3. **`null` → кнопка не рендерится** — при ненастроенном/битом контакте `Support.tsx` не показывает кнопку, а не открывает молча `https://t.me/support` (ушёл дефолт `@support` из кода).

Заодно url-ветка в блоке `ticketsDisabled` и карточка `both`-режима теперь тоже ходят через `resolveSupportContact`: ушёл прямой `openLink(support_url!)` с non-null assertion, три идентичные ветки `getSupportMessage` (profile/url/fallback) схлопнуты в две.

## Проверки

- `resolveSupportContact.test.ts` дополнен: схемы (`javascript:`/`data:`/не-URL → null), `tg://` deep link, URL-образный legacy username → null, пустой контакт → null. **13/13 зелёные**, полный прогон `vitest run` — **47/47**.
- `tsc` по изменённым файлам чист (предсуществующая ошибка в `NewsArticle.tsx` про `@types/trusted-types` — не отсюда).
- `biome check` — clean.

Семантику dev сохранил: `support_url` без `contact_is_telegram` по-прежнему трактуется как telegram (деградация в старое поведение, а не во внешнюю ссылку).