### PR TITLE
feat: add sort by subscription expiry to user list

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3449,7 +3449,8 @@
         "byDate": "By date",
         "byBalance": "By balance",
         "byActivity": "By activity",
-        "bySpent": "By spending"
+        "bySpent": "By spending",
+        "byExpiry": "By expiry"
       },
       "pagination": {
         "showing": "Showing {{from}}-{{to}} of {{total}}"

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -2956,7 +2956,8 @@
         "byDate": "بر اساس تاریخ",
         "byBalance": "بر اساس موجودی",
         "byActivity": "بر اساس فعالیت",
-        "bySpent": "بر اساس هزینه"
+        "bySpent": "بر اساس هزینه",
+        "byExpiry": "بر اساس انقضا"
       },
       "pagination": {
         "showing": "نمایش {{from}}-{{to}} از {{total}}"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -3846,7 +3846,8 @@
         "byDate": "По дате",
         "byBalance": "По балансу",
         "byActivity": "По активности",
-        "bySpent": "По расходам"
+        "bySpent": "По расходам",
+        "byExpiry": "По истечению подписки"
       },
       "pagination": {
         "showing": "Показано {{from}}-{{to}} из {{total}}"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -2955,7 +2955,8 @@
         "byDate": "按日期",
         "byBalance": "按余额",
         "byActivity": "按活跃度",
-        "bySpent": "按消费"
+        "bySpent": "按消费",
+        "byExpiry": "按到期"
       },
       "pagination": {
         "showing": "显示 {{from}}-{{to}}，共 {{total}}"

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -288,6 +288,7 @@ export default function AdminUsers() {
             <option value="balance">{t('admin.users.filters.byBalance')}</option>
             <option value="last_activity">{t('admin.users.filters.byActivity')}</option>
             <option value="total_spent">{t('admin.users.filters.bySpent')}</option>
+            <option value="subscription_end_date">{t('admin.users.filters.byExpiry')}</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Описание
Добавляет опцию «По истечению подписки» в сортировку списка пользователей админ-кабинета. Работает в паре с backend-PR, добавляющим ключ `subscription_end_date` в параметр `sort_by` API.

## Изменения
- Новый `<option value="subscription_end_date">` в дропдауне сортировки на `AdminUsers.tsx`
- Ключ локализации `byExpiry` во всех четырёх языках (en/ru/fa/zh), в блоке `filters` рядом с `byBalance`/`byActivity`/`bySpent`

## Зависимости
Требует backend-PR: https://github.com/BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot/pull/3129. Без него API не распознаёт ключ сортировки `subscription_end_date`.

## Тип изменений
- [x] New feature