### PR TITLE
Релиз: починка кастомных тем — сохранение цветов, фон светлой темы, точный акцент, текст карточек

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,11 +47,16 @@
     </script>
     <style>
       /* Фон первой отрисовки — до того, как приедет CSS приложения. Светлый
-         вариант соответствует champagne-200 из globals.css (.light body). */
+         вариант соответствует champagne-200 из globals.css (.light body).
+         Специфичность обоих правил обязана оставаться (0,0,1): фон темы в
+         globals.css задаёт `.light body` (0,1,1) операторским цветом, а
+         @layer base в Tailwind v3 — не настоящий каскадный слой. Более
+         специфичный селектор здесь (например `html.light body`) навсегда
+         перекрывал бы кастомный светлый фон. :where() обнуляет вклад класса. */
       body {
         background-color: #0a0f1a;
       }
-      html.light body {
+      :where(html.light) body {
         background-color: #f7e7ce;
       }
     </style>

--- a/src/components/admin/ThemeTab.test.tsx
+++ b/src/components/admin/ThemeTab.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ruLocale from '@/locales/ru.json';
+import { DEFAULT_THEME_COLORS, type ThemeColors } from '@/types/theme';
+import { THEME_PRESETS } from './constants';
+
+/**
+ * Ручная настройка цветов темы в админке.
+ *
+ * Редактор держит черновик отдельно от сохранённого снимка и показывает
+ * «Сохранить», пока они расходятся. Для живого превью он же пишет черновик в
+ * кэш запроса `theme-colors` (с задержкой 150 мс), а эффект синхронизации с
+ * сервером слушает тот же кэш. Эхо собственной записи не должно превращать
+ * черновик в «сохранённое»: иначе кнопка исчезает, PATCH не уходит, а после
+ * перезагрузки цвета откатываются.
+ */
+
+function resolveRu(key: string): string | undefined {
+  const value = key
+    .split('.')
+    .reduce<unknown>((node, part) => (node as Record<string, unknown>)?.[part], ruLocale);
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Строка из ru.json, обязанная существовать: забытый перевод валит тест, а не маскируется ключом. */
+function ru(key: string): string {
+  const value = resolveRu(key);
+  if (value === undefined) throw new Error(`ru.json: нет строки ${key}`);
+  return value;
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown> | string) => {
+      const fallback = typeof options === 'string' ? options : (options?.defaultValue as string);
+      return resolveRu(key) ?? fallback ?? key;
+    },
+    i18n: { language: 'ru', changeLanguage: () => Promise.resolve() },
+  }),
+  Trans: ({ children }: { children?: unknown }) => children ?? null,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+const state: { serverColors: ThemeColors; patches: Partial<ThemeColors>[] } = {
+  serverColors: DEFAULT_THEME_COLORS,
+  patches: [],
+};
+
+vi.mock('@/api/themeColors', () => ({
+  themeColorsApi: {
+    getColors: () => Promise.resolve(state.serverColors),
+    updateColors: (patch: Partial<ThemeColors>) => {
+      state.patches.push(patch);
+      state.serverColors = { ...state.serverColors, ...patch };
+      return Promise.resolve(state.serverColors);
+    },
+    resetColors: () => {
+      state.serverColors = DEFAULT_THEME_COLORS;
+      return Promise.resolve(state.serverColors);
+    },
+    getEnabledThemes: () => Promise.resolve({ dark: true, light: true }),
+    updateEnabledThemes: (themes: { dark?: boolean; light?: boolean }) =>
+      Promise.resolve({ dark: true, light: true, ...themes }),
+  },
+}));
+
+function presetColors(id: string): ThemeColors {
+  const preset = THEME_PRESETS.find((candidate) => candidate.id === id);
+  if (!preset) throw new Error(`THEME_PRESETS: нет пресета ${id}`);
+  return preset.colors as ThemeColors;
+}
+
+const OCEAN = presetColors('ocean');
+const DEBOUNCE_MS = 150;
+
+const SAVE = ru('common.save');
+const CUSTOM_COLORS = ru('admin.settings.customColors');
+
+// jsdom без pretendToBeVisual не даёт requestAnimationFrame, а превью на нём.
+if (typeof globalThis.requestAnimationFrame !== 'function') {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) =>
+    window.setTimeout(() => cb(performance.now()), 0);
+  globalThis.cancelAnimationFrame = (id: number) => window.clearTimeout(id);
+}
+
+async function renderThemeTab() {
+  const { ThemeTab } = await import('./ThemeTab');
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeTab />
+    </QueryClientProvider>,
+  );
+
+  fireEvent.click(await screen.findByText(CUSTOM_COLORS));
+
+  // Первый пикер в разметке — акцентный цвет; ждём, пока в него приедут
+  // серверные значения, а не начальные дефолты черновика.
+  const accentInput = await waitFor(() => {
+    const inputs = screen.getAllByPlaceholderText('#000000') as HTMLInputElement[];
+    expect(inputs[0].value.toLowerCase()).toBe(state.serverColors.accent.toLowerCase());
+    return inputs[0];
+  });
+
+  return { accentInput, queryClient };
+}
+
+async function letDebounceFire() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_MS * 2));
+  });
+}
+
+beforeEach(() => {
+  state.patches = [];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ThemeTab: ручная настройка цветов', () => {
+  it.each([
+    ['сохранённые цвета — дефолтные (свежая установка или после сброса)', DEFAULT_THEME_COLORS],
+    ['сохранённые цвета уже кастомные', OCEAN],
+  ])('изменённый цвет можно сохранить: %s', async (_label, saved) => {
+    state.serverColors = saved;
+    const { accentInput } = await renderThemeTab();
+
+    fireEvent.change(accentInput, { target: { value: '#ff0000' } });
+    expect(screen.getByText(SAVE)).toBeTruthy();
+
+    // Через 150 мс черновик уходит в кэш `theme-colors` для превью — и
+    // возвращается в эффект синхронизации. Кнопка обязана пережить это эхо.
+    await letDebounceFire();
+    expect(screen.queryByText(SAVE)).not.toBeNull();
+
+    fireEvent.click(screen.getByText(SAVE));
+
+    await waitFor(() => expect(state.patches).toHaveLength(1));
+    expect(state.patches[0]).toMatchObject({ accent: '#ff0000' });
+    await waitFor(() => expect(screen.queryByText(SAVE)).toBeNull());
+  });
+
+  it('без локальных правок новые серверные цвета подхватываются в редактор', async () => {
+    state.serverColors = DEFAULT_THEME_COLORS;
+    const { accentInput, queryClient } = await renderThemeTab();
+
+    // Так выглядит refetch или сохранение из другой вкладки.
+    act(() => {
+      queryClient.setQueryData(['theme-colors'], OCEAN);
+    });
+
+    await waitFor(() => expect(accentInput.value.toLowerCase()).toBe(OCEAN.accent.toLowerCase()));
+    expect(screen.queryByText(SAVE)).toBeNull();
+  });
+});

