### PR TITLE
fix(blocking): локализовать дефолтное сообщение на экране подписки на канал

### DIFF
--- a/src/components/blocking/ChannelSubscriptionScreen.tsx
+++ b/src/components/blocking/ChannelSubscriptionScreen.tsx
@@ -4,6 +4,7 @@ import { useBlockingStore } from '../../store/blocking';
 import { apiClient, isChannelSubscriptionError } from '../../api/client';
 import { usePlatform } from '../../platform';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { customChannelMessage } from '../../utils/channelBlockingMessage';
 import { TelegramIcon, ClockIcon, CheckIcon, RestartIcon } from '@/components/icons';
 import { Button } from '@/components/primitives';
 import BlockingShell from './BlockingShell';
@@ -108,7 +109,9 @@ export default function ChannelSubscriptionScreen() {
       ariaLive="polite"
       icon={<TelegramIcon className="h-9 w-9" />}
       title={t('blocking.channel.title')}
-      description={channelInfo?.message || t('blocking.channel.defaultMessage')}
+      description={
+        customChannelMessage(channelInfo?.message) ?? t('blocking.channel.defaultMessage')
+      }
       footer={t('blocking.channel.hint')}
       actions={
         <Button

--- a/src/utils/channelBlockingMessage.test.ts
+++ b/src/utils/channelBlockingMessage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { customChannelMessage } from './channelBlockingMessage';
+
+describe('customChannelMessage', () => {
+  it('returns null for empty values', () => {
+    expect(customChannelMessage(undefined)).toBeNull();
+    expect(customChannelMessage(null)).toBeNull();
+    expect(customChannelMessage('')).toBeNull();
+    expect(customChannelMessage('   ')).toBeNull();
+  });
+
+  it('returns null for the hardcoded backend default message', () => {
+    expect(
+      customChannelMessage('Please subscribe to the required channels to continue'),
+    ).toBeNull();
+  });
+
+  it('ignores surrounding whitespace when matching the backend default', () => {
+    expect(
+      customChannelMessage('  Please subscribe to the required channels to continue  '),
+    ).toBeNull();
+  });
+
+  it('passes through a custom message', () => {
+    expect(customChannelMessage('Подпишитесь на наш канал @example')).toBe(
+      'Подпишитесь на наш канал @example',
+    );
+  });
+
+  it('trims a custom message', () => {
+    expect(customChannelMessage('  custom  ')).toBe('custom');
+  });
+});

--- a/src/utils/channelBlockingMessage.ts
+++ b/src/utils/channelBlockingMessage.ts
@@ -1,0 +1,18 @@
+/**
+ * The backend hardcodes this English message in the 403
+ * `channel_subscription_required` payload (app/cabinet/dependencies.py). It is
+ * not admin-configurable and not localized, so showing it verbatim leaks
+ * English into every locale. Treat it as "no custom message" and let the UI
+ * fall back to its own i18n string.
+ */
+const BACKEND_DEFAULT_MESSAGES = new Set(['Please subscribe to the required channels to continue']);
+
+/**
+ * Returns the backend-provided channel-subscription message only when it is a
+ * real custom message; `null` for empty values and known backend defaults.
+ */
+export function customChannelMessage(message: string | null | undefined): string | null {
+  const trimmed = message?.trim();
+  if (!trimmed || BACKEND_DEFAULT_MESSAGES.has(trimmed)) return null;
+  return trimmed;
+}


### PR DESCRIPTION
## 📝 Описание

На экране обязательной подписки на канал текст «Please subscribe to the required channels to continue» показывался по-английски во всех локалях. Это захардкоженный дефолт бэкенда из 403-ответа `channel_subscription_required` (`app/cabinet/dependencies.py`) — он не настраивается админом и не локализуется, но перебивал собственную i18n-строку кабинета `blocking.channel.defaultMessage`, которая уже переведена на все 4 языка.

Добавлен хелпер `customChannelMessage()`: известный бэкендовый дефолт (и пустые значения) отбрасываются, и экран показывает локализованную строку; настоящий кастомный текст из бэкенда, если такой появится, по-прежнему проходит как есть.

Closes #311

## 🎯 Мотивация

Русскоязычный (и любой другой не-английский) пользователь видел английский текст на блокирующем экране — issue #311.

## 🔧 Тип изменений

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист

- [x] Код соответствует стандартам проекта
- [x] Добавлены/обновлены тесты
- [ ] Документация обновлена (не требуется)

## 🧪 Тестирование

- Новый `src/utils/channelBlockingMessage.test.ts` — 5 кейсов: пустые значения, бэкендовый дефолт (в т.ч. с пробелами по краям), кастомное сообщение, трим.
- `npm run test` — 10 файлов / 45 тестов зелёные, `npm run type-check`, `npx biome check` по затронутым файлам без замечаний, `npm run build` успешен.
