### PR TITLE
fix(referral): показывать секцию вывода средств всем реферерам

### DIFF
--- a/src/pages/Referral.tsx
+++ b/src/pages/Referral.tsx
@@ -101,17 +101,21 @@ export default function Referral() {
 
   const isPartner = partnerStatus?.partner_status === 'approved';
 
-  // Withdrawal queries (only when partner is approved)
+  // Withdrawal is available to any referrer: the backend endpoints
+  // (/cabinet/referral/withdrawal/*) do not require partner_status, so the
+  // section is gated only by the admin visibility flag.
+  const withdrawalVisible = terms?.partner_section_visible !== false;
+
   const { data: withdrawalBalance } = useQuery({
     queryKey: ['withdrawal-balance'],
     queryFn: withdrawalApi.getBalance,
-    enabled: isPartner,
+    enabled: withdrawalVisible,
   });
 
   const { data: withdrawalHistory } = useQuery({
     queryKey: ['withdrawal-history'],
     queryFn: withdrawalApi.getHistory,
-    enabled: isPartner,
+    enabled: withdrawalVisible,
   });
 
   // Withdrawal cancel mutation
@@ -540,9 +544,9 @@ export default function Referral() {
           </div>
         )}
 
-      {/* ==================== Withdrawal Section (approved partners only) ==================== */}
+      {/* ==================== Withdrawal Section ==================== */}
 
-      {terms?.partner_section_visible !== false && isPartner && (
+      {withdrawalVisible && (
         <div id="withdrawal-section" className="space-y-6">
           {/* Withdrawal Balance Card */}
           {withdrawalBalance && (


### PR DESCRIPTION
## 📝 Описание

Секция вывода реферальных средств на странице `/referral` рендерилась только при `partner_status === 'approved'`, хотя ни один бэкенд-эндпоинт (`/cabinet/referral/withdrawal/balance|create|history|{id}/cancel`) и `referral_withdrawal_service` партнёрский статус не проверяют — вывод доступен любому рефереру с балансом. Более того, страница `/referral/withdrawal/request` партнёрство тоже не проверяет, т.е. `isPartner` лишь прятал точку входа.

Из условия рендера и из `enabled` у запросов баланса/истории убран `isPartner`; секция гейтится только админским флагом `terms.partner_section_visible`, как и предложено в issue.

Closes #472

## 🎯 Мотивация

Рефереры без формальной партнёрской заявки не видели кнопку вывода заработанных средств, хотя API им это разрешает — issue #472 (поведение подтверждено кодом бота: в `app/cabinet/routes/withdrawal.py` и `app/services/referral_withdrawal_service.py` проверок `partner_status` нет).

## 🔧 Тип изменений

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист

- [x] Код соответствует стандартам проекта
- [ ] Добавлены/обновлены тесты (изменение — только JSX-условие видимости; юнит-тестируемой логики не добавилось)
- [ ] Документация обновлена (не требуется)

## 🧪 Тестирование

- `npm run test` — 10 файлов / 45 тестов зелёные, `npm run type-check`, `npx biome check src/pages/Referral.tsx` без замечаний, `npm run build` успешен.
- Логика: доступность кнопки внутри секции по-прежнему управляется бэкендом (`can_request` / `cannot_request_reason` из `/withdrawal/balance`), так что для пользователей без заработка секция покажет нулевой баланс и недоступную кнопку с причиной — как сейчас у партнёров.
