### PR TITLE
fix(admin): сделать имя пользователя в тикете ссылкой на его профиль

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2671,7 +2671,7 @@
       "reminderCooldownDesc": "Minimum time between reminders (1-120 minutes)",
       "settingsUpdateError": "Error saving settings",
       "copyTelegramId": "Click to copy Telegram ID",
-      "viewUser": "Profile",
+      "viewUser": "User profile",
       "cabinetNotifications": "Cabinet Notifications",
       "userNotificationsEnabled": "User Notifications",
       "userNotificationsEnabledDesc": "Send notifications to users about admin replies",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -2178,7 +2178,7 @@
       "adminNotificationsEnabledDesc": "ارسال اعلان به مدیران درباره تیکت‌ها و پاسخ‌های جدید",
       "cabinetNotifications": "اعلان‌های پنل",
       "copyTelegramId": "برای کپی شناسه تلگرام کلیک کنید",
-      "viewUser": "کاربر",
+      "viewUser": "پروفایل کاربر",
       "userNotificationsEnabled": "اعلان‌های کاربر",
       "userNotificationsEnabledDesc": "ارسال اعلان به کاربران درباره پاسخ‌های مدیر",
       "replyFailed": "ارسال پاسخ ناموفق بود",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -3056,7 +3056,7 @@
       "reminderCooldownDesc": "Минимальное время между напоминаниями (1-120 минут)",
       "settingsUpdateError": "Ошибка сохранения настроек",
       "copyTelegramId": "Нажмите чтобы скопировать Telegram ID",
-      "viewUser": "Карточка",
+      "viewUser": "Профиль пользователя",
       "cabinetNotifications": "Уведомления в кабинете",
       "userNotificationsEnabled": "Уведомления для пользователей",
       "userNotificationsEnabledDesc": "Отправлять уведомления пользователям об ответах админа",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -2245,7 +2245,7 @@
       "adminNotificationsEnabledDesc": "向管理员发送新工单和回复通知",
       "cabinetNotifications": "面板通知",
       "copyTelegramId": "点击复制Telegram ID",
-      "viewUser": "用户",
+      "viewUser": "用户资料",
       "userNotificationsEnabled": "用户通知",
       "userNotificationsEnabledDesc": "向用户发送管理员回复通知",
       "replyFailed": "发送回复失败",

--- a/src/pages/AdminTickets.tsx
+++ b/src/pages/AdminTickets.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import logger from '../utils/logger';
 import { linkifyText } from '../utils/linkify';
 import { MessageMediaGrid } from '../components/tickets/MessageMediaGrid';