--- a/src/components/admin/ThemeTab.tsx
+++ b/src/components/admin/ThemeTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { themeColorsApi } from '../../api/themeColors';
-import { DEFAULT_THEME_COLORS, ThemeColors } from '../../types/theme';
+import { DEFAULT_THEME_COLORS, type ThemeColors } from '../../types/theme';
 import { ColorPicker } from '../ColorPicker';
 import { applyThemeColors } from '../../hooks/useThemeColors';
 import { updateEnabledThemesCache } from '../../hooks/useTheme';
@@ -79,11 +79,13 @@ export function ThemeTab() {
         warning: serverColors.warning,
         error: serverColors.error,
       };
-      // Only sync if saved snapshot matches current draft (no unsaved changes)
-      if (
-        colorsEqual(savedColorsRef.current, draftColorsRef.current) ||
-        colorsEqual(savedColorsRef.current, DEFAULT_THEME_COLORS)
-      ) {
+      // Подхватываем данные из кэша только пока черновик совпадает с сохранённым
+      // снимком. Черновик сам уходит в этот кэш для живого превью (updateDraftColor,
+      // с задержкой 150 мс) и возвращается сюда эхом; при несохранённых правках его
+      // нельзя принимать за серверное состояние — иначе они выглядят сохранёнными,
+      // кнопка «Сохранить» исчезает, PATCH не уходит. Ветка «сохранённое == дефолты»
+      // пропускала это эхо у каждой свежей инсталляции и после «Сбросить все цвета».
+      if (colorsEqual(savedColorsRef.current, draftColorsRef.current)) {
         setDraftColors(colors);
         savedColorsRef.current = colors;
       }

--- a/src/hooks/useThemeColors.test.ts
+++ b/src/hooks/useThemeColors.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { applyThemeColors } from './useThemeColors';
+import { DEFAULT_THEME_COLORS, SHADE_LEVELS } from '../types/theme';
+
+/**
+ * Палитра статусных цветов строится из одного выбранного оператором цвета.
+ * Контракт: шейд 500 — ровно выбранный цвет (его видят кнопки и активные
+ * состояния), остальные шейды монотонно светлее/темнее его, а текстовые
+ * шейды читаемы на поверхностях темы, каким бы светлым или тёмным ни был
+ * базовый цвет.
+ */
+
+type Rgb = { r: number; g: number; b: number };
+
+function readVar(name: string): string {
+  return document.documentElement.style.getPropertyValue(name).trim();
+}
+
+function parseTriplet(triplet: string): Rgb {
+  const [r, g, b] = triplet.split(',').map((part) => Number(part.trim()));
+  return { r, g, b };
+}
+
+function hexToTriplet(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `${r}, ${g}, ${b}`;
+}
+
+function luminance({ r, g, b }: Rgb): number {
+  const channel = (v: number) => {
+    const c = v / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+const PASTEL_ACCENT = '#a5b4fc'; // светлая лаванда, L≈82
+const NAVY_ACCENT = '#1e3a8a'; // тёмный синий, L≈33
+
+afterEach(() => {
+  document.documentElement.removeAttribute('style');
+});
+
+describe('applyThemeColors: статусные палитры', () => {
+  it('шейд 500 — ровно выбранный оператором цвет', () => {
+    applyThemeColors({
+      ...DEFAULT_THEME_COLORS,
+      accent: PASTEL_ACCENT,
+      success: NAVY_ACCENT,
+      warning: '#f97316',
+      error: '#dc2626',
+    });
+
+    expect(readVar('--color-accent-500')).toBe(hexToTriplet(PASTEL_ACCENT));
+    expect(readVar('--color-success-500')).toBe(hexToTriplet(NAVY_ACCENT));
+    expect(readVar('--color-warning-500')).toBe(hexToTriplet('#f97316'));
+    expect(readVar('--color-error-500')).toBe(hexToTriplet('#dc2626'));
+  });
+
+  it('дефолтная палитра в рантайме совпадает со статикой globals.css', () => {
+    // Иначе после загрузки JS цвета «уезжают» относительно первой отрисовки.
+    applyThemeColors(DEFAULT_THEME_COLORS);
+
+    expect(readVar('--color-accent-500')).toBe('59, 130, 246');
+    expect(readVar('--color-success-500')).toBe('34, 197, 94');
+    expect(readVar('--color-warning-500')).toBe('245, 158, 11');
+    expect(readVar('--color-error-500')).toBe('239, 68, 68');
+  });
+
+  it.each([
+    ['пастельный', PASTEL_ACCENT],
+    ['тёмный', NAVY_ACCENT],
+    ['дефолтный', DEFAULT_THEME_COLORS.accent],
+  ])('лестница шейдов монотонна от светлого к тёмному: %s акцент', (_label, accent) => {
+    applyThemeColors({ ...DEFAULT_THEME_COLORS, accent });
+
+    const ladder = SHADE_LEVELS.map((shade) =>
+      luminance(parseTriplet(readVar(`--color-accent-${shade}`))),
+    );
+    for (let i = 1; i < ladder.length; i += 1) {
+      expect(ladder[i]).toBeLessThanOrEqual(ladder[i - 1]);
+    }
+  });
+
+  it('текстовые шейды читаемы на поверхностях темы при крайних базовых цветах', () => {
+    const darkSurface = parseTriplet(hexToTriplet(DEFAULT_THEME_COLORS.darkSurface));
+    const lightSurface = parseTriplet(hexToTriplet(DEFAULT_THEME_COLORS.lightSurface));
+
+    // Тёмный акцент: в тёмной теме текстом идут 300/400.
+    applyThemeColors({ ...DEFAULT_THEME_COLORS, accent: NAVY_ACCENT });
+    expect(
+      contrast(parseTriplet(readVar('--color-accent-400')), darkSurface),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      contrast(parseTriplet(readVar('--color-accent-300')), darkSurface),
+    ).toBeGreaterThanOrEqual(4.5);
+
+    // Светлый акцент: .light подменяет 300/400 на 700.
+    applyThemeColors({ ...DEFAULT_THEME_COLORS, accent: PASTEL_ACCENT });
+    expect(
+      contrast(parseTriplet(readVar('--color-accent-700')), lightSurface),
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('текст поверх светлого акцента — тёмный, поверх тёмного и дефолтного — белый', () => {
+    applyThemeColors({ ...DEFAULT_THEME_COLORS, accent: PASTEL_ACCENT });
+    expect(readVar('--color-on-accent')).toBe('15, 23, 42');
+
+    applyThemeColors({ ...DEFAULT_THEME_COLORS, accent: NAVY_ACCENT });
+    expect(readVar('--color-on-accent')).toBe('255, 255, 255');
+
+    // На дефолтном синем белый даёт 3.7:1 — привычный белый текст кнопок
+    // остаётся, хотя формально тёмный контрастнее (4.8:1).
+    applyThemeColors(DEFAULT_THEME_COLORS);
+    expect(readVar('--color-on-accent')).toBe('255, 255, 255');
+    expect(readVar('--color-on-error')).toBe('255, 255, 255');
+    expect(readVar('--color-on-success')).toBe('15, 23, 42');
+    expect(readVar('--color-on-warning')).toBe('15, 23, 42');
+  });
+});

--- a/src/hooks/useThemeColors.ts
+++ b/src/hooks/useThemeColors.ts
@@ -1,7 +1,13 @@
 import { useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { themeColorsApi } from '../api/themeColors';
-import { ThemeColors, DEFAULT_THEME_COLORS, SHADE_LEVELS, ColorPalette } from '../types/theme';
+import {
+  type ThemeColors,
+  DEFAULT_THEME_COLORS,
+  SHADE_LEVELS,
+  type ColorPalette,
+  type ShadeLevel,
+} from '../types/theme';
 import { hexToRgb, hexToHsl, hslToRgb } from '../utils/colorConversion';
 
 // Convert RGB to string format for CSS variable
@@ -9,32 +15,53 @@ function rgbToString(r: number, g: number, b: number): string {
   return `${r}, ${g}, ${b}`;
 }
 
-// Generate color palette from base color (returns RGB strings)
+// Опорная светлота шейдов для базового цвета с L = 50 %. Для реального базового
+// цвета лестница масштабируется: 500 — ровно выбранный цвет, светлые шейды
+// растягиваются от него к 97 (шейд 50), тёмные — к 10 (шейд 950).
+const LIGHTNESS_LADDER: Record<ShadeLevel, number> = {
+  50: 97,
+  100: 94,
+  200: 86,
+  300: 76,
+  400: 64,
+  500: 50,
+  600: 42,
+  700: 34,
+  800: 26,
+  900: 18,
+  950: 10,
+};
+const LADDER_TOP = LIGHTNESS_LADDER[50];
+const LADDER_MID = LIGHTNESS_LADDER[500];
+const LADDER_BOTTOM = LIGHTNESS_LADDER[950];
+
+function shadeLightness(shade: ShadeLevel, baseLightness: number): number {
+  const target = LIGHTNESS_LADDER[shade];
+  if (target > LADDER_MID) {
+    const share = (target - LADDER_MID) / (LADDER_TOP - LADDER_MID);
+    return Math.max(baseLightness, baseLightness + share * (LADDER_TOP - baseLightness));
+  }
+  const share = (LADDER_MID - target) / (LADDER_MID - LADDER_BOTTOM);
+  return Math.min(baseLightness, baseLightness - share * (baseLightness - LADDER_BOTTOM));
+}
+
+// Generate color palette from base color (returns RGB strings).
+// Шейд 500 — сам выбранный цвет. Раньше он принудительно получал L = 50 %:
+// оператор выбирал один цвет, а кнопки красились другим (пастель становилась
+// насыщенной, дефолтный #3b82f6 уезжал в 11,100,244 против статики globals.css).
 function generatePalette(baseHex: string): ColorPalette {
-  const { h, s } = hexToHsl(baseHex);
-
-  // Lightness values for each shade level (from light to dark)
-  const lightnessMap: Record<number, number> = {
-    50: 97,
-    100: 94,
-    200: 86,
-    300: 76,
-    400: 64,
-    500: 50,
-    600: 42,
-    700: 34,
-    800: 26,
-    900: 18,
-    950: 10,
-  };
-
+  const base = hexToRgb(baseHex);
+  const { h, s, l } = hexToHsl(baseHex);
   const palette: Partial<ColorPalette> = {};
 
   for (const shade of SHADE_LEVELS) {
-    const lightness = lightnessMap[shade];
+    if (shade === 500) {
+      palette[shade] = rgbToString(base.r, base.g, base.b);
+      continue;
+    }
     // Adjust saturation slightly for very light/dark shades
     const adjustedS = shade <= 100 ? s * 0.7 : shade >= 900 ? s * 0.8 : s;
-    const { r, g, b } = hslToRgb(h, adjustedS, lightness);
+    const { r, g, b } = hslToRgb(h, adjustedS, shadeLightness(shade, l));
     palette[shade] = rgbToString(r, g, b);
   }
 
@@ -68,7 +95,7 @@ function mixRgb(rgb1: Rgb, rgb2: Rgb, factor: number): Rgb {
 function relativeLuminance({ r, g, b }: Rgb): number {
   const srgb = (v: number) => {
     const c = v / 255;
-    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
   };
   return 0.2126 * srgb(r) + 0.7152 * srgb(g) + 0.0722 * srgb(b);
 }
@@ -99,14 +126,52 @@ function ensureReadable(fg: Rgb, towards: Rgb, bg: Rgb, minRatio: number): Rgb {
   return towards;
 }
 
-// Black-or-white text for a given button/badge background: pick whichever
-// side actually reads on top of it (operators may choose a light accent).
+function parseTriplet(triplet: string): Rgb {
+  const [r, g, b] = triplet.split(',').map((x) => Number(x.trim()));
+  return { r, g, b };
+}
+
+function tripletOf({ r, g, b }: Rgb): string {
+  return rgbToString(r, g, b);
+}
+
+// Белый текст на заливке остаётся, пока даёт AA для UI-элементов (3:1) —
+// так на средних по светлоте цветах (синий #3b82f6: белый 3.7, тёмный 4.8)
+// сохраняется привычный белый на кнопках. Ниже порога берётся сторона с
+// лучшим контрастом: на пастельном акценте это тёмный текст.
+const ON_COLOR_WHITE_MIN_RATIO = 3;
+
+// Black-or-white text for a given button/badge background.
 function onColorFor(bgTriplet: string): string {
-  const [r, g, b] = bgTriplet.split(',').map((x) => Number(x.trim()));
-  const bg = { r, g, b };
+  const bg = parseTriplet(bgTriplet);
   const white = { r: 255, g: 255, b: 255 };
   const ink = { r: 15, g: 23, b: 42 };
-  return contrastRatio(white, bg) >= contrastRatio(ink, bg) ? '255, 255, 255' : '15, 23, 42';
+  const whiteRatio = contrastRatio(white, bg);
+  if (whiteRatio >= ON_COLOR_WHITE_MIN_RATIO) return '255, 255, 255';
+  return whiteRatio >= contrastRatio(ink, bg) ? '255, 255, 255' : '15, 23, 42';
+}
+
+type ThemeSurfaces = { surface: Rgb; text: Rgb };
+const TEXT_SHADE_MIN_RATIO = 4.5;
+
+// Текстовые шейды статусных палитр: 300/400 — текст в тёмной теме (ссылки,
+// суммы, бейджи), 700 — их замена в светлой (.light ремапит *-300/400 -> *-700).
+// Лестница привязана к базовому цвету, поэтому у тёмного акцента светлые шейды
+// сжимаются, у светлого — тёмные; здесь им гарантируется AA на поверхности
+// своей темы. Палитры, которые и так читаются, остаются нетронутыми.
+function withReadableTextShades(
+  palette: ColorPalette,
+  dark: ThemeSurfaces,
+  light: ThemeSurfaces,
+): ColorPalette {
+  const readable = (shade: ShadeLevel, towards: Rgb, bg: Rgb) =>
+    tripletOf(ensureReadable(parseTriplet(palette[shade]), towards, bg, TEXT_SHADE_MIN_RATIO));
+  return {
+    ...palette,
+    300: readable(300, dark.text, dark.surface),
+    400: readable(400, dark.text, dark.surface),
+    700: readable(700, light.text, light.surface),
+  };
 }
 
 // Apply theme colors as CSS variables (RGB format for Tailwind opacity support)
@@ -231,19 +296,26 @@ export function applyThemeColors(themeColors: ThemeColors): void {
     rgbToString(lightTextRgb.r, lightTextRgb.g, lightTextRgb.b),
   );
 
+  const darkSurfaces: ThemeSurfaces = { surface: darkSurfaceRgb, text: darkTextRgb };
+  const lightSurfaces: ThemeSurfaces = { surface: lightSurfaceRgb, text: lightTextRgb };
+  const accent = withReadableTextShades(accentPalette, darkSurfaces, lightSurfaces);
+  const success = withReadableTextShades(successPalette, darkSurfaces, lightSurfaces);
+  const warning = withReadableTextShades(warningPalette, darkSurfaces, lightSurfaces);
+  const error = withReadableTextShades(errorPalette, darkSurfaces, lightSurfaces);
+
   for (const shade of SHADE_LEVELS) {
-    root.style.setProperty(`--color-accent-${shade}`, accentPalette[shade]);
-    root.style.setProperty(`--color-success-${shade}`, successPalette[shade]);
-    root.style.setProperty(`--color-warning-${shade}`, warningPalette[shade]);
-    root.style.setProperty(`--color-error-${shade}`, errorPalette[shade]);
+    root.style.setProperty(`--color-accent-${shade}`, accent[shade]);
+    root.style.setProperty(`--color-success-${shade}`, success[shade]);
+    root.style.setProperty(`--color-warning-${shade}`, warning[shade]);
+    root.style.setProperty(`--color-error-${shade}`, error[shade]);
   }
 
   // Readable text color on top of each status color (buttons, filled badges).
   // Hardcoded white breaks the moment an operator picks a light accent.
-  root.style.setProperty('--color-on-accent', onColorFor(accentPalette[500]));
-  root.style.setProperty('--color-on-success', onColorFor(successPalette[500]));
-  root.style.setProperty('--color-on-warning', onColorFor(warningPalette[500]));
-  root.style.setProperty('--color-on-error', onColorFor(errorPalette[500]));
+  root.style.setProperty('--color-on-accent', onColorFor(accent[500]));
+  root.style.setProperty('--color-on-success', onColorFor(success[500]));
+  root.style.setProperty('--color-on-warning', onColorFor(warning[500]));
+  root.style.setProperty('--color-on-error', onColorFor(error[500]));
 
   // Apply semantic colors (hex for direct use)
   root.style.setProperty('--color-dark-bg', colors.darkBackground);

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -68,4 +68,35 @@ describe('тема до первой отрисовки', () => {
     expect(htmlSource).toContain(STORAGE_KEYS.THEME);
     expect(htmlSource).toContain(STORAGE_KEYS.ENABLED_THEMES);
   });
+
+  it('фон первой отрисовки уступает фону темы из CSS приложения', () => {
+    // Инлайн-стиль index.html — только заглушка до прихода CSS приложения.
+    // Фон светлой темы там задаёт `.light body` (специфичность 0,1,1) через
+    // операторский цвет из applyThemeColors; `@layer base` в Tailwind v3 — не
+    // настоящий каскадный слой, так что более специфичный селектор в index.html
+    // (`html.light body`, 0,1,2) молча перекрывал бы кастомный фон навсегда.
+    const inlineCss = /<style>([\s\S]*?)<\/style>/.exec(htmlSource)?.[1];
+    expect(inlineCss).toBeTruthy();
+
+    const root = document.documentElement;
+    const inline = document.createElement('style');
+    inline.textContent = inlineCss ?? '';
+    const app = document.createElement('style');
+    app.textContent = '.light body { background-color: rgb(1, 2, 3); }';
+    const bodyBg = () => getComputedStyle(document.body).backgroundColor;
+
+    root.className = 'light';
+    document.head.append(inline);
+    try {
+      // До CSS приложения заглушка обязана рисовать светлый фон, не тёмный.
+      expect(bodyBg()).toBe('rgb(247, 231, 206)');
+
+      document.head.append(app);
+      expect(bodyBg()).toBe('rgb(1, 2, 3)');
+    } finally {
+      inline.remove();
+      app.remove();
+      root.className = '';
+    }
+  });
 });

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -1912,7 +1912,7 @@ export default function Subscription() {
                           height="16"
                           viewBox="0 0 24 24"
                           fill="none"
-                          stroke={g.textSecondary}
+                          style={{ stroke: g.textSecondary }}
                           strokeWidth="1.5"
                           strokeLinecap="round"
                           strokeLinejoin="round"

--- a/src/utils/glassTheme.test.ts
+++ b/src/utils/glassTheme.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getGlassColors } from './glassTheme';
+
+/**
+ * Стеклянные карточки (дашборд, подписки) раньше красили текст зашитыми
+ * белым/чёрным по isDark и не видели операторский цвет текста. Токены текста
+ * обязаны идти через переменную темы.
+ */
+describe('getGlassColors', () => {
+  it.each([true, false])('текстовые токены берут цвет текста темы (isDark=%s)', (isDark) => {
+    const g = getGlassColors(isDark);
+    for (const token of [g.text, g.textSecondary, g.textMuted, g.textFaint, g.textGhost]) {
+      expect(token).toContain('var(--color-dark-50)');
+    }
+  });
+});

--- a/src/utils/glassTheme.ts
+++ b/src/utils/glassTheme.ts
@@ -3,6 +3,9 @@
  * Provides consistent colors for the glassmorphic card components
  * that work on both dark and light backgrounds.
  */
+// Цвет текста темы: darkText в тёмной, через ремап .light — lightText в светлой.
+const TEXT_VAR = '--color-dark-50';
+
 export function getGlassColors(isDark: boolean) {
   return {
     // Card container
@@ -19,12 +22,15 @@ export function getGlassColors(isDark: boolean) {
     hoverBg: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.05)',
     hoverBorder: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.1)',
 
-    // Text
-    text: isDark ? '#fff' : '#1a1a2e',
-    textSecondary: isDark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.5)',
-    textMuted: isDark ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.35)',
-    textFaint: isDark ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.25)',
-    textGhost: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+    // Text — из палитры оператора, а не зашитые белый/чёрный: иначе кастомный
+    // цвет текста не доходил до дашборда и карточек подписок. Годится только
+    // для CSS-свойств: в SVG-атрибутах var() не раскрывается — там передавать
+    // через style={{ stroke }}.
+    text: `rgb(var(${TEXT_VAR}))`,
+    textSecondary: `rgba(var(${TEXT_VAR}), ${isDark ? 0.4 : 0.5})`,
+    textMuted: `rgba(var(${TEXT_VAR}), ${isDark ? 0.3 : 0.35})`,
+    textFaint: `rgba(var(${TEXT_VAR}), 0.25)`,
+    textGhost: `rgba(var(${TEXT_VAR}), ${isDark ? 0.08 : 0.06})`,
 
     // Progress bar track
     trackBg: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',


### PR DESCRIPTION
## Что сделано

**Темы**
- **Сохранение кастомных цветов** в админке. При дефолтной палитре (свежая установка или после «Сбросить все цвета») кнопка «Сохранить» появлялась и через 150 мс исчезала: PATCH не уходил, после перезагрузки цвета откатывались. Причина — эхо собственной записи черновика в кэш запроса `theme-colors` принималось за серверное состояние. Закрыто, регресс-тест на реальном ColorPicker для обоих состояний сохранённой палитры.
- **Фон светлой темы.** Заглушка первой отрисовки в index.html (`html.light body`) по специфичности перебивала операторский фон из globals.css (`.light body`), и страница за карточками всегда оставалась дефолтным шампанем. Селектор переведён на `:where(html.light) body`, анти-флэш до загрузки CSS сохранён, сторож-тест каскада в jsdom.
- **Точный акцент.** Генератор палитры принудительно ставил шейду 500 светлоту 50%, поэтому выбранный оператором цвет никогда не совпадал с цветом кнопок: дефолтный `#3b82f6` (59,130,246) в рантайме становился 11,100,244, а пастель — насыщенной. Теперь 500 — ровно выбранный цвет, остальные шейды масштабируются от него; текстовым шейдам (300/400 в тёмной, 700 в светлой) гарантирован AA 4.5:1 на поверхности своей темы; белый текст на заливке остаётся, пока даёт 3:1, иначе берётся более контрастный.
- **Текст стеклянных карточек** (дашборд, карточки подписок) берёт цвет из палитры оператора вместо зашитых белого/чёрного; единственный SVG-атрибут переведён на `style`.

Только фронт: бот обновлять не требуется.

---

Тестировать не нужно
