### PR TITLE
ci(security): dependabot + CodeQL + npm audit + Trivy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Схлопываем шумные обновления в один PR, чтобы не плодить десятки веток.
+      dev-dependencies:
+        dependency-type: "development"
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Еженедельный полный проход, чтобы ловить новые правила даже без коммитов.
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml
@@ -22,6 +25,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -53,6 +57,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -66,3 +71,23 @@ jobs:
             VITE_TELEGRAM_BOT_USERNAME=
             VITE_APP_NAME=Cabinet
             VITE_APP_LOGO=V
+
+      # Сканируем запушенный образ на CVE. Пока non-blocking (exit-code: 0):
+      # находки уезжают в Security → Code scanning, но сборку не роняют.
+      # Для ужесточения — поставить severity-фильтр в exit-code и убрать PR-гейт.
+      - name: Scan image with Trivy
+        if: github.event_name != 'pull_request'
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+
+      - name: Upload Trivy results to Security tab
+        if: github.event_name != 'pull_request'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,35 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  npm-audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Пока non-blocking: сообщаем о HIGH/CRITICAL, но не валим пайплайн.
+      # Когда долги по зависимостям разгребём — убрать continue-on-error.
+      - name: Run npm audit (high+)
+        continue-on-error: true
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Что добавляет

Набор security-проверок в CI (easy wins), все сканеры **non-blocking** — репортят, но не роняют сборку.

- **`.github/dependabot.yml`** — еженедельные апдейты `npm` / `github-actions` / `docker`, PR сгруппированы (dev-deps и prod minor/patch отдельно), чтобы не плодить десятки веток.
- **`codeql.yml`** — SAST (`javascript-typescript`, набор `security-and-quality`) на push/PR в `main`/`dev` + еженедельный проход. Находки → Security → Code scanning.
- **`security-audit.yml`** — `npm audit --audit-level=high` (`continue-on-error`, пока non-blocking).
- **`docker.yml`** — Trivy сканирует **запушенный** образ по digest (HIGH/CRITICAL), SARIF выгружается в Security tab. `exit-code: 0` — сборку не валит. Плюс least-privilege `permissions` на workflow.

## Как ужесточить потом

- npm audit: убрать `continue-on-error`.
- Trivy: выставить `exit-code: 1` и снять PR-гейт (нужен `load: true` для скана до push на PR).

## Не входит (follow-up)

SBOM/provenance у `build-push-action`, secret-scanning push-protection (это настройка репо, не файл).