-import { useNavigate, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { adminApi, type AdminTicket, type AdminTicketDetail } from '../api/admin';
@@ -485,7 +485,18 @@ export default function AdminTickets() {
                 </div>
                 <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-dark-500">
                   <span>
-                    {t('admin.tickets.from')}: {formatUser(selectedTicket)}
+                    {t('admin.tickets.from')}:{' '}
+                    {selectedTicket.user ? (
+                      <Link
+                        to={`/admin/users/${selectedTicket.user.id}`}
+                        title={t('admin.tickets.viewUser')}
+                        className="font-medium text-accent-400 underline decoration-accent-400/40 underline-offset-2 transition-colors hover:text-accent-300 hover:decoration-accent-300"
+                      >
+                        {formatUser(selectedTicket)}
+                      </Link>
+                    ) : (
+                      formatUser(selectedTicket)
+                    )}
                     {selectedTicket.user?.telegram_id && (
                       <button
                         onClick={() => copyToClipboard(String(selectedTicket.user!.telegram_id))}
@@ -498,14 +509,6 @@ export default function AdminTickets() {
                     | {t('admin.tickets.created')}:{' '}
                     {new Date(selectedTicket.created_at).toLocaleString()}
                   </span>
-                  {selectedTicket.user && (
-                    <button
-                      onClick={() => navigate(`/admin/users/${selectedTicket.user!.id}`)}
-                      className="shrink-0 rounded-lg border border-accent-500/30 bg-accent-500/10 px-2 py-0.5 text-xs text-accent-400 transition-colors hover:bg-accent-500/20"
-                    >
-                      {t('admin.tickets.viewUser')}
-                    </button>
-                  )}
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {['open', 'pending', 'answered', 'closed'].map((s) => (

--- a/src/pages/adminTicketUserLink.test.tsx
+++ b/src/pages/adminTicketUserLink.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PlatformProvider } from '@/platform/PlatformProvider';
+import type { AdminTicketDetail, AdminTicketUser } from '@/api/admin';
+
+/**
+ * Имя автора тикета в шапке карточки — ссылка на его профиль. Раньше оно было
+ * обычным текстом, и найти пользователя по имени приходилось руками через
+ * список: переход прятался в отдельном чипе рядом.
+ *
+ * Тест держит именно контракт «имя = ссылка на /admin/users/:id», а не вёрстку:
+ * ломается он только если имя перестало быть ссылкой или id уехал.
+ */
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: unknown) => (typeof fallback === 'string' ? fallback : key),
+    i18n: { language: 'ru', changeLanguage: () => Promise.resolve() },
+  }),
+  Trans: ({ children }: { children?: unknown }) => children ?? null,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+const ticketUser: AdminTicketUser = {
+  id: 42,
+  telegram_id: 777,
+  username: 'ivan',
+  first_name: 'Иван',
+  last_name: 'Петров',
+};
+
+const ticketDetail = (user: AdminTicketUser | null): AdminTicketDetail => ({
+  id: 1,
+  title: 'Не работает подписка',
+  status: 'open',
+  priority: 'high',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  closed_at: null,
+  is_reply_blocked: false,
+  user,
+  messages: [],
+});
+
+const getTicket = vi.fn();
+
+vi.mock('@/api/admin', () => ({
+  adminApi: {
+    getTicketStats: () =>
+      Promise.resolve({ total: 1, open: 1, pending: 0, answered: 0, closed: 0 }),
+    getTickets: () => Promise.resolve({ items: [], total: 0, page: 1, per_page: 20, pages: 1 }),
+    getTicket: (id: number) => getTicket(id),
+    updateTicketStatus: () => Promise.resolve(),
+    replyToTicket: () => Promise.resolve(),
+  },
+}));
+
+// jsdom не реализует matchMedia, а тема и фоны его спрашивают.
+if (!window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+// Значение подставляет vite через define; в тестах его нет.
+(globalThis as Record<string, unknown>).__APP_VERSION__ ??= '0.0.0-test';
+
+afterEach(cleanup);
+beforeEach(() => getTicket.mockReset());
+
+async function renderTicket() {
+  const AdminTickets = (await import('./AdminTickets')).default;
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <PlatformProvider>
+        <MemoryRouter initialEntries={['/admin/tickets/1']}>
+          <Routes>
+            <Route path="/admin/tickets/:ticketId" element={<AdminTickets />} />
+          </Routes>
+        </MemoryRouter>
+      </PlatformProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('имя пользователя в карточке тикета', () => {
+  it('ведёт на профиль автора', async () => {
+    getTicket.mockResolvedValue(ticketDetail(ticketUser));
+    await renderTicket();
+
+    const link = await screen.findByRole('link', { name: 'Иван Петров' });
+    expect(link.getAttribute('href')).toBe('/admin/users/42');
+  });
+
+  it('остаётся текстом, когда автор недоступен', async () => {
+    getTicket.mockResolvedValue(ticketDetail(null));
+    await renderTicket();
+
+    expect(await screen.findByText(/Unknown/)).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /Unknown/ })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Проблема

В админке в разделе «Управление тикетами» при открытии тикета видно, от какого он пользователя, но имя — обычный текст. Чтобы попасть в карточку автора, нужно было заметить отдельный чип «Карточка» справа в той же строке; найти пользователя по имени вручную через список — заметно дольше.

## Решение

Ссылкой стало само имя — то, на что и тянется курсор:

- имя автора в шапке тикета теперь `<Link>` на `/admin/users/:id`, акцентный цвет с подчёркиванием;
- дублирующий чип убран, шапка стала чище;
- ключ `admin.tickets.viewUser` не удалён, а переиспользован как `title`-тултип ссылки и переформулирован во всех четырёх локалях: «Карточка» / «Profile» ничего не говорили о том, куда ведёт переход — теперь «Профиль пользователя» / «User profile» (аналогично `fa`, `zh`);
- при `user: null` имя остаётся текстом `Unknown`, а не превращается в ссылку на `/admin/users/undefined`.

Кнопка копирования TG-ID и список тикетов слева не затронуты.

## Проверка

- `src/pages/adminTicketUserLink.test.tsx` — держит контракт «имя = ссылка на `/admin/users/:id`» и отдельным кейсом случай `user: null`. Проверил, что тест действительно падает на коде до фикса, а не проходит вхолостую.
- `npm test` — 32 файла, 318 тестов, всё зелёное.
- `npm run type-check`, `biome check` по затронутым файлам — чисто. В `AdminTickets.tsx` заодно стало на один `!`-ассерт меньше (8 → 7 предупреждений biome по файлу).
- Изменение обкатано на проде форка.