### PR TITLE
feat(landing): отправлять слаг рекламной кампании при гостевой покупке

### DIFF
--- a/src/api/landings.ts
+++ b/src/api/landings.ts
@@ -114,6 +114,10 @@ export interface PurchaseRequest {
   yandex_cid?: string;
   referrer?: string;
   subid?: string;
+  // Слаг рекламной кампании: без него покупка гостем не попадает в статистику
+  // кампании и не даёт её бонус — auth-флоу, который привязывает кампанию
+  // обычно, на этом пути не срабатывает.
+  campaign_slug?: string;
 }
 
 export interface PurchaseResponse {

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -29,6 +29,7 @@ import { CheckCircleIcon, CheckIcon, DevicesIcon, DownloadIcon } from '@/compone
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import { cn } from '../lib/utils';
 import { getApiErrorMessage } from '../utils/api-error';
+import { getPendingCampaignSlug } from '../utils/campaign';
 import { formatPrice } from '../utils/format';
 import { setFavicon, letterFaviconDataUri, roundedFaviconDataUri } from '../utils/favicon';
 import { useCurrency } from '../hooks/useCurrency';
@@ -1084,6 +1085,12 @@ export default function QuickPurchase() {
     if (ymCid) data.yandex_cid = ymCid;
     const subid = sessionStorage.getItem('landing_subid');
     if (subid) (data as unknown as Record<string, unknown>).subid = subid;
+
+    // Слаг рекламной кампании захватил captureCampaignFromUrl() при заходе по
+    // рекламной ссылке. Читаем БЕЗ потребления: гость может позже войти в
+    // кабинет, и там привязка должна остаться возможной.
+    const campaignSlug = getPendingCampaignSlug();
+    if (campaignSlug) data.campaign_slug = campaignSlug;
 
     // Fire landing-specific click goal
     if (config?.analytics_click_enabled && config?.analytics_click_goal) {


### PR DESCRIPTION
## Проблема

Клиент, пришедший по ссылке рекламной кампании и купивший подписку гостем на лендинге (`/buy/:slug`), не попадает в статистику кампании и не получает её бонус: гостевая покупка не проходит через auth-флоу, в котором `campaign_slug` уходит на бэкенд.

## Решение

Слаг уже лежит в `localStorage` — `captureCampaignFromUrl()` вызывается на уровне модуля в `src/store/auth.ts`, то есть срабатывает на **любом** маршруте SPA, включая `/buy/:slug`. Осталось положить его в запрос покупки, рядом с уже существующими `subid` / `referrer` / `yandex_cid`.

Читаем через `getPendingCampaignSlug()`, то есть **без потребления**: гость может позже войти в кабинет, и там привязка должна остаться возможной. Потребление слага остаётся за auth-флоу.

## Зависимость

Требует поддержки `campaign_slug` в `PurchaseRequest` на стороне бота — BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#3163. До его мержа поле просто игнорируется бэкендом (pydantic отбрасывает лишнее), так что порядок выката некритичен.

## Проверка

- `npm run build` проходит, ошибок TypeScript нет.
- `biome check` на изменённых файлах даёт те же 8 предупреждений, что и на чистом `main` — новых нет.
