### PR TITLE
feat(landing): автозаполнение поля контакта из параметра URL (?contact=...)

### DIFF
--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -870,7 +870,8 @@ export default function QuickPurchase() {
   const contactKey = `lp_contact_${slug ?? ''}`;
   const [contactValue, setContactValue] = useState(() => {
     try {
-      return localStorage.getItem(contactKey) || '';
+      const urlContact = new URLSearchParams(window.location.search).get('contact');
+      return urlContact || localStorage.getItem(contactKey) || '';
     } catch {
       return '';
     }


### PR DESCRIPTION
## Описание
Добавлена возможность автоматического предзаполнения поля контакта (Email или Telegram) на странице быстрой покупки с помощью параметра `contact` в URL. 

## Что было сделано
* Теперь скрипт сначала ищет параметр `contact` в адресной строке (`window.location.search`), если параметр отсутствует - откатывается к предыдущему поведению (чтения параметра из `localStorage`)

## Зачем это нужно
Это позволяет формировать персональные ссылки на оплату для пользователей (например, из Telegram-бота или приложения Happ, пример: `profile-web-page-url`: `https://domain.com/buy/slug?contact=@{{USERNAME}}`). Переход по ссылке вида `https://domain.com/buy/slug?contact=@username` избавит клиента от необходимости вводить контактные данные вручную.

## Как протестировать
1. Открыть страницу покупки по обычной ссылке — поле должно быть пустым (или подтянуться из `localStorage`, если вы вводили данные ранее).
2. Перейти по ссылке с добавленным параметром `?contact=test@example.com`.
3. Убедиться, что поле контакта автоматически заполнилось значением `test@example.com`.
4. То же самое проверить для Telegram: `?contact=@test`.