### PR TITLE
fix(i18n): не рисовать интерфейс раньше словарей и темы

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,10 +46,62 @@
       })();
     </script>
     <style>
+      /* Фон первой отрисовки — до того, как приедет CSS приложения. Светлый
+         вариант соответствует champagne-200 из globals.css (.light body). */
       body {
         background-color: #0a0f1a;
       }
+      html.light body {
+        background-color: #f7e7ce;
+      }
     </style>
+    <script>
+      // Тема ДО первой отрисовки. useTheme вешает класс в useEffect, то есть уже
+      // после неё, а тут зашиты class="dark" и тёмный фон — пользователь светлой
+      // темы видел тёмную вспышку. Порядок разрешения повторяет useTheme:
+      // сохранённый выбор -> системная тема -> тёмная. Ветку Telegram намеренно
+      // не трогаем: colorScheme доступен только после init() SDK, а внутри
+      // Telegram фон и так задаёт клиент.
+      (function () {
+        try {
+          var enabled = { dark: true, light: true };
+          try {
+            var rawEnabled = localStorage.getItem('cabinet-enabled-themes');
+            if (rawEnabled) {
+              var parsed = JSON.parse(rawEnabled);
+              if (parsed && typeof parsed === 'object') {
+                enabled = { dark: parsed.dark !== false, light: parsed.light !== false };
+              }
+            }
+          } catch (e) {}
+          if (!enabled.dark && !enabled.light) enabled = { dark: true, light: true };
+
+          var stored = null;
+          try {
+            stored = localStorage.getItem('cabinet-theme');
+          } catch (e) {}
+
+          var theme;
+          if (stored === 'light' || stored === 'dark') {
+            theme = enabled[stored] ? stored : enabled.dark ? 'dark' : 'light';
+          } else if (window.matchMedia('(prefers-color-scheme: light)').matches && enabled.light) {
+            theme = 'light';
+          } else {
+            theme = enabled.dark ? 'dark' : 'light';
+          }
+
+          var root = document.documentElement;
+          root.classList.remove('dark', 'light');
+          root.classList.add(theme);
+          if (theme === 'light') {
+            var meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute('content', '#f7e7ce');
+          }
+        } catch (e) {
+          // Хранилище заблокировано — остаётся тёмная тема из разметки.
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/ea/Desktop/DEV/bedolaga-cabinet/node_modules

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import htmlSource from '../index.html?raw';
+import mainSource from './main.tsx?raw';
+
+/**
+ * На холодном кэше интерфейс успевал отрисоваться раньше словарей, и на экране
+ * оставались сырые ключи: `auth.login`, `auth.email`, `common.or`. Ключи с
+ * инлайн-дефолтом — `t('auth.register', 'Register')` — при этом рисовались
+ * по-английски, отчего форма выглядела наполовину переведённой.
+ *
+ * Причина: локали разнесены по ленивым чанкам (`import('./locales/ru.json')`,
+ * ~75 КБ gzip), `react.useSuspense` выключен, а `main.tsx` звал
+ * `createRoot().render()`, не дожидаясь загрузки. С прогретым кэшем чанк
+ * приходил за ~0 мс и успевал к первой отрисовке — отсюда «с некоторой
+ * вероятностью».
+ *
+ * Здесь держится контракт: модуль i18n отдаёт промис готовности, и точка
+ * входа рисует приложение только после него.
+ */
+
+describe('готовность словарей', () => {
+  it('после i18nReady активный язык переведён, а не отдаёт ключи', async () => {
+    const { default: i18n, i18nReady } = await import('./i18n');
+
+    await i18nReady;
+
+    expect(i18n.hasResourceBundle('ru', 'translation')).toBe(true);
+    // Ключи с картинки из репорта.
+    for (const key of ['auth.login', 'auth.email', 'auth.password', 'common.or']) {
+      expect(i18n.t(key)).not.toBe(key);
+    }
+  });
+
+  it('i18nReady не отваливается, даже если словарь не загрузился', async () => {
+    // Промис готовности не должен ронять точку входа: белый экран хуже
+    // непереведённого. Проверяем, что он именно резолвится, а не реджектится.
+    const { i18nReady } = await import('./i18n');
+    await expect(i18nReady).resolves.toBeUndefined();
+  });
+});
+
+describe('точка входа', () => {
+  it('рисует приложение только после i18nReady', () => {
+    expect(mainSource).toMatch(/i18nReady/);
+
+    const readyAt = mainSource.indexOf('i18nReady');
+    const renderAt = mainSource.indexOf('createRoot');
+    expect(readyAt).toBeGreaterThan(-1);
+    expect(readyAt).toBeLessThan(renderAt);
+  });
+});
+
+describe('тема до первой отрисовки', () => {
+  it('index.html применяет сохранённую тему инлайн-скриптом', () => {
+    // Тему вешает useTheme в useEffect, то есть уже ПОСЛЕ первой отрисовки,
+    // а в index.html зашиты class="dark" и тёмный фон. Пользователь светлой
+    // темы поэтому видит тёмную вспышку — тем заметнее, что рендер теперь
+    // ждёт словари.
+    expect(htmlSource).toMatch(/cabinet-theme/);
+  });
+
+  it('ключи хранилища в инлайн-скрипте совпадают с STORAGE_KEYS', async () => {
+    const { STORAGE_KEYS } = await import('./config/constants');
+
+    // Переименуют ключ в constants.ts — инлайн-скрипт молча перестанет
+    // находить тему, и вспышка вернётся без единой ошибки в консоли.
+    expect(htmlSource).toContain(STORAGE_KEYS.THEME);
+    expect(htmlSource).toContain(STORAGE_KEYS.ENABLED_THEMES);
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -55,7 +55,27 @@ i18n
 // Load detected language + fallback on startup
 const detectedLng = i18n.language?.split('-')[0] || FALLBACK_LNG;
 const langsToLoad = [FALLBACK_LNG, ...(detectedLng !== FALLBACK_LNG ? [detectedLng] : [])];
-Promise.all(langsToLoad.map(loadLanguage));
+
+// Сколько ждать словари, прежде чем рисовать без них. Белый экран хуже
+// непереведённого текста: если чанк локали не приехал (сеть отвалилась, прокси
+// отдал 502), приложение обязано появиться.
+const READY_TIMEOUT_MS = 5000;
+
+/**
+ * Резолвится, когда словари активного языка зарегистрированы в i18next.
+ *
+ * Локали лежат в отдельных ленивых чанках (~75 КБ gzip), а `useSuspense`
+ * выключен — значит react-i18next не приостановит отрисовку и `t('auth.login')`
+ * вернёт сам ключ. С прогретым кэшем чанк приходил раньше первой отрисовки и
+ * этого не было видно; на холодном интерфейс успевал нарисоваться с сырыми
+ * ключами. Точка входа ждёт этот промис перед `createRoot().render()`.
+ *
+ * Никогда не реджектится и не висит дольше READY_TIMEOUT_MS.
+ */
+export const i18nReady: Promise<void> = Promise.race([
+  Promise.all(langsToLoad.map(loadLanguage)).then(() => undefined),
+  new Promise<void>((resolve) => setTimeout(resolve, READY_TIMEOUT_MS)),
+]).catch(() => undefined);
 
 // Keep <html lang> + dir in sync with i18n so screen readers pronounce
 // content correctly, browsers don't offer to translate it, and RTL
@@ -87,16 +107,21 @@ i18n.on('languageChanged', (lng: string) => {
  * Telegram client language. Must be called after the Telegram SDK is initialised
  * (e.g. from main.tsx), since launch params are unavailable before init().
  */
-export function applyTelegramLanguage(): void {
+export function applyTelegramLanguage(): Promise<void> {
   try {
-    if (localStorage.getItem(LANGUAGE_STORAGE_KEY)) return; // explicit choice wins
+    if (localStorage.getItem(LANGUAGE_STORAGE_KEY)) return Promise.resolve(); // explicit choice wins
   } catch {
-    return;
+    return Promise.resolve();
   }
   const code = getTelegramLanguageCode();
   if (code && SUPPORTED_LANGS.includes(code) && i18n.language?.split('-')[0] !== code) {
     i18n.changeLanguage(code);
+    // Возвращаем именно загрузку словаря, а не changeLanguage: обработчик
+    // languageChanged тянет чанк отдельно, и без этого ожидания точка входа
+    // нарисовала бы новый язык до его словаря — те же сырые ключи.
+    return loadLanguage(code).catch(() => undefined);
   }
+  return Promise.resolve();
 }
 
 export default i18n;

--- a/src/i18nColdCache.test.tsx
+++ b/src/i18nColdCache.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import i18next from 'i18next';
+import { I18nextProvider, useTranslation } from 'react-i18next';
+import { afterEach, describe, expect, it } from 'vitest';
+import ru from './locales/ru.json';
+
+/**
+ * Воспроизведение самого симптома, а не только контракта модуля: конфигурация
+ * i18next здесь повторяет боевую (ленивая загрузка словаря, `useSuspense: false`),
+ * а чанк локали приезжает с задержкой — как на холодном кэше.
+ *
+ * Так видно, ПОЧЕМУ форма выглядела наполовину переведённой: `t('auth.login')`
+ * отдаёт сам ключ, а `t('auth.register', 'Register')` — инлайн-дефолт. Ровно то,
+ * что на скриншоте из репорта.
+ */
+
+function Form() {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <span data-testid="no-default">{t('auth.login')}</span>
+      <span data-testid="with-default">{t('auth.register', 'Register')}</span>
+    </div>
+  );
+}
+
+async function makeI18n() {
+  const instance = i18next.createInstance();
+  await instance.init({
+    lng: 'ru',
+    fallbackLng: 'ru',
+    partialBundledLanguages: true,
+    resources: {},
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+  });
+  return instance;
+}
+
+function loadRu(instance: typeof i18next, delayMs: number): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(() => {
+      instance.addResourceBundle('ru', 'translation', ru, true, true);
+      resolve();
+    }, delayMs),
+  );
+}
+
+afterEach(cleanup);
+
+describe('отрисовка до словарей (холодный кэш)', () => {
+  it('без ожидания на экране остаются сырые ключи и инлайн-дефолты', async () => {
+    const instance = await makeI18n();
+    const loading = loadRu(instance, 30);
+
+    render(
+      <I18nextProvider i18n={instance}>
+        <Form />
+      </I18nextProvider>,
+    );
+
+    // Ровно картинка из репорта: слева ключ, справа английский дефолт.
+    expect(screen.getByTestId('no-default').textContent).toBe('auth.login');
+    expect(screen.getByTestId('with-default').textContent).toBe('Register');
+
+    await loading;
+  });
+
+  it('после ожидания загрузки — переведено', async () => {
+    const instance = await makeI18n();
+    await loadRu(instance, 30);
+
+    render(
+      <I18nextProvider i18n={instance}>
+        <Form />
+      </I18nextProvider>,
+    );
+
+    const translated = screen.getByTestId('no-default').textContent;
+    expect(translated).not.toBe('auth.login');
+    expect(translated).toBe(ru.auth.login);
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -41,9 +41,14 @@ installEncodingSurrogateGuard();
 // Without this, init() and any launch-params retrieval below throw
 // LaunchParamsRetrieveError on affected devices.
 // See: https://github.com/Telegram-Mini-Apps/tma.js/issues/683
+// Тело полифила берёт hasOwnProperty из прототипа заранее: автофикс biome
+// (noPrototypeBuiltins) переписывает прямой вызов на Object.hasOwn(), то есть на
+// вызов самого полифила — бесконечная рекурсия и падение tsc на target ниже es2022.
+const objectHasOwnProperty = Object.prototype.hasOwnProperty;
 if (typeof (Object as { hasOwn?: unknown }).hasOwn !== 'function') {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (Object as any).hasOwn = (obj: object, prop: PropertyKey): boolean => Object.hasOwn(obj, prop);
+  (Object as any).hasOwn = (obj: object, prop: PropertyKey): boolean =>
+    objectHasOwnProperty.call(obj, prop);
 }
 
 // Only initialize Telegram SDK when running inside Telegram

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,7 +27,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { initLogoPreload } from './api/branding';
 import { checkBackendOnStartup } from './api/health';
 import { getCachedFullscreenEnabled, isTelegramMobile } from './hooks/useTelegramSDK';
-import { applyTelegramLanguage } from './i18n';
+import { applyTelegramLanguage, i18nReady } from './i18n';
 import './styles/globals.css';
 
 // Harden the global encoders against lone UTF-16 surrogates (truncated emoji in
@@ -43,8 +43,7 @@ installEncodingSurrogateGuard();
 // See: https://github.com/Telegram-Mini-Apps/tma.js/issues/683
 if (typeof (Object as { hasOwn?: unknown }).hasOwn !== 'function') {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (Object as any).hasOwn = (obj: object, prop: PropertyKey): boolean =>
-    Object.prototype.hasOwnProperty.call(obj, prop);
+  (Object as any).hasOwn = (obj: object, prop: PropertyKey): boolean => Object.hasOwn(obj, prop);
 }
 
 // Only initialize Telegram SDK when running inside Telegram
@@ -52,6 +51,11 @@ const isTelegramEnv =
   !!(window as unknown as Record<string, unknown>).TelegramWebviewProxy ||
   location.hash.includes('tgWebApp') ||
   location.search.includes('tgWebApp');
+
+// Язык из клиента Telegram может отличаться от определённого по navigator, и его
+// словарь тянется отдельным чанком. Точка входа ждёт и его тоже — иначе смена
+// языка сразу после старта снова покажет сырые ключи.
+let telegramLanguageReady: Promise<void> = Promise.resolve();
 
 const HMR_KEY = '__tg_sdk_initialized';
 const alreadyInitialized = (window as unknown as Record<string, unknown>)[HMR_KEY] === true;
@@ -66,7 +70,7 @@ if (isTelegramEnv && !alreadyInitialized) {
     clearStaleSessionIfNeeded(getTelegramInitData());
 
     // Adopt the user's Telegram client language on first run (no explicit choice yet).
-    applyTelegramLanguage();
+    telegramLanguageReady = applyTelegramLanguage();
 
     // Each mount in its own try/catch so one failure doesn't block others.
     // mountMiniApp() internally mounts themeParams in SDK v3,
@@ -135,12 +139,20 @@ const queryClient = new QueryClient({
   },
 });
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <ErrorBoundary level="app">
-      <QueryClientProvider client={queryClient}>
-        <AppWithNavigator />
-      </QueryClientProvider>
-    </ErrorBoundary>
-  </React.StrictMode>,
-);
+// Рисуем только после словарей. Локали лежат в отдельных ленивых чанках, а
+// react.useSuspense выключен: без ожидания первая отрисовка на холодном кэше
+// уходила с сырыми ключами (`auth.login`, `auth.email`), а ключи с инлайн-
+// дефолтом — по-английски, отчего форма выглядела наполовину переведённой.
+// i18nReady не реджектится и сам снимается по таймауту, так что не приехавший
+// чанк даёт непереведённый текст, а не белый экран.
+void Promise.all([i18nReady, telegramLanguageReady]).then(() => {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <ErrorBoundary level="app">
+        <QueryClientProvider client={queryClient}>
+          <AppWithNavigator />
+        </QueryClientProvider>
+      </ErrorBoundary>
+    </React.StrictMode>,
+  );
+});


### PR DESCRIPTION
## Проблема

По репорту: на холодном кэше (или у нового пользователя) интерфейс с некоторой вероятностью отрисовывается раньше словарей — на экране остаются сырые ключи и мигает тема. Воспроизводится несколькими Ctrl+F5 подряд, от прокси и сервера не зависит.

На скриншоте видна важная деталь: форма выглядит **наполовину** переведённой. `auth.login`, `auth.email`, `common.or` — сырыми ключами, а `Register` и `Forgot password?` — по-английски. Это и указало на причину: в коде `t('auth.login')` без дефолта, а `t('auth.register', 'Register')` — с инлайн-дефолтом. То есть i18next работает, но словаря активного языка у него ещё нет.

## Причина

1. Локали разнесены по **ленивым чанкам**: `import('./locales/ru.json')` → в сборке это отдельный `ru-*.js` на ~293 КБ (75 КБ gzip).
2. Загрузка запускалась как fire-and-forget: `Promise.all(langsToLoad.map(loadLanguage));` — результат никуда не сохранялся.
3. `react: { useSuspense: false }` — react-i18next отрисовку не приостанавливает.
4. `main.tsx` звал `createRoot().render()` сразу, следующей строкой после импорта `./i18n`.

С прогретым кэшем чанк резолвится за ~0 мс и успевает к первой отрисовке. С холодным это отдельный сетевой запрос — React успевает смонтироваться и покрасить раньше. Отсюда «с некоторой вероятностью».

Вторая половина репорта — вспышка темы — отдельная причина: `index.html` жёстко задаёт `class="dark"` и тёмный фон, а сохранённая тема применяется в `useEffect` внутри `useTheme`, то есть **после** первой отрисовки. Пользователь светлой темы видит тёмную вспышку. С ожиданием словарей она стала бы заметнее, поэтому чиню здесь же.

## Что сделано

- `i18n.ts` отдаёт **`i18nReady`** — промис готовности словарей активного языка. Он не реджектится и снимается по таймауту 5 с: не приехавший чанк должен давать непереведённый текст, а не белый экран.
- `main.tsx` рисует приложение только после него.
- `applyTelegramLanguage()` теперь возвращает загрузку словаря, и точка входа ждёт и её. Язык из клиента Telegram может отличаться от определённого по `navigator`, а его словарь тянется отдельным чанком — без ожидания смена языка сразу после старта давала ровно те же сырые ключи.
- Тема применяется **инлайн-скриптом до первой отрисовки**. Порядок разрешения повторяет `useTheme`: сохранённый выбор → системная тема → тёмная; ветка Telegram намеренно не трогается (`colorScheme` доступен только после `init()` SDK). Фон первой отрисовки для светлой темы вынесен в `html.light body`.

## Тесты

- `src/i18nColdCache.test.tsx` — воспроизводит **сам симптом** на боевой конфигурации i18next (ленивый словарь, `useSuspense: false`): до загрузки `t('auth.login')` отдаёт ключ, а `t('auth.register', 'Register')` — английский дефолт, ровно как на скриншоте; после загрузки — перевод.
- `src/i18n.test.ts` — контракт готовности (`i18nReady` резолвится, активный язык переведён, промис не реджектится), ратчет на то, что точка входа ждёт его перед `createRoot`, и сверка ключей хранилища в инлайн-скрипте с `STORAGE_KEYS` — иначе переименование ключа молча вернёт вспышку.

Все 5 тестов контракта и оба воспроизводящих падают на `dev`.

## Проверки

`vitest` — **502 прошли (48 файлов)**. `tsc --noEmit` чисто, `biome check` по своим файлам чисто (3 предупреждения в `main.tsx` — предсуществующие, есть и на `dev`), сборка проходит. Проверил собранный `dist/index.html`: инлайн-скрипт и правило `html.light body` на месте, локали остались ленивыми чанками.

## Что осталось

Заголовок вкладки по-прежнему моргает `VPN` → имя из настроек: `document.title` выставляется в эффекте по данным XHR, и без кэширования имени это не убрать. Вынес бы отдельно, если нужно.