### PR TITLE
fix: показывать полную цену при переносе устройств с classic-подписки

### DIFF
--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -386,11 +386,12 @@ export const subscriptionApi = {
    */
   purchaseWithSbpRecurring: async (
     tariffId: number,
+    subscriptionId?: number,
   ): Promise<{ status: string; redirect_url: string | null; subscription_id: number }> => {
     const response = await apiClient.post(
       '/cabinet/subscription/platega-recurrent/purchase',
       {},
-      { params: { tariff_id: tariffId } },
+      { params: { tariff_id: tariffId, subscription_id: subscriptionId } },
     );
     return response.data;
   },
@@ -429,11 +430,12 @@ export const subscriptionApi = {
    */
   purchaseWithLavaRecurring: async (
     tariffId: number,
+    subscriptionId?: number,
   ): Promise<{ status: string; redirect_url: string | null; subscription_id: number }> => {
     const response = await apiClient.post(
       '/cabinet/subscription/lava-recurrent/purchase',
       {},
-      { params: { tariff_id: tariffId } },
+      { params: { tariff_id: tariffId, subscription_id: subscriptionId } },
     );
     return response.data;
   },

--- a/src/components/subscription/purchase/TariffPickerGrid.tsx
+++ b/src/components/subscription/purchase/TariffPickerGrid.tsx
@@ -205,10 +205,18 @@ export function TariffPickerGrid({
                       tariff.daily_price_kopeks ?? tariff.price_per_day_kopeks ?? 0;
                     const originalDailyPrice = tariff.original_daily_price_kopeks || 0;
                     if (dailyPrice > 0 || originalDailyPrice > 0) {
-                      const promoDaily = applyPromoDiscount(
-                        dailyPrice,
-                        originalDailyPrice > dailyPrice ? originalDailyPrice : undefined,
-                      );
+                      // The backend returns the exact daily charge with promo and
+                      // preserved extra devices already included. Applying the
+                      // cabinet promo a second time would understate the charge.
+                      const promoDaily = {
+                        price: dailyPrice,
+                        original: originalDailyPrice > dailyPrice ? originalDailyPrice : undefined,
+                        percent:
+                          originalDailyPrice > dailyPrice
+                            ? Math.round((1 - dailyPrice / originalDailyPrice) * 100)
+                            : undefined,
+                        isPromoGroup: Boolean(tariff.promo_group_name),
+                      };
                       return (
                         <span className="flex items-center gap-2">
                           <span className="font-medium text-accent-400">

--- a/src/components/subscription/purchase/TariffPurchaseForm.tsx
+++ b/src/components/subscription/purchase/TariffPurchaseForm.tsx
@@ -9,6 +9,7 @@ import { usePromoDiscount } from '../../../hooks/usePromoDiscount';
 import { usePlatform } from '../../../platform';
 import { openPaymentUrl } from '../../../utils/openPaymentUrl';
 import { getMonthlyPriceKopeks } from '../../../utils/pricing';
+import { getCustomDaysTariffPricing } from '../../../utils/tariffPricing';
 import InsufficientBalancePrompt from '../../InsufficientBalancePrompt';
 import type { Tariff, TariffPeriod } from '../../../types';
 
@@ -106,7 +107,7 @@ export function TariffPurchaseForm({
   // СБП-оформление: первое списание = подтверждение привязки в банке; период
   // на форме не участвует — списания идут по каденс-правилу тарифа.
   const sbpPurchaseMutation = useMutation({
-    mutationFn: () => subscriptionApi.purchaseWithSbpRecurring(tariff.id),
+    mutationFn: () => subscriptionApi.purchaseWithSbpRecurring(tariff.id, subscriptionId),
     onSuccess: (data) => {
       if (data.redirect_url) {
         openPaymentUrl(data.redirect_url, platform, openLink);
@@ -147,7 +148,7 @@ export function TariffPurchaseForm({
   );
 
   const lavaPurchaseMutation = useMutation({
-    mutationFn: () => subscriptionApi.purchaseWithLavaRecurring(tariff.id),
+    mutationFn: () => subscriptionApi.purchaseWithLavaRecurring(tariff.id, subscriptionId),
     onSuccess: (data) => {
       if (data.redirect_url) {
         openPaymentUrl(data.redirect_url, platform, openLink);
@@ -443,11 +444,11 @@ export function TariffPurchaseForm({
                       />
                     </div>
                     {(() => {
-                      const basePrice = customDays * (tariff.price_per_day_kopeks ?? 0);
+                      const customPricing = getCustomDaysTariffPricing(tariff, customDays);
+                      const basePrice = customPricing.price;
                       const existingOriginal =
-                        tariff.original_price_per_day_kopeks &&
-                        tariff.original_price_per_day_kopeks > (tariff.price_per_day_kopeks ?? 0)
-                          ? customDays * tariff.original_price_per_day_kopeks
+                        customPricing.originalPrice > customPricing.price
+                          ? customPricing.originalPrice
                           : undefined;
                       const promoCustom = applyPromoDiscount(basePrice, existingOriginal);
                       return (
@@ -575,13 +576,13 @@ export function TariffPurchaseForm({
           {(selectedTariffPeriod || useCustomDays) && (
             <div className="rounded-xl bg-dark-800/50 p-5">
               {(() => {
+                const customDaysPricing = getCustomDaysTariffPricing(tariff, customDays);
                 const basePeriodPrice = useCustomDays
-                  ? customDays * (tariff.price_per_day_kopeks ?? 0)
+                  ? customDaysPricing.price
                   : selectedTariffPeriod?.price_kopeks || 0;
                 const existingPeriodOriginal = useCustomDays
-                  ? tariff.original_price_per_day_kopeks &&
-                    tariff.original_price_per_day_kopeks > (tariff.price_per_day_kopeks ?? 0)
-                    ? customDays * tariff.original_price_per_day_kopeks
+                  ? customDaysPricing.originalPrice > customDaysPricing.price
+                    ? customDaysPricing.originalPrice
                     : undefined
                   : selectedTariffPeriod?.original_price_kopeks &&
                       selectedTariffPeriod.original_price_kopeks > selectedTariffPeriod.price_kopeks

--- a/src/utils/tariffPricing.test.ts
+++ b/src/utils/tariffPricing.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Tariff } from '../types';
+import { getCustomDaysTariffPricing } from './tariffPricing';
+
+const tariff = {
+  extra_devices_count: 2,
+  price_per_day_kopeks: 100,
+  original_price_per_day_kopeks: 120,
+  device_price_kopeks: 500,
+  original_device_price_kopeks: 600,
+} as Tariff;
+
+describe('getCustomDaysTariffPricing', () => {
+  it('includes preserved extra devices in custom-day prices', () => {
+    expect(getCustomDaysTariffPricing(tariff, 45)).toEqual({
+      months: 2,
+      extraDevicesCost: 2000,
+      originalExtraDevicesCost: 2400,
+      price: 6500,
+      originalPrice: 7800,
+    });
+  });
+
+  it('matches backend half-to-even month rounding', () => {
+    expect(getCustomDaysTariffPricing(tariff, 75).months).toBe(2);
+  });
+});

--- a/src/utils/tariffPricing.ts
+++ b/src/utils/tariffPricing.ts
@@ -1,0 +1,28 @@
+import type { Tariff } from '../types';
+
+function roundHalfToEven(value: number): number {
+  const floor = Math.floor(value);
+  const fraction = value - floor;
+  if (fraction === 0.5) return floor % 2 === 0 ? floor : floor + 1;
+  return Math.round(value);
+}
+
+export function getCustomDaysTariffPricing(tariff: Tariff, days: number) {
+  const months = Math.max(1, roundHalfToEven(days / 30));
+  const extraDevices = Math.max(0, tariff.extra_devices_count || 0);
+  const devicePrice = tariff.device_price_kopeks || 0;
+  const originalDevicePrice = tariff.original_device_price_kopeks ?? devicePrice;
+  const pricePerDay = tariff.price_per_day_kopeks || 0;
+  const originalPricePerDay = tariff.original_price_per_day_kopeks ?? pricePerDay;
+
+  const extraDevicesCost = extraDevices * devicePrice * months;
+  const originalExtraDevicesCost = extraDevices * originalDevicePrice * months;
+
+  return {
+    months,
+    extraDevicesCost,
+    originalExtraDevicesCost,
+    price: days * pricePerDay + extraDevicesCost,
+    originalPrice: days * originalPricePerDay + originalExtraDevicesCost,
+  };
+}


### PR DESCRIPTION
## Связанный backend PR

Этот PR дополняет backend-изменения, которые позволяют переносить ранее докупленные устройства при первой покупке тарифа пользователем со старой classic-подпиской.
## Связанный backend PR

- BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#3153



## Что исправлено

Ранее кабинет не во всех сценариях учитывал дополнительные устройства старой classic-подписки.

Из-за этого пользователь мог увидеть базовую стоимость тарифа, хотя backend рассчитывал и списывал полную сумму с учётом сохранённых дополнительных устройств.

Особенно это проявлялось:

- при выборе произвольного количества дней;
- при использовании посуточного тарифа;
- при первой покупке через Platega/СБП или Lava;
- при наличии пользовательской промоскидки.

## Передача выбранной подписки

При покупке через СБП/Platega или Lava кабинет теперь передаёт `subscription_id` выбранной подписки.

Это позволяет backend:

- найти именно выбранную classic-подписку;
- проверить её принадлежность пользователю;
- преобразовать существующую запись в тарифную;
- сохранить идентификатор и историю подписки;
- перенести ранее докупленные устройства;
- не создавать отдельную параллельную подписку.

Передача `subscription_id` также обеспечивает корректную работу в мультитарифном режиме, где у одного пользователя может быть несколько подписок.

## Полная стоимость произвольного периода

Добавлен отдельный клиентский модуль расчёта стоимости тарифа с произвольным количеством дней.

Расчёт учитывает:

- базовую дневную стоимость тарифа;
- выбранное количество дней;
- количество дополнительных устройств;
- стоимость дополнительного устройства;
- количество оплачиваемых месяцев;
- скидку на базовую стоимость;
- отдельную скидку на дополнительные устройства;
- пользовательскую промоскидку.

Количество оплачиваемых месяцев рассчитывается тем же способом, что и на Python-backend:

`max(1, round(days / 30))`

Для совместимости реализовано округление `half-to-even`. Это важно для пограничных значений, например 75 дней, где результат стандартного JavaScript-округления мог отличаться от результата Python.

Теперь предварительная цена в кабинете совпадает с серверным расчётом.

## Посуточные тарифы

Для посуточного тарифа кабинет теперь использует готовую полную стоимость одного списания, полученную из backend `purchase-options`.

Backend уже включает в эту сумму:

- стоимость тарифа за день;
- стоимость дополнительных устройств;
- тарифные скидки;
- пользовательскую промоскидку.

Ранее кабинет повторно применял промоскидку к уже рассчитанной backend-сумме. Это могло привести к отображению заниженной цены.

Повторное применение скидки удалено.

Теперь одинаковая сумма отображается:

- в карточке тарифа;
- в форме подтверждения;
- при проверке доступного баланса;
- перед пополнением;
- при фактическом списании backend.

## Пример

У пользователя имеется старая classic-подписка:

- одно базовое устройство;
- два ранее докупленных устройства;
- общий лимит — три устройства.

Пользователь выбирает тариф, включающий одно устройство.

Кабинет теперь:

1. Получает сохранённый лимит устройств.
2. Определяет два дополнительных устройства.
3. Добавляет их стоимость к цене выбранного периода.
4. Применяет скидки в том же порядке, что и backend.
5. Показывает пользователю полную итоговую сумму.
6. Передаёт идентификатор исходной подписки при покупке через СБП или Lava.

После оплаты backend преобразует эту же подписку в тарифную и сохраняет лимит три устройства.

## Совместимость

PR не меняет структуру базы данных и не требует миграций.

Для корректной работы передачи `subscription_id` требуется связанный backend PR.

Если рекуррентные платежи Platega и Lava отключены, соответствующие изменения клиентского API остаются неактивными и не влияют на обычные способы оплаты.

Обычное пополнение баланса и покупка тарифа с баланса продолжают работать без изменений.

## Проверки

Добавлены unit-тесты для:

- расчёта стоимости дополнительных устройств;
- произвольного количества дней;
- применения скидок;
- совместимости округления с Python;
- пограничных периодов, включая 75 дней.

Также проверены:

- TypeScript-сборка;
- production build;
- форматирование и статический анализ.

Все добавленные unit-тесты и production build проходят успешно.