### PR TITLE
fix(subscription): корректная цена за месяц при выборе периода

### DIFF
--- a/src/components/subscription/purchase/TariffPurchaseForm.tsx
+++ b/src/components/subscription/purchase/TariffPurchaseForm.tsx
@@ -8,6 +8,7 @@ import { useCurrency } from '../../../hooks/useCurrency';
 import { usePromoDiscount } from '../../../hooks/usePromoDiscount';
 import { usePlatform } from '../../../platform';
 import { openPaymentUrl } from '../../../utils/openPaymentUrl';
+import { getMonthlyPriceKopeks } from '../../../utils/pricing';
 import InsufficientBalancePrompt from '../../InsufficientBalancePrompt';
 import type { Tariff, TariffPeriod } from '../../../types';
 
@@ -279,10 +280,7 @@ export function TariffPurchaseForm({
                   const displayDiscount = promoPeriod.percent;
                   const displayOriginal = promoPeriod.original;
                   const displayPrice = promoPeriod.price;
-                  const displayPerMonth =
-                    displayPrice !== period.price_kopeks
-                      ? Math.round(displayPrice / Math.max(1, period.days / 30))
-                      : period.price_per_month_kopeks;
+                  const displayPerMonth = getMonthlyPriceKopeks(displayPrice, period.days);
 
                   return (
                     <button
@@ -317,9 +315,11 @@ export function TariffPurchaseForm({
                           </span>
                         )}
                       </div>
-                      <div className="mt-1 text-xs text-dark-500">
-                        {formatPrice(displayPerMonth)}/{t('subscription.month')}
-                      </div>
+                      {displayPerMonth !== null && (
+                        <div className="mt-1 text-xs text-dark-500">
+                          {formatPrice(displayPerMonth)}/{t('subscription.month')}
+                        </div>
+                      )}
                     </button>
                   );
                 })}

--- a/src/pages/RenewSubscription.tsx
+++ b/src/pages/RenewSubscription.tsx
@@ -5,6 +5,7 @@ import { Navigate, useNavigate, useParams } from 'react-router';
 import { subscriptionApi } from '../api/subscription';
 import { useTheme } from '../hooks/useTheme';
 import { getGlassColors } from '../utils/glassTheme';
+import { getMonthlyPriceKopeks } from '../utils/pricing';
 import { useCurrency } from '../hooks/useCurrency';
 import { useHaptic } from '../platform';
 import InsufficientBalancePrompt from '../components/InsufficientBalancePrompt';
@@ -143,8 +144,7 @@ export default function RenewSubscription() {
           {options.map((option) => {
             const isSelected = selectedPeriod === option.period_days;
             const canAfford = balanceKopeks >= option.price_kopeks;
-            const months = Math.max(1, Math.round(option.period_days / 30));
-            const perMonth = option.price_kopeks / months;
+            const perMonth = getMonthlyPriceKopeks(option.price_kopeks, option.period_days);
 
             return (
               <button
@@ -181,7 +181,7 @@ export default function RenewSubscription() {
                         ? t('subscription.free', 'Бесплатно')
                         : `${formatAmount(option.price_kopeks / 100)} ${currencySymbol}`}
                     </div>
-                    {months > 1 && (
+                    {perMonth !== null && (
                       <div className="text-[11px]" style={{ color: g.textSecondary }}>
                         {formatAmount(perMonth / 100)} {currencySymbol}/
                         {t('common.units.mo', 'мес')}

--- a/src/utils/pricing.test.ts
+++ b/src/utils/pricing.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getMonthlyPriceKopeks } from './pricing';
+
+describe('getMonthlyPriceKopeks', () => {
+  it('hides the monthly rate for periods of a month or shorter', () => {
+    expect(getMonthlyPriceKopeks(4830, 7)).toBeNull();
+    expect(getMonthlyPriceKopeks(9900, 14)).toBeNull();
+    expect(getMonthlyPriceKopeks(16030, 30)).toBeNull();
+  });
+
+  it('divides by whole months for multiples of 30 days', () => {
+    expect(getMonthlyPriceKopeks(30000, 90)).toBe(10000);
+    expect(getMonthlyPriceKopeks(60000, 180)).toBe(10000);
+  });
+
+  it('prorates periods that are not whole months', () => {
+    expect(getMonthlyPriceKopeks(15000, 45)).toBe(10000);
+    expect(getMonthlyPriceKopeks(100000, 365)).toBe(8219);
+  });
+
+  it('returns null for non-finite input', () => {
+    expect(getMonthlyPriceKopeks(Number.NaN, 90)).toBeNull();
+    expect(getMonthlyPriceKopeks(30000, Number.NaN)).toBeNull();
+    expect(getMonthlyPriceKopeks(30000, Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -1,0 +1,15 @@
+/** Длина «месяца» в днях — тот же множитель, что использует бэкенд при расчёте цены за месяц. */
+const DAYS_IN_MONTH = 30;
+
+/**
+ * Цена за месяц (в копейках) для периода длиной `days` дней.
+ *
+ * Возвращает `null`, когда месячная ставка не имеет смысла: для периода
+ * в месяц и короче она либо повторяет цену периода (30 дней), либо
+ * выдаёт цену периода за месячную (7 дней → цена семи дней «за месяц»).
+ */
+export function getMonthlyPriceKopeks(priceKopeks: number, days: number): number | null {
+  if (!Number.isFinite(priceKopeks) || !Number.isFinite(days)) return null;
+  if (days <= DAYS_IN_MONTH) return null;
+  return Math.round((priceKopeks * DAYS_IN_MONTH) / days);
+}


### PR DESCRIPTION
## 📝 Описание
Для периодов короче месяца в карточке периода под ценой выводилась та же
сумма с подписью «/мес» — цена за 7 дней показывалась как цена за месяц,
а у карточки «1 месяц» строка дублировала цену. Причина — делитель
`max(1, days / 30)`, который для коротких периодов равен 1; бэкендовый
`price_per_month_kopeks` считается так же (`price // (days // 30)`), поэтому
без скидки баг был тот же.

Расчёт вынесен в `getMonthlyPriceKopeks()`: месячная ставка считается
пропорцией `price * 30 / days` и не выводится для периодов в месяц и короче.
Тот же хелпер применён на экране продления, где для периодов вроде 45 дней
цена делилась на округлённое число месяцев.

## 🎯 Мотивация
Пользователь видел «48.30 ₽/мес» у семидневного периода — заниженная и
неверная цена за месяц вводит в заблуждение при сравнении периодов.

## 🔧 Тип изменений
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## ✅ Чеклист
- [x] Код соответствует стандартам проекта
- [x] Добавлены/обновлены тесты
- [ ] Документация обновлена (не требуется)

## 🧪 Тестирование
- `npm run test` — 15 файлов / 104 теста, включая новый `src/utils/pricing.test.ts`
- `npm run type-check`, `npm run build` — без ошибок
- `npx biome check` по затронутым файлам — только исторические infos в нетронутых строках
