### PR TITLE
Релиз: бренд инсталляции, ярлык iOS/Android, палитра без скачка при загрузке, элементы у нижней панели

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,55 @@
         }
       })();
     </script>
+    <script data-hint="theme-colors">
+      // Палитра оператора ДО первой отрисовки. Цвета приходят с бэкенда уже после
+      // загрузки JS, и каждая загрузка сначала показывала палитру по умолчанию,
+      // а потом прыгала в операторскую. applyThemeColors записывает применённые
+      // переменные в localStorage (ключ = STORAGE_KEYS.THEME_COLORS_HINT), здесь
+      // они ставятся на :root теми же именами. Принимаются только --color-* с
+      // hex или RGB-триплетом: подсказка не может подменить прочие токены.
+      // Фон страницы и theme-color тоже берутся отсюда — до прихода CSS приложения
+      // они иначе остаются цветами сборки. Специфичность правил фона (0,0,1)
+      // обязательна, см. <style> выше.
+      (function () {
+        try {
+          var raw = localStorage.getItem('cabinet-theme-colors-hint');
+          if (!raw) return;
+          var hint = JSON.parse(raw);
+          var vars = hint && hint.vars;
+          if (!vars || typeof vars !== 'object') return;
+          var NAME = /^--color-[a-z0-9-]+$/;
+          var VALUE = /^(#[0-9a-f]{6}|\d{1,3}, \d{1,3}, \d{1,3})$/i;
+          var root = document.documentElement;
+          var applied = {};
+          for (var name in vars) {
+            var value = vars[name];
+            if (NAME.test(name) && typeof value === 'string' && VALUE.test(value)) {
+              root.style.setProperty(name, value);
+              applied[name] = value;
+            }
+          }
+          var css = function (v) {
+            return v.charAt(0) === '#' ? v : 'rgb(' + v + ')';
+          };
+          var dark = applied['--color-dark-950'];
+          var light = applied['--color-champagne-200'];
+          if (dark || light) {
+            var style = document.createElement('style');
+            style.textContent =
+              (dark ? 'body{background-color:' + css(dark) + '}' : '') +
+              (light ? ':where(html.light) body{background-color:' + css(light) + '}' : '');
+            document.head.appendChild(style);
+          }
+          var isLight = root.classList.contains('light');
+          var chrome = isLight ? applied['--color-light-bg'] : applied['--color-dark-bg'];
+          var meta = document.querySelector('meta[name="theme-color"]');
+          if (meta && chrome) meta.setAttribute('content', css(chrome));
+        } catch (e) {
+          // Хранилище заблокировано или подсказка битая — остаётся палитра сборки.
+        }
+      })();
+    </script>
     <script>
       // Бренд до первой отрисовки. Имя и логотип приходят с бэкенда уже после
       // загрузки JS, и на медленной сети вкладка успевает показать значения из

--- a/index.html
+++ b/index.html
@@ -2,20 +2,20 @@
 <html lang="ru" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link
-      rel="icon"
-      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2064%2064'%3E%3Crect%20width='64'%20height='64'%20rx='14'%20fill='%230a0f1a'/%3E%3Ctext%20x='50%25'%20y='50%25'%20font-family='Manrope,Arial,sans-serif'%20font-size='38'%20font-weight='700'%20fill='%23ffffff'%20text-anchor='middle'%20dominant-baseline='central'%3EV%3C/text%3E%3C/svg%3E"
-    />
+    <link rel="icon" href="__APP_ICON__" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <meta name="theme-color" content="#0a0f1a" />
     <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <title>VPN</title>
+    <title>__APP_NAME__</title>
+    <meta name="application-name" content="__APP_NAME__" />
+    <meta name="apple-mobile-web-app-title" content="__APP_NAME__" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -104,6 +104,34 @@
           }
         } catch (e) {
           // Хранилище заблокировано — остаётся тёмная тема из разметки.
+        }
+      })();
+    </script>
+    <script>
+      // Бренд до первой отрисовки. Имя и логотип приходят с бэкенда уже после
+      // загрузки JS, и на медленной сети вкладка успевает показать значения из
+      // сборки (__APP_NAME__ и монограмму). Повторные визиты берут подсказку,
+      // которую записал useDocumentBranding (ключ = STORAGE_KEYS.BRAND_HINT).
+      (function () {
+        try {
+          var raw = localStorage.getItem('cabinet-brand-hint');
+          if (!raw) return;
+          var hint = JSON.parse(raw);
+          if (!hint || typeof hint.name !== 'string') return;
+          var name = hint.name.trim();
+          if (name) {
+            document.title = name;
+            var metas = document.querySelectorAll(
+              'meta[name="application-name"], meta[name="apple-mobile-web-app-title"]'
+            );
+            for (var i = 0; i < metas.length; i++) metas[i].setAttribute('content', name);
+          }
+          if (typeof hint.icon === 'string' && hint.icon.indexOf('data:image/') === 0) {
+            var icon = document.querySelector('link[rel="icon"]');
+            if (icon) icon.setAttribute('href', hint.icon);
+          }
+        } catch (e) {
+          // Хранилище заблокировано — остаются значения сборки.
         }
       })();
     </script>

--- a/src/AppWithNavigator.tsx
+++ b/src/AppWithNavigator.tsx
@@ -13,6 +13,7 @@ import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PlatformProvider } from './platform/PlatformProvider';
 import { ThemeColorsProvider } from './providers/ThemeColorsProvider';
+import { DocumentBranding } from './components/DocumentBranding';
 import { WebSocketProvider } from './providers/WebSocketProvider';
 import { ToastProvider } from './components/Toast';
 import { TooltipProvider } from './components/primitives/Tooltip';
@@ -233,6 +234,7 @@ export function AppWithNavigator() {
       <ErrorBoundary level="page">
         <PlatformProvider>
           <ThemeColorsProvider>
+            <DocumentBranding />
             <TooltipProvider>
               <ToastProvider>
                 <WebSocketProvider>

--- a/src/api/themeColors.ts
+++ b/src/api/themeColors.ts
@@ -1,8 +1,10 @@
+import { queryOptions } from '@tanstack/react-query';
+import { readThemeColorsHint } from '@/utils/themeColorsHint';
 import apiClient from './client';
 import {
-  ThemeSettings,
+  type ThemeSettings,
   DEFAULT_THEME_COLORS,
-  EnabledThemes,
+  type EnabledThemes,
   DEFAULT_ENABLED_THEMES,
 } from '../types/theme';
 
@@ -46,3 +48,23 @@ export const themeColorsApi = {
     return response.data;
   },
 };
+
+export const THEME_COLORS_QUERY_KEY = ['theme-colors'] as const;
+
+/**
+ * Единые параметры запроса палитры для всех, кто рисует ею на старте (провайдер,
+ * бренд во вкладке). Стартует с подсказки прошлого визита: initialDataUpdatedAt = 0
+ * помечает её заведомо устаревшей, запрос на сервер уходит сразу, но первый рендер
+ * идёт в операторских цветах, а не в дефолтных.
+ */
+export function themeColorsQueryOptions() {
+  return queryOptions({
+    queryKey: THEME_COLORS_QUERY_KEY,
+    queryFn: themeColorsApi.getColors,
+    initialData: () => readThemeColorsHint()?.colors,
+    initialDataUpdatedAt: 0,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+}

--- a/src/components/DocumentBranding.tsx
+++ b/src/components/DocumentBranding.tsx
@@ -1,0 +1,7 @@
+import { useDocumentBranding } from '@/hooks/useDocumentBranding';
+
+/** Ничего не рисует: держит заголовок, фавикон, имя приложения и манифест в <head>. */
+export function DocumentBranding() {
+  useDocumentBranding();
+  return null;
+}

--- a/src/components/admin/bulkActions/FloatingActionBar.tsx
+++ b/src/components/admin/bulkActions/FloatingActionBar.tsx
@@ -157,7 +157,9 @@ export function FloatingActionBar({
   ];
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-[9999] flex justify-center px-4 pb-[max(5rem,calc(4.5rem+env(safe-area-inset-bottom)))]">
+    // Снизу — просвет под мобильной панелью (на 5rem бар наезжал на неё на 12px);
+    // на десктопе панели нет, там прежние 5rem.
+    <div className="fixed inset-x-0 bottom-0 z-[9999] flex justify-center px-4 pb-[var(--mobile-nav-clearance)] lg:pb-20">
       <div
         ref={menuRef}
         className="relative flex w-full max-w-2xl items-center gap-3 rounded-2xl border border-dark-700/60 bg-dark-800/80 px-5 py-3 shadow-2xl backdrop-blur-xl"

--- a/src/components/connection/TvQuickConnect.tsx
+++ b/src/components/connection/TvQuickConnect.tsx
@@ -253,7 +253,8 @@ export default function TvQuickConnect({ subscriptionUrl, isLight }: Props) {
       {/* Toast */}
       {toast && (
         <div
-          className={`fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-xl px-5 py-3 text-sm font-medium shadow-lg transition-all ${
+          // На мобильном стоит над нижней панелью: на bottom-6 тост целиком уходил за неё.
+          className={`fixed bottom-[var(--mobile-nav-clearance)] left-1/2 z-50 -translate-x-1/2 rounded-xl px-5 py-3 text-sm font-medium shadow-lg transition-all lg:bottom-6 ${
             toast.type === 'success' ? 'bg-success-500/90 text-white' : 'bg-error-500/90 text-white'
           }`}
         >

--- a/src/components/layout/AppShell/AppHeader.tsx
+++ b/src/components/layout/AppShell/AppHeader.tsx
@@ -175,13 +175,27 @@ export function AppHeader({
 
   return (
     <>
+      {/* Полоса под статус-баром в standalone-режиме iOS («На экран Домой»):
+          непрозрачный фон страницы, шапка сдвигается под неё и остаётся своей
+          обычной высоты. Растягивать само стекло шапки на статус-бар нельзя —
+          оно читалось как лишний размытый блок сверху. В обычном браузере и в
+          Mini App env() равен нулю, полоса невидима; в fullscreen Telegram
+          отступ считает SDK и полоса не нужна. */}
+      {!isFullscreen && (
+        <div
+          aria-hidden="true"
+          className="fixed inset-x-0 top-0 z-50 bg-dark-950 lg:hidden"
+          style={{ height: 'env(safe-area-inset-top, 0px)' }}
+        />
+      )}
       {/* Header - only on mobile */}
       <header
-        className="glass fixed left-0 right-0 top-0 z-50 shadow-lg shadow-black/10 lg:hidden"
+        className="glass fixed left-0 right-0 z-50 shadow-lg shadow-black/10 lg:hidden"
         style={{
+          top: isFullscreen ? 0 : 'env(safe-area-inset-top, 0px)',
           paddingTop: isFullscreen
             ? `${Math.max(safeAreaInset.top, contentSafeAreaInset.top) + (telegramPlatform === 'android' ? 48 : 45)}px`
-            : 'env(safe-area-inset-top, 0px)',
+            : undefined,
         }}
       >
         <div

--- a/src/components/layout/AppShell/AppHeader.tsx
+++ b/src/components/layout/AppShell/AppHeader.tsx
@@ -188,7 +188,9 @@ export function AppHeader({
         }}
       >
         <div
-          className="mx-auto w-full px-4"
+          // Боковые отступы не меньше вырезов: в альбомной ориентации iPhone
+          // env(safe-area-inset-left/right) — это чёлка и скруглённые углы.
+          className="mx-auto w-full pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))]"
           onClick={() => mobileMenuOpen && setMobileMenuOpen(false)}
         >
           <div className="flex h-16 items-center justify-between">
@@ -324,7 +326,7 @@ export function AppHeader({
             className="mobile-menu-content absolute inset-x-0 bottom-0 top-0 overflow-y-auto overscroll-contain border-t border-dark-800/50 bg-dark-900/95 pb-[calc(5rem+env(safe-area-inset-bottom,0px))]"
             style={{ WebkitOverflowScrolling: 'touch' }}
           >
-            <div className="mx-auto max-w-6xl px-4 py-4">
+            <div className="mx-auto max-w-6xl py-4 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))]">
               {/* User info */}
               <div className="mb-4 flex items-center justify-between border-b border-dark-800/50 pb-4">
                 <div className="flex items-center gap-3">

--- a/src/components/layout/AppShell/AppHeader.tsx
+++ b/src/components/layout/AppShell/AppHeader.tsx
@@ -175,27 +175,16 @@ export function AppHeader({
 
   return (
     <>
-      {/* Полоса под статус-баром в standalone-режиме iOS («На экран Домой»):
-          непрозрачный фон страницы, шапка сдвигается под неё и остаётся своей
-          обычной высоты. Растягивать само стекло шапки на статус-бар нельзя —
-          оно читалось как лишний размытый блок сверху. В обычном браузере и в
-          Mini App env() равен нулю, полоса невидима; в fullscreen Telegram
-          отступ считает SDK и полоса не нужна. */}
-      {!isFullscreen && (
-        <div
-          aria-hidden="true"
-          className="fixed inset-x-0 top-0 z-50 bg-dark-950 lg:hidden"
-          style={{ height: 'env(safe-area-inset-top, 0px)' }}
-        />
-      )}
-      {/* Header - only on mobile */}
+      {/* Header - only on mobile. В standalone-режиме iOS («На экран Домой»)
+          шапка продолжается под статус-бар через padding-top; тон для этого
+          режима задаёт .app-mobile-header в globals.css (display-mode: standalone),
+          чтобы не было ни отдельного светлого блока, ни жёсткой границы. */}
       <header
-        className="glass fixed left-0 right-0 z-50 shadow-lg shadow-black/10 lg:hidden"
+        className="glass app-mobile-header fixed left-0 right-0 top-0 z-50 shadow-lg shadow-black/10 lg:hidden"
         style={{
-          top: isFullscreen ? 0 : 'env(safe-area-inset-top, 0px)',
           paddingTop: isFullscreen
             ? `${Math.max(safeAreaInset.top, contentSafeAreaInset.top) + (telegramPlatform === 'android' ? 48 : 45)}px`
-            : undefined,
+            : 'env(safe-area-inset-top, 0px)',
         }}
       >
         <div

--- a/src/components/layout/AppShell/AppHeader.tsx
+++ b/src/components/layout/AppShell/AppHeader.tsx
@@ -53,7 +53,8 @@ interface AppHeaderProps {
   mobileMenuOpen: boolean;
   setMobileMenuOpen: (open: boolean) => void;
   onCommandPaletteOpen: () => void;
-  headerHeight: number;
+  /** CSS-длина шапки (учитывает safe-area) — сдвиг оверлея меню. */
+  headerHeight: string;
   isFullscreen: boolean;
   safeAreaInset: { top: number; bottom: number; left: number; right: number };
   contentSafeAreaInset: { top: number; bottom: number; left: number; right: number };
@@ -180,7 +181,7 @@ export function AppHeader({
         style={{
           paddingTop: isFullscreen
             ? `${Math.max(safeAreaInset.top, contentSafeAreaInset.top) + (telegramPlatform === 'android' ? 48 : 45)}px`
-            : undefined,
+            : 'env(safe-area-inset-top, 0px)',
         }}
       >
         <div

--- a/src/components/layout/AppShell/AppHeader.tsx
+++ b/src/components/layout/AppShell/AppHeader.tsx
@@ -323,7 +323,7 @@ export function AppHeader({
 
           {/* Menu content */}
           <div
-            className="mobile-menu-content absolute inset-x-0 bottom-0 top-0 overflow-y-auto overscroll-contain border-t border-dark-800/50 bg-dark-900/95 pb-[calc(5rem+env(safe-area-inset-bottom,0px))]"
+            className="mobile-menu-content absolute inset-x-0 bottom-0 top-0 overflow-y-auto overscroll-contain border-t border-dark-800/50 bg-dark-900/95 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]"
             style={{ WebkitOverflowScrolling: 'touch' }}
           >
             <div className="mx-auto max-w-6xl py-4 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))]">

--- a/src/components/layout/AppShell/AppShell.tsx
+++ b/src/components/layout/AppShell/AppShell.tsx
@@ -52,7 +52,7 @@ export function AppShell({ children }: AppShellProps) {
   const logout = useAuthStore((state) => state.logout);
   const { isFullscreen, safeAreaInset, contentSafeAreaInset, platform, isMobile } =
     useTelegramSDK();
-  const { mobile: headerHeight } = useHeaderHeight();
+  const { mobileCss: headerHeight } = useHeaderHeight();
   const haptic = useHaptic();
   const { toggleTheme, isDark } = useTheme();
 

--- a/src/components/layout/AppShell/AppShell.tsx
+++ b/src/components/layout/AppShell/AppShell.tsx
@@ -300,7 +300,10 @@ export function AppShell({ children }: AppShellProps) {
       <div className="lg:hidden" style={{ height: headerHeight }} />
 
       {/* Main content */}
-      <main className="mx-auto max-w-6xl px-4 py-6 pb-28 lg:px-6 lg:pb-8">{children}</main>
+      {/* Боковые отступы не меньше вырезов (альбомная ориентация iPhone). */}
+      <main className="mx-auto max-w-6xl py-6 pb-28 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] lg:px-6 lg:pb-8">
+        {children}
+      </main>
 
       {/* Mobile Bottom Navigation */}
       <MobileBottomNav

--- a/src/components/layout/AppShell/AppShell.tsx
+++ b/src/components/layout/AppShell/AppShell.tsx
@@ -300,14 +300,17 @@ export function AppShell({ children }: AppShellProps) {
       <div className="lg:hidden" style={{ height: headerHeight }} />
 
       {/* Main content */}
-      {/* Боковые отступы не меньше вырезов (альбомная ориентация iPhone). */}
-      <main className="mx-auto max-w-6xl py-6 pb-28 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] lg:px-6 lg:pb-8">
+      {/* Боковые отступы не меньше вырезов (альбомная ориентация iPhone); снизу —
+          просвет под панелью: фиксированные 112px в standalone iOS не хватало,
+          и низ контента уходил под неё. */}
+      <main className="mx-auto max-w-6xl py-6 pb-[calc(var(--mobile-nav-clearance)+0.5rem)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] lg:px-6 lg:pb-8">
         {children}
       </main>
 
       {/* Mobile Bottom Navigation */}
       <MobileBottomNav
         isKeyboardOpen={isKeyboardOpen}
+        isMenuOpen={mobileMenuOpen}
         referralEnabled={referralEnabled}
         wheelEnabled={wheelEnabled}
       />

--- a/src/components/layout/AppShell/MobileBottomNav.tsx
+++ b/src/components/layout/AppShell/MobileBottomNav.tsx
@@ -64,7 +64,10 @@ export function MobileBottomNav({
         isKeyboardOpen ? 'pointer-events-none opacity-0' : 'opacity-100',
       )}
       style={{
-        bottom: 'calc(16px + env(safe-area-inset-bottom, 0px))',
+        // В standalone iOS inset снизу ~34pt: складывать с ним ещё 16px — панель
+        // висит слишком высоко. Берём большее из двух: над индикатором «Домой»
+        // панель стоит вплотную к безопасной зоне, в браузере — прежние 16px.
+        bottom: 'max(16px, env(safe-area-inset-bottom, 0px))',
         left: '16px',
         right: '16px',
         borderRadius: 'var(--bento-radius, 24px)',

--- a/src/components/layout/AppShell/MobileBottomNav.tsx
+++ b/src/components/layout/AppShell/MobileBottomNav.tsx
@@ -10,12 +10,15 @@ import { HomeIcon, SubscriptionIcon, WalletIcon, UsersIcon, ChatIcon, WheelIcon 
 
 interface MobileBottomNavProps {
   isKeyboardOpen: boolean;
+  /** Открыто выезжающее меню шапки: у него есть все те же пункты, панель поверх него лишняя. */
+  isMenuOpen?: boolean;
   referralEnabled?: boolean;
   wheelEnabled?: boolean;
 }
 
 export function MobileBottomNav({
   isKeyboardOpen,
+  isMenuOpen = false,
   referralEnabled,
   wheelEnabled,
 }: MobileBottomNavProps) {
@@ -61,13 +64,13 @@ export function MobileBottomNav({
         'fixed z-50 transition-all duration-200 lg:hidden',
         'bg-dark-900/95 backdrop-blur-linear',
         'border border-dark-700/30',
-        isKeyboardOpen ? 'pointer-events-none opacity-0' : 'opacity-100',
+        isKeyboardOpen || isMenuOpen ? 'pointer-events-none opacity-0' : 'opacity-100',
       )}
       style={{
-        // В standalone iOS inset снизу ~34pt: складывать с ним ещё 16px — панель
-        // висит слишком высоко. Берём большее из двух: над индикатором «Домой»
-        // панель стоит вплотную к безопасной зоне, в браузере — прежние 16px.
-        bottom: 'max(16px, env(safe-area-inset-bottom, 0px))',
+        // Отступ снизу и просвет под панелью объявлены в globals.css
+        // (--mobile-nav-*): в standalone iOS inset около 34pt, и панель стоит
+        // вплотную к безопасной зоне, в браузере — 16px.
+        bottom: 'var(--mobile-nav-offset)',
         // По бокам та же логика: в альбомной ориентации iPhone вырезы слева и
         // справа около 59pt, панель не должна уходить под чёлку и углы.
         left: 'max(16px, env(safe-area-inset-left, 0px))',

--- a/src/components/layout/AppShell/MobileBottomNav.tsx
+++ b/src/components/layout/AppShell/MobileBottomNav.tsx
@@ -68,8 +68,10 @@ export function MobileBottomNav({
         // висит слишком высоко. Берём большее из двух: над индикатором «Домой»
         // панель стоит вплотную к безопасной зоне, в браузере — прежние 16px.
         bottom: 'max(16px, env(safe-area-inset-bottom, 0px))',
-        left: '16px',
-        right: '16px',
+        // По бокам та же логика: в альбомной ориентации iPhone вырезы слева и
+        // справа около 59pt, панель не должна уходить под чёлку и углы.
+        left: 'max(16px, env(safe-area-inset-left, 0px))',
+        right: 'max(16px, env(safe-area-inset-right, 0px))',
         borderRadius: 'var(--bento-radius, 24px)',
         padding: '8px 4px',
         boxShadow: '0 4px 30px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.05) inset',

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,6 +1,8 @@
 export const STORAGE_KEYS = {
   THEME: 'cabinet-theme',
   ENABLED_THEMES: 'cabinet-enabled-themes',
+  /** Подсказка первой отрисовки: имя, буква и иконка бренда для инлайн-скрипта index.html. */
+  BRAND_HINT: 'cabinet-brand-hint',
   FAVORITE_SETTINGS: 'admin_favorite_settings',
 } as const;
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,6 +3,8 @@ export const STORAGE_KEYS = {
   ENABLED_THEMES: 'cabinet-enabled-themes',
   /** Подсказка первой отрисовки: имя, буква и иконка бренда для инлайн-скрипта index.html. */
   BRAND_HINT: 'cabinet-brand-hint',
+  /** Подсказка первой отрисовки: палитра оператора (CSS-переменные) для инлайн-скрипта index.html. */
+  THEME_COLORS_HINT: 'cabinet-theme-colors-hint',
   FAVORITE_SETTINGS: 'admin_favorite_settings',
 } as const;
 
@@ -20,6 +22,8 @@ export const UI = {
   TELEGRAM_HEADER_IOS_PX: 45,
   MOBILE_HEADER_HEIGHT_PX: 64,
   DESKTOP_HEADER_HEIGHT_PX: 56,
+  /** Сколько ждать палитру оператора перед первой отрисовкой, когда подсказки ещё нет. */
+  THEME_COLORS_FIRST_PAINT_TIMEOUT_MS: 1500,
 } as const;
 
 // API

--- a/src/hooks/useBranding.ts
+++ b/src/hooks/useBranding.ts
@@ -9,7 +9,6 @@ import {
   preloadLogo,
   isLogoPreloaded,
 } from '@/api/branding';
-import { setFavicon, letterFaviconDataUri, roundedFaviconDataUri } from '@/utils/favicon';
 
 const FALLBACK_NAME = import.meta.env.VITE_APP_NAME || 'Cabinet';
 const FALLBACK_LOGO = import.meta.env.VITE_APP_LOGO || 'V';
@@ -38,26 +37,7 @@ export function useBranding() {
   const hasCustomLogo = branding?.has_custom_logo || false;
   const logoUrl = branding ? brandingApi.getLogoUrl(branding) : null;
 
-  // Set document title
-  useEffect(() => {
-    document.title = appName || 'VPN';
-  }, [appName]);
-
-  // Update favicon — custom logo (rounded like the header tile) when available,
-  // else a brand-letter monogram so the tab always carries an icon.
-  useEffect(() => {
-    if (!logoUrl) {
-      setFavicon(letterFaviconDataUri(logoLetter));
-      return;
-    }
-    let cancelled = false;
-    roundedFaviconDataUri(logoUrl).then((rounded) => {
-      if (!cancelled) setFavicon(rounded || logoUrl);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [logoUrl, logoLetter]);
+  // Заголовок, фавикон и метатеги ведёт useDocumentBranding на уровне приложения.
 
   // Fullscreen setting from server
   const { data: fullscreenSetting } = useQuery({

--- a/src/hooks/useDocumentBranding.test.tsx
+++ b/src/hooks/useDocumentBranding.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STORAGE_KEYS } from '@/config/constants';
+import { DEFAULT_THEME_COLORS } from '@/types/theme';
+
+/**
+ * Владелец бренда в <head> работает без авторизации и на любой странице:
+ * посетитель страницы входа раньше видел «VPN»/«Cabinet»/«V» из сборки, потому
+ * что заголовок и фавикон ставил только AppShell после логина.
+ */
+
+vi.mock('@/api/branding', () => ({
+  brandingApi: {
+    getBranding: () =>
+      Promise.resolve({
+        name: 'ZeroPing',
+        logo_url: null,
+        logo_letter: 'Z',
+        has_custom_logo: false,
+      }),
+  },
+  getCachedBranding: () => null,
+  setCachedBranding: () => {},
+  preloadLogo: () => Promise.resolve(),
+  getLogoBlobUrl: () => null,
+}));
+
+vi.mock('@/api/themeColors', () => ({
+  themeColorsApi: {
+    getColors: () => Promise.resolve({ ...DEFAULT_THEME_COLORS, accent: '#22c55e' }),
+    getEnabledThemes: () => Promise.resolve({ dark: true, light: true }),
+  },
+}));
+
+// jsdom не реализует matchMedia, а useTheme его спрашивает.
+if (!window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+  document.head.innerHTML = '<link rel="icon" href="data:image/svg+xml,static" />';
+  document.title = 'Cabinet';
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  document.head.innerHTML = '';
+});
+
+async function renderBranding() {
+  const { DocumentBranding } = await import('@/components/DocumentBranding');
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <DocumentBranding />
+    </QueryClientProvider>,
+  );
+}
+
+describe('DocumentBranding', () => {
+  it('ставит заголовок, имя приложения, фавикон и манифест из брендинга', async () => {
+    await renderBranding();
+
+    await waitFor(() => expect(document.title).toBe('ZeroPing'));
+    expect(document.querySelector('meta[name="application-name"]')?.getAttribute('content')).toBe(
+      'ZeroPing',
+    );
+    expect(
+      document.querySelector('meta[name="apple-mobile-web-app-title"]')?.getAttribute('content'),
+    ).toBe('ZeroPing');
+
+    await waitFor(() => {
+      const href = document.querySelector('link[rel="icon"]')?.getAttribute('href') ?? '';
+      // Монограмма буквы Z в цвете акцента инсталляции, а не статический «V».
+      expect(decodeURIComponent(href)).toContain('>Z</text>');
+      expect(decodeURIComponent(href)).toContain('fill="#22c55e"');
+    });
+
+    const manifestHref = document.querySelector('link[rel="manifest"]')?.getAttribute('href') ?? '';
+    const manifest = JSON.parse(
+      decodeURIComponent(manifestHref.slice(manifestHref.indexOf(',') + 1)),
+    );
+    expect(manifest.name).toBe('ZeroPing');
+    expect(manifest.icons.length).toBeGreaterThan(0);
+
+    // Подсказка для следующей первой отрисовки записана.
+    const hint = JSON.parse(localStorage.getItem(STORAGE_KEYS.BRAND_HINT) ?? 'null');
+    expect(hint).toMatchObject({ name: 'ZeroPing', letter: 'Z' });
+    expect(String(hint.icon)).toContain('data:image/svg+xml');
+  });
+});

--- a/src/hooks/useDocumentBranding.test.tsx
+++ b/src/hooks/useDocumentBranding.test.tsx
@@ -27,12 +27,16 @@ vi.mock('@/api/branding', () => ({
   getLogoBlobUrl: () => null,
 }));
 
-vi.mock('@/api/themeColors', () => ({
-  themeColorsApi: {
-    getColors: () => Promise.resolve({ ...DEFAULT_THEME_COLORS, accent: '#22c55e' }),
-    getEnabledThemes: () => Promise.resolve({ dark: true, light: true }),
-  },
-}));
+vi.mock('@/api/themeColors', () => {
+  const getColors = () => Promise.resolve({ ...DEFAULT_THEME_COLORS, accent: '#22c55e' });
+  return {
+    themeColorsApi: {
+      getColors,
+      getEnabledThemes: () => Promise.resolve({ dark: true, light: true }),
+    },
+    themeColorsQueryOptions: () => ({ queryKey: ['theme-colors'], queryFn: getColors }),
+  };
+});
 
 // jsdom не реализует matchMedia, а useTheme его спрашивает.
 if (!window.matchMedia) {

--- a/src/hooks/useDocumentBranding.ts
+++ b/src/hooks/useDocumentBranding.ts
@@ -18,7 +18,12 @@ import {
   setWebManifest,
   writeBrandHint,
 } from '@/utils/documentBranding';
-import { letterFaviconDataUri, roundedFaviconDataUri, setFavicon } from '@/utils/favicon';
+import {
+  letterFaviconDataUri,
+  roundedFaviconDataUri,
+  setFavicon,
+  squareIconDataUri,
+} from '@/utils/favicon';
 import { readableTextOnHex } from './useThemeColors';
 import { useTheme } from './useTheme';
 
@@ -26,8 +31,10 @@ const FALLBACK_NAME = import.meta.env.VITE_APP_NAME || 'Cabinet';
 const FALLBACK_LOGO = import.meta.env.VITE_APP_LOGO || 'V';
 const APPLE_TOUCH_ICON_PX = 180;
 const MANIFEST_ICON_SIZES = [192, 512] as const;
-/** Скругление плитки логотипа, как у шапки; монограмма скруглена внутри самого SVG. */
+/** Скругление плитки логотипа во вкладке, как у шапки; для ярлыков не скругляем. */
 const LOGO_TILE_RADIUS = 0.3;
+/** Безопасная зона maskable-иконок Android: содержимое в центральных 80 %. */
+const MASKABLE_SAFE_ZONE = 0.8;
 
 async function fetchBranding(): Promise<BrandingInfo> {
   const data = await brandingApi.getBranding();
@@ -42,37 +49,47 @@ interface BrandIcons {
   manifest: ManifestIcon[];
 }
 
-async function rasterSet(
+/**
+ * Иконки для ярлыков: непрозрачные квадраты на `background` без скругления —
+ * iOS и Android накладывают свою маску, а прозрачные углы рисуют белым.
+ * Для Android добавляем вариант maskable с содержимым в безопасной зоне.
+ */
+async function shortcutIcons(
   src: string,
-  radiusRatio: number,
+  background: string,
 ): Promise<{ touch: string | null; manifest: ManifestIcon[] }> {
   const [touch, ...sized] = await Promise.all([
-    roundedFaviconDataUri(src, APPLE_TOUCH_ICON_PX, radiusRatio),
-    ...MANIFEST_ICON_SIZES.map((size) => roundedFaviconDataUri(src, size, radiusRatio)),
+    squareIconDataUri(src, APPLE_TOUCH_ICON_PX, { background }),
+    ...MANIFEST_ICON_SIZES.flatMap((size) => [
+      squareIconDataUri(src, size, { background }),
+      squareIconDataUri(src, size, { background, contentScale: MASKABLE_SAFE_ZONE }),
+    ]),
   ]);
-  const manifest = sized.flatMap((uri, index) =>
-    uri
-      ? [
-          {
-            src: uri,
-            sizes: `${MANIFEST_ICON_SIZES[index]}x${MANIFEST_ICON_SIZES[index]}`,
-            type: 'image/png',
-          },
-        ]
-      : [],
-  );
+  const manifest = MANIFEST_ICON_SIZES.flatMap((size, index): ManifestIcon[] => {
+    const sizes = `${size}x${size}`;
+    const any = sized[index * 2];
+    const maskable = sized[index * 2 + 1];
+    return [
+      ...(any ? [{ src: any, sizes, type: 'image/png', purpose: 'any' as const }] : []),
+      ...(maskable
+        ? [{ src: maskable, sizes, type: 'image/png', purpose: 'maskable' as const }]
+        : []),
+    ];
+  });
   return { touch, manifest };
 }
 
 /**
  * Иконки бренда: логотип инсталляции, иначе монограмма в цвете акцента.
- * Для вкладки годится SVG, для iOS и манифеста нужен PNG — растеризуем через
- * canvas; без canvas манифест получает SVG, а apple-touch-icon не ставится.
+ * Во вкладке — скруглённая плитка (прозрачные углы там безвредны), для
+ * ярлыков — непрозрачные квадраты. Без canvas манифест получает SVG, а
+ * apple-touch-icon не ставится.
  */
 async function buildBrandIcons(
   branding: BrandingInfo,
   letter: string,
   accent: string,
+  background: string,
 ): Promise<BrandIcons> {
   if (branding.has_custom_logo) {
     await preloadLogo(branding);
@@ -80,7 +97,7 @@ async function buildBrandIcons(
     if (blobUrl) {
       const favicon = await roundedFaviconDataUri(blobUrl, 64, LOGO_TILE_RADIUS);
       if (favicon) {
-        const { touch, manifest } = await rasterSet(blobUrl, LOGO_TILE_RADIUS);
+        const { touch, manifest } = await shortcutIcons(blobUrl, background);
         return { favicon, touch, manifest };
       }
     }
@@ -90,7 +107,8 @@ async function buildBrandIcons(
     background: accent,
     foreground: readableTextOnHex(accent),
   });
-  const { touch, manifest } = await rasterSet(monogram, 0);
+  // Заливка тем же акцентом, что и плашка внутри SVG: углы сливаются, белых пятен нет.
+  const { touch, manifest } = await shortcutIcons(monogram, accent);
   return {
     favicon: monogram,
     touch,
@@ -140,7 +158,7 @@ export function useDocumentBranding(): void {
   useEffect(() => {
     if (!branding) return;
     let cancelled = false;
-    buildBrandIcons(branding, letter, accent)
+    buildBrandIcons(branding, letter, accent, background)
       .then((icons) => {
         if (cancelled) return;
         setFavicon(icons.favicon);

--- a/src/hooks/useDocumentBranding.ts
+++ b/src/hooks/useDocumentBranding.ts
@@ -8,7 +8,7 @@ import {
   preloadLogo,
   setCachedBranding,
 } from '@/api/branding';
-import { themeColorsApi } from '@/api/themeColors';
+import { themeColorsQueryOptions } from '@/api/themeColors';
 import { DEFAULT_THEME_COLORS } from '@/types/theme';
 import {
   type ManifestIcon,
@@ -131,13 +131,7 @@ export function useDocumentBranding(): void {
     staleTime: 60_000,
     retry: 1,
   });
-  const { data: colors } = useQuery({
-    queryKey: ['theme-colors'],
-    queryFn: themeColorsApi.getColors,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
-    retry: 1,
-  });
+  const { data: colors } = useQuery(themeColorsQueryOptions());
   const { isDark } = useTheme();
 
   const palette = colors ?? DEFAULT_THEME_COLORS;

--- a/src/hooks/useDocumentBranding.ts
+++ b/src/hooks/useDocumentBranding.ts
@@ -1,0 +1,163 @@
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  type BrandingInfo,
+  brandingApi,
+  getCachedBranding,
+  getLogoBlobUrl,
+  preloadLogo,
+  setCachedBranding,
+} from '@/api/branding';
+import { themeColorsApi } from '@/api/themeColors';
+import { DEFAULT_THEME_COLORS } from '@/types/theme';
+import {
+  type ManifestIcon,
+  setAppNameMeta,
+  setAppleTouchIcon,
+  setDocumentTitle,
+  setWebManifest,
+  writeBrandHint,
+} from '@/utils/documentBranding';
+import { letterFaviconDataUri, roundedFaviconDataUri, setFavicon } from '@/utils/favicon';
+import { readableTextOnHex } from './useThemeColors';
+import { useTheme } from './useTheme';
+
+const FALLBACK_NAME = import.meta.env.VITE_APP_NAME || 'Cabinet';
+const FALLBACK_LOGO = import.meta.env.VITE_APP_LOGO || 'V';
+const APPLE_TOUCH_ICON_PX = 180;
+const MANIFEST_ICON_SIZES = [192, 512] as const;
+/** Скругление плитки логотипа, как у шапки; монограмма скруглена внутри самого SVG. */
+const LOGO_TILE_RADIUS = 0.3;
+
+async function fetchBranding(): Promise<BrandingInfo> {
+  const data = await brandingApi.getBranding();
+  setCachedBranding(data);
+  await preloadLogo(data);
+  return data;
+}
+
+interface BrandIcons {
+  favicon: string;
+  touch: string | null;
+  manifest: ManifestIcon[];
+}
+
+async function rasterSet(
+  src: string,
+  radiusRatio: number,
+): Promise<{ touch: string | null; manifest: ManifestIcon[] }> {
+  const [touch, ...sized] = await Promise.all([
+    roundedFaviconDataUri(src, APPLE_TOUCH_ICON_PX, radiusRatio),
+    ...MANIFEST_ICON_SIZES.map((size) => roundedFaviconDataUri(src, size, radiusRatio)),
+  ]);
+  const manifest = sized.flatMap((uri, index) =>
+    uri
+      ? [
+          {
+            src: uri,
+            sizes: `${MANIFEST_ICON_SIZES[index]}x${MANIFEST_ICON_SIZES[index]}`,
+            type: 'image/png',
+          },
+        ]
+      : [],
+  );
+  return { touch, manifest };
+}
+
+/**
+ * Иконки бренда: логотип инсталляции, иначе монограмма в цвете акцента.
+ * Для вкладки годится SVG, для iOS и манифеста нужен PNG — растеризуем через
+ * canvas; без canvas манифест получает SVG, а apple-touch-icon не ставится.
+ */
+async function buildBrandIcons(
+  branding: BrandingInfo,
+  letter: string,
+  accent: string,
+): Promise<BrandIcons> {
+  if (branding.has_custom_logo) {
+    await preloadLogo(branding);
+    const blobUrl = getLogoBlobUrl();
+    if (blobUrl) {
+      const favicon = await roundedFaviconDataUri(blobUrl, 64, LOGO_TILE_RADIUS);
+      if (favicon) {
+        const { touch, manifest } = await rasterSet(blobUrl, LOGO_TILE_RADIUS);
+        return { favicon, touch, manifest };
+      }
+    }
+  }
+
+  const monogram = letterFaviconDataUri(letter, {
+    background: accent,
+    foreground: readableTextOnHex(accent),
+  });
+  const { touch, manifest } = await rasterSet(monogram, 0);
+  return {
+    favicon: monogram,
+    touch,
+    manifest: manifest.length ? manifest : [{ src: monogram, sizes: 'any', type: 'image/svg+xml' }],
+  };
+}
+
+/**
+ * Единственный владелец бренда в <head> (см. utils/documentBranding). Работает на
+ * всех страницах, включая вход и публичные лендинги: раньше заголовок и фавикон
+ * ставил только AppShell после авторизации, и посетитель страницы входа видел
+ * значения из сборки.
+ */
+export function useDocumentBranding(): void {
+  const { data: branding } = useQuery({
+    queryKey: ['branding'],
+    queryFn: fetchBranding,
+    initialData: getCachedBranding() ?? undefined,
+    initialDataUpdatedAt: 0,
+    staleTime: 60_000,
+    retry: 1,
+  });
+  const { data: colors } = useQuery({
+    queryKey: ['theme-colors'],
+    queryFn: themeColorsApi.getColors,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+  const { isDark } = useTheme();
+
+  const palette = colors ?? DEFAULT_THEME_COLORS;
+  const accent = palette.accent;
+  const background = isDark ? palette.darkBackground : palette.lightBackground;
+  const name = branding?.name.trim() || FALLBACK_NAME;
+  const letter = branding?.logo_letter || FALLBACK_LOGO;
+  const appliedTitleRef = useRef<string | null>(null);
+
+  // Пока брендинг не известен, ничего не трогаем: инлайн-скрипт index.html уже
+  // показал подсказку прошлого визита, и затирать её значениями сборки нельзя.
+  useEffect(() => {
+    if (!branding) return;
+    appliedTitleRef.current = setDocumentTitle(name, appliedTitleRef.current);
+    setAppNameMeta(name);
+  }, [branding, name]);
+
+  useEffect(() => {
+    if (!branding) return;
+    let cancelled = false;
+    buildBrandIcons(branding, letter, accent)
+      .then((icons) => {
+        if (cancelled) return;
+        setFavicon(icons.favicon);
+        setAppleTouchIcon(icons.touch);
+        setWebManifest({
+          name,
+          icons: icons.manifest,
+          themeColor: background,
+          backgroundColor: background,
+        });
+        writeBrandHint({ name, letter, icon: icons.favicon });
+      })
+      .catch(() => {
+        // Иконка не критична: вкладка остаётся со статическим фавиконом сборки.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [branding, name, letter, accent, background]);
+}

--- a/src/hooks/useHeaderHeight.test.ts
+++ b/src/hooks/useHeaderHeight.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { headerHeightCss } from './useHeaderHeight';
+
+/**
+ * В standalone-режиме iOS («На экран Домой») страница начинается под
+ * статус-баром, и фиксированная шапка без отступа срезалась. Вне fullscreen
+ * Telegram высота шапки включает env(safe-area-inset-top); в fullscreen
+ * Telegram отступ уже посчитан из SDK и дублировать его нельзя.
+ */
+describe('headerHeightCss', () => {
+  it('добавляет safe-area сверху вне fullscreen Telegram', () => {
+    expect(headerHeightCss(64, false)).toBe('calc(64px + env(safe-area-inset-top, 0px))');
+  });
+
+  it('в fullscreen Telegram оставляет высоту из SDK как есть', () => {
+    expect(headerHeightCss(157, true)).toBe('157px');
+  });
+});

--- a/src/hooks/useHeaderHeight.ts
+++ b/src/hooks/useHeaderHeight.ts
@@ -9,11 +9,11 @@ import { UI } from '@/config/constants';
  * bottomSafeArea: TG SDK bottom inset (home indicator etc.), 0 outside TG.
  */
 /**
- * Место, занятое шапкой сверху, как CSS-длина. Вне fullscreen Telegram добавляет
+ * Высота мобильной шапки как CSS-длина. Вне fullscreen Telegram добавляет
  * env(safe-area-inset-top): в standalone-режиме iOS («На экран Домой», статус-бар
- * black-translucent) страница начинается под статус-баром; шапка сдвигается под
- * него (AppHeader рисует над ней непрозрачную полосу), и распорка контента с
- * оверлеем меню должны учитывать этот сдвиг.
+ * black-translucent) страница начинается под статус-баром, и шапка продолжается
+ * под него через padding-top — распорка контента и оверлей меню должны это
+ * учитывать.
  */
 export function headerHeightCss(mobilePx: number, isMobileFullscreen: boolean): string {
   return isMobileFullscreen

--- a/src/hooks/useHeaderHeight.ts
+++ b/src/hooks/useHeaderHeight.ts
@@ -8,8 +8,21 @@ import { UI } from '@/config/constants';
  * Desktop: 56px (h-14). Mobile: 64px (h-16) + safe area + TG header when fullscreen.
  * bottomSafeArea: TG SDK bottom inset (home indicator etc.), 0 outside TG.
  */
+/**
+ * Высота мобильной шапки как CSS-длина. Вне fullscreen Telegram добавляет
+ * env(safe-area-inset-top): в standalone-режиме iOS («На экран Домой», статус-бар
+ * black-translucent) страница начинается под статус-баром, и без отступа
+ * верх шапки срезается.
+ */
+export function headerHeightCss(mobilePx: number, isMobileFullscreen: boolean): string {
+  return isMobileFullscreen
+    ? `${mobilePx}px`
+    : `calc(${mobilePx}px + env(safe-area-inset-top, 0px))`;
+}
+
 export function useHeaderHeight(): {
   mobile: number;
+  mobileCss: string;
   desktop: number;
   bottomSafeArea: number;
   isMobileFullscreen: boolean;
@@ -31,5 +44,11 @@ export function useHeaderHeight(): {
     ? Math.max(safeAreaInset.bottom, contentSafeAreaInset.bottom)
     : 0;
 
-  return { mobile, desktop: UI.DESKTOP_HEADER_HEIGHT_PX, bottomSafeArea, isMobileFullscreen };
+  return {
+    mobile,
+    mobileCss: headerHeightCss(mobile, isMobileFullscreen),
+    desktop: UI.DESKTOP_HEADER_HEIGHT_PX,
+    bottomSafeArea,
+    isMobileFullscreen,
+  };
 }

--- a/src/hooks/useHeaderHeight.ts
+++ b/src/hooks/useHeaderHeight.ts
@@ -9,10 +9,11 @@ import { UI } from '@/config/constants';
  * bottomSafeArea: TG SDK bottom inset (home indicator etc.), 0 outside TG.
  */
 /**
- * Высота мобильной шапки как CSS-длина. Вне fullscreen Telegram добавляет
+ * Место, занятое шапкой сверху, как CSS-длина. Вне fullscreen Telegram добавляет
  * env(safe-area-inset-top): в standalone-режиме iOS («На экран Домой», статус-бар
- * black-translucent) страница начинается под статус-баром, и без отступа
- * верх шапки срезается.
+ * black-translucent) страница начинается под статус-баром; шапка сдвигается под
+ * него (AppHeader рисует над ней непрозрачную полосу), и распорка контента с
+ * оверлеем меню должны учитывать этот сдвиг.
  */
 export function headerHeightCss(mobilePx: number, isMobileFullscreen: boolean): string {
   return isMobileFullscreen

--- a/src/hooks/useThemeColors.test.ts
+++ b/src/hooks/useThemeColors.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from 'vitest';
-import { applyThemeColors } from './useThemeColors';
+import { applyThemeColors, computeThemeCssVars } from './useThemeColors';
 import { DEFAULT_THEME_COLORS, SHADE_LEVELS } from '../types/theme';
+import { readThemeColorsHint } from '../utils/themeColorsHint';
 
 /**
  * Палитра статусных цветов строится из одного выбранного оператором цвета.
@@ -124,5 +125,33 @@ describe('applyThemeColors: статусные палитры', () => {
     expect(readVar('--color-on-error')).toBe('255, 255, 255');
     expect(readVar('--color-on-success')).toBe('15, 23, 42');
     expect(readVar('--color-on-warning')).toBe('15, 23, 42');
+  });
+});
+
+describe('applyThemeColors: подсказка первой отрисовки', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('после применения в localStorage лежат те же переменные, что и на :root', () => {
+    const custom = { ...DEFAULT_THEME_COLORS, accent: '#14b8a6', darkBackground: '#0a1410' };
+    applyThemeColors(custom);
+    const hint = readThemeColorsHint();
+    expect(hint?.colors).toEqual(custom);
+    expect(hint?.vars['--color-accent-500']).toBe(hexToTriplet('#14b8a6'));
+    expect(hint?.vars['--color-dark-950']).toBe(hexToTriplet('#0a1410'));
+    for (const [name, value] of Object.entries(hint?.vars ?? {})) {
+      expect(readVar(name)).toBe(value);
+    }
+  });
+
+  it('computeThemeCssVars чист и совпадает с тем, что ставит applyThemeColors', () => {
+    const vars = computeThemeCssVars(DEFAULT_THEME_COLORS);
+    expect(Object.keys(vars).length).toBeGreaterThan(50);
+    expect(document.documentElement.getAttribute('style')).toBeNull();
+    applyThemeColors(DEFAULT_THEME_COLORS);
+    for (const [name, value] of Object.entries(vars)) {
+      expect(readVar(name)).toBe(value);
+    }
   });
 });

--- a/src/hooks/useThemeColors.ts
+++ b/src/hooks/useThemeColors.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { themeColorsApi } from '../api/themeColors';
+import { themeColorsQueryOptions } from '../api/themeColors';
 import {
   type ThemeColors,
   DEFAULT_THEME_COLORS,
@@ -9,6 +9,7 @@ import {
   type ShadeLevel,
 } from '../types/theme';
 import { hexToRgb, hexToHsl, hslToRgb } from '../utils/colorConversion';
+import { writeThemeColorsHint } from '../utils/themeColorsHint';
 
 // Convert RGB to string format for CSS variable
 function rgbToString(r: number, g: number, b: number): string {
@@ -183,12 +184,15 @@ function withReadableTextShades(
   };
 }
 
-// Apply theme colors as CSS variables (RGB format for Tailwind opacity support)
-export function applyThemeColors(themeColors: ThemeColors): void {
+/**
+ * CSS-переменные палитры для :root (RGB-триплеты — ради Tailwind-прозрачности).
+ * Чистая функция: результат и ставится на документ, и уходит в подсказку первой
+ * отрисовки, которую инлайн-скрипт index.html применит до загрузки приложения.
+ */
+export function computeThemeCssVars(themeColors: ThemeColors): Record<string, string> {
   // Частичный/битый ответ /branding/colors раньше ронял ВСЁ приложение в
   // ErrorBoundary (hexToRgb(undefined)). Недостающие поля добиваем дефолтами.
   const colors: ThemeColors = { ...DEFAULT_THEME_COLORS, ...themeColors };
-  const root = document.documentElement;
 
   // Generate palettes from status colors
   const accentPalette = generatePalette(colors.accent);
@@ -213,62 +217,30 @@ export function applyThemeColors(themeColors: ThemeColors): void {
     3.8,
   );
 
-  // Apply dark palette with actual user colors:
-  // Text colors (light shades): 50-100 = primary text, 200-300 = mixed, 400 = secondary text
-  root.style.setProperty(
-    '--color-dark-50',
-    rgbToString(darkTextRgb.r, darkTextRgb.g, darkTextRgb.b),
-  );
-  root.style.setProperty(
-    '--color-dark-100',
-    rgbToString(darkTextRgb.r, darkTextRgb.g, darkTextRgb.b),
-  );
-  root.style.setProperty('--color-dark-200', interpolateRgb(darkTextRgb, darkTextSecRgb, 0.33));
-  root.style.setProperty('--color-dark-300', interpolateRgb(darkTextRgb, darkTextSecRgb, 0.66));
-  root.style.setProperty(
-    '--color-dark-400',
-    rgbToString(darkTextSecReadable.r, darkTextSecReadable.g, darkTextSecReadable.b),
-  );
-
-  // Transition colors (500-700): interpolate between secondary text and surface
-  root.style.setProperty(
-    '--color-dark-500',
-    rgbToString(darkHintReadable.r, darkHintReadable.g, darkHintReadable.b),
-  );
-  root.style.setProperty('--color-dark-600', interpolateRgb(darkTextSecRgb, darkSurfaceRgb, 0.6));
-  root.style.setProperty('--color-dark-700', interpolateRgb(darkTextSecRgb, darkSurfaceRgb, 0.8));
-
-  // Surface/card colors (800-850): surface color
-  root.style.setProperty(
-    '--color-dark-800',
-    rgbToString(darkSurfaceRgb.r, darkSurfaceRgb.g, darkSurfaceRgb.b),
-  );
-  root.style.setProperty('--color-dark-850', interpolateRgb(darkSurfaceRgb, darkBgRgb, 0.5));
-
-  // Background colors (900-950): background color
-  root.style.setProperty('--color-dark-900', interpolateRgb(darkSurfaceRgb, darkBgRgb, 0.7));
-  root.style.setProperty('--color-dark-950', rgbToString(darkBgRgb.r, darkBgRgb.g, darkBgRgb.b));
+  // Dark palette with actual user colors:
+  // text colors (light shades): 50-100 = primary text, 200-300 = mixed, 400 = secondary text;
+  // transition colors (500-700): between secondary text and surface;
+  // surface/card colors (800-850); background colors (900-950).
+  const darkVars = {
+    '--color-dark-50': tripletOf(darkTextRgb),
+    '--color-dark-100': tripletOf(darkTextRgb),
+    '--color-dark-200': interpolateRgb(darkTextRgb, darkTextSecRgb, 0.33),
+    '--color-dark-300': interpolateRgb(darkTextRgb, darkTextSecRgb, 0.66),
+    '--color-dark-400': tripletOf(darkTextSecReadable),
+    '--color-dark-500': tripletOf(darkHintReadable),
+    '--color-dark-600': interpolateRgb(darkTextSecRgb, darkSurfaceRgb, 0.6),
+    '--color-dark-700': interpolateRgb(darkTextSecRgb, darkSurfaceRgb, 0.8),
+    '--color-dark-800': tripletOf(darkSurfaceRgb),
+    '--color-dark-850': interpolateRgb(darkSurfaceRgb, darkBgRgb, 0.5),
+    '--color-dark-900': interpolateRgb(darkSurfaceRgb, darkBgRgb, 0.7),
+    '--color-dark-950': tripletOf(darkBgRgb),
+  };
 
   const lightBgRgb = hexToRgb(colors.lightBackground);
   const lightSurfaceRgb = hexToRgb(colors.lightSurface);
   const lightTextRgb = hexToRgb(colors.lightText);
   const lightTextSecRgb = hexToRgb(colors.lightTextSecondary);
 
-  // Apply champagne palette with actual user colors:
-  // Background colors (light shades): 50-100 = surface, 200-400 = background tones
-  root.style.setProperty(
-    '--color-champagne-50',
-    rgbToString(lightSurfaceRgb.r, lightSurfaceRgb.g, lightSurfaceRgb.b),
-  );
-  root.style.setProperty('--color-champagne-100', interpolateRgb(lightSurfaceRgb, lightBgRgb, 0.3));
-  root.style.setProperty(
-    '--color-champagne-200',
-    rgbToString(lightBgRgb.r, lightBgRgb.g, lightBgRgb.b),
-  );
-  root.style.setProperty('--color-champagne-300', interpolateRgb(lightBgRgb, lightTextSecRgb, 0.2));
-  root.style.setProperty('--color-champagne-400', interpolateRgb(lightBgRgb, lightTextSecRgb, 0.4));
-
-  // Transition colors (500-600): between bg and text.
   // Same contrast floors as the dark palette: champagne-600 backs dark-400
   // (secondary text) in the light theme, champagne-500 backs dark-500 (hints).
   const lightHintReadable = ensureReadable(
@@ -278,32 +250,23 @@ export function applyThemeColors(themeColors: ThemeColors): void {
     3.8,
   );
   const lightTextSecReadable = ensureReadable(lightTextSecRgb, lightTextRgb, lightSurfaceRgb, 5.0);
-  root.style.setProperty(
-    '--color-champagne-500',
-    rgbToString(lightHintReadable.r, lightHintReadable.g, lightHintReadable.b),
-  );
-  root.style.setProperty(
-    '--color-champagne-600',
-    rgbToString(lightTextSecReadable.r, lightTextSecReadable.g, lightTextSecReadable.b),
-  );
 
-  // Text colors (700-950): secondary to primary text
-  root.style.setProperty(
-    '--color-champagne-700',
-    interpolateRgb(lightTextSecRgb, lightTextRgb, 0.33),
-  );
-  root.style.setProperty(
-    '--color-champagne-800',
-    interpolateRgb(lightTextSecRgb, lightTextRgb, 0.66),
-  );
-  root.style.setProperty(
-    '--color-champagne-900',
-    rgbToString(lightTextRgb.r, lightTextRgb.g, lightTextRgb.b),
-  );
-  root.style.setProperty(
-    '--color-champagne-950',
-    rgbToString(lightTextRgb.r, lightTextRgb.g, lightTextRgb.b),
-  );
+  // Champagne palette with actual user colors:
+  // background colors (light shades): 50-100 = surface, 200-400 = background tones;
+  // transition colors (500-600): between bg and text; text colors (700-950).
+  const lightVars = {
+    '--color-champagne-50': tripletOf(lightSurfaceRgb),
+    '--color-champagne-100': interpolateRgb(lightSurfaceRgb, lightBgRgb, 0.3),
+    '--color-champagne-200': tripletOf(lightBgRgb),
+    '--color-champagne-300': interpolateRgb(lightBgRgb, lightTextSecRgb, 0.2),
+    '--color-champagne-400': interpolateRgb(lightBgRgb, lightTextSecRgb, 0.4),
+    '--color-champagne-500': tripletOf(lightHintReadable),
+    '--color-champagne-600': tripletOf(lightTextSecReadable),
+    '--color-champagne-700': interpolateRgb(lightTextSecRgb, lightTextRgb, 0.33),
+    '--color-champagne-800': interpolateRgb(lightTextSecRgb, lightTextRgb, 0.66),
+    '--color-champagne-900': tripletOf(lightTextRgb),
+    '--color-champagne-950': tripletOf(lightTextRgb),
+  };
 
   const darkSurfaces: ThemeSurfaces = { surface: darkSurfaceRgb, text: darkTextRgb };
   const lightSurfaces: ThemeSurfaces = { surface: lightSurfaceRgb, text: lightTextRgb };
@@ -312,46 +275,56 @@ export function applyThemeColors(themeColors: ThemeColors): void {
   const warning = withReadableTextShades(warningPalette, darkSurfaces, lightSurfaces);
   const error = withReadableTextShades(errorPalette, darkSurfaces, lightSurfaces);
 
-  for (const shade of SHADE_LEVELS) {
-    root.style.setProperty(`--color-accent-${shade}`, accent[shade]);
-    root.style.setProperty(`--color-success-${shade}`, success[shade]);
-    root.style.setProperty(`--color-warning-${shade}`, warning[shade]);
-    root.style.setProperty(`--color-error-${shade}`, error[shade]);
-  }
+  const statusVars = Object.fromEntries(
+    SHADE_LEVELS.flatMap((shade) => [
+      [`--color-accent-${shade}`, accent[shade]],
+      [`--color-success-${shade}`, success[shade]],
+      [`--color-warning-${shade}`, warning[shade]],
+      [`--color-error-${shade}`, error[shade]],
+    ]),
+  );
 
   // Readable text color on top of each status color (buttons, filled badges).
   // Hardcoded white breaks the moment an operator picks a light accent.
-  root.style.setProperty('--color-on-accent', onColorFor(accent[500]));
-  root.style.setProperty('--color-on-success', onColorFor(success[500]));
-  root.style.setProperty('--color-on-warning', onColorFor(warning[500]));
-  root.style.setProperty('--color-on-error', onColorFor(error[500]));
+  const onColorVars = {
+    '--color-on-accent': onColorFor(accent[500]),
+    '--color-on-success': onColorFor(success[500]),
+    '--color-on-warning': onColorFor(warning[500]),
+    '--color-on-error': onColorFor(error[500]),
+  };
 
-  // Apply semantic colors (hex for direct use)
-  root.style.setProperty('--color-dark-bg', colors.darkBackground);
-  root.style.setProperty('--color-dark-surface', colors.darkSurface);
-  root.style.setProperty('--color-dark-text', colors.darkText);
-  root.style.setProperty('--color-dark-text-secondary', colors.darkTextSecondary);
+  // Semantic colors (hex for direct use)
+  const semanticVars = {
+    '--color-dark-bg': colors.darkBackground,
+    '--color-dark-surface': colors.darkSurface,
+    '--color-dark-text': colors.darkText,
+    '--color-dark-text-secondary': colors.darkTextSecondary,
+    '--color-light-bg': colors.lightBackground,
+    '--color-light-surface': colors.lightSurface,
+    '--color-light-text': colors.lightText,
+    '--color-light-text-secondary': colors.lightTextSecondary,
+  };
 
-  root.style.setProperty('--color-light-bg', colors.lightBackground);
-  root.style.setProperty('--color-light-surface', colors.lightSurface);
-  root.style.setProperty('--color-light-text', colors.lightText);
-  root.style.setProperty('--color-light-text-secondary', colors.lightTextSecondary);
+  return { ...darkVars, ...lightVars, ...statusVars, ...onColorVars, ...semanticVars };
+}
+
+// Apply theme colors as CSS variables on :root and remember them for the next first paint.
+export function applyThemeColors(themeColors: ThemeColors): void {
+  const colors: ThemeColors = { ...DEFAULT_THEME_COLORS, ...themeColors };
+  const vars = computeThemeCssVars(colors);
+  const root = document.documentElement;
+  for (const [name, value] of Object.entries(vars)) {
+    root.style.setProperty(name, value);
+  }
+  // Следующая загрузка стартует с этой палитры, а не с дефолтной: инлайн-скрипт
+  // index.html ставит переменные из подсказки до загрузки приложения.
+  writeThemeColorsHint({ colors, vars });
 }
 
 export function useThemeColors() {
   const queryClient = useQueryClient();
 
-  const {
-    data: colors,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ['theme-colors'],
-    queryFn: themeColorsApi.getColors,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    refetchOnWindowFocus: false,
-    retry: 1,
-  });
+  const { data: colors, isLoading, error } = useQuery(themeColorsQueryOptions());
 
   // Apply colors when loaded or changed
   useEffect(() => {

--- a/src/hooks/useThemeColors.ts
+++ b/src/hooks/useThemeColors.ts
@@ -141,14 +141,23 @@ function tripletOf({ r, g, b }: Rgb): string {
 // лучшим контрастом: на пастельном акценте это тёмный текст.
 const ON_COLOR_WHITE_MIN_RATIO = 3;
 
+const WHITE: Rgb = { r: 255, g: 255, b: 255 };
+const INK: Rgb = { r: 15, g: 23, b: 42 };
+
+function prefersWhiteText(bg: Rgb): boolean {
+  const whiteRatio = contrastRatio(WHITE, bg);
+  if (whiteRatio >= ON_COLOR_WHITE_MIN_RATIO) return true;
+  return whiteRatio >= contrastRatio(INK, bg);
+}
+
 // Black-or-white text for a given button/badge background.
 function onColorFor(bgTriplet: string): string {
-  const bg = parseTriplet(bgTriplet);
-  const white = { r: 255, g: 255, b: 255 };
-  const ink = { r: 15, g: 23, b: 42 };
-  const whiteRatio = contrastRatio(white, bg);
-  if (whiteRatio >= ON_COLOR_WHITE_MIN_RATIO) return '255, 255, 255';
-  return whiteRatio >= contrastRatio(ink, bg) ? '255, 255, 255' : '15, 23, 42';
+  return prefersWhiteText(parseTriplet(bgTriplet)) ? '255, 255, 255' : '15, 23, 42';
+}
+
+/** Тот же выбор белый/тёмный для hex-заливки — для иконок, рисуемых вне CSS. */
+export function readableTextOnHex(hex: string): string {
+  return prefersWhiteText(hexToRgb(hex)) ? '#ffffff' : '#0f172a';
 }
 
 type ThemeSurfaces = { surface: Rgb; text: Rgb };

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -67,6 +67,7 @@ describe('тема до первой отрисовки', () => {
     // находить тему, и вспышка вернётся без единой ошибки в консоли.
     expect(htmlSource).toContain(STORAGE_KEYS.THEME);
     expect(htmlSource).toContain(STORAGE_KEYS.ENABLED_THEMES);
+    expect(htmlSource).toContain(STORAGE_KEYS.BRAND_HINT);
   });
 
   it('фон первой отрисовки уступает фону темы из CSS приложения', () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -28,6 +28,10 @@ import { initLogoPreload } from './api/branding';
 import { checkBackendOnStartup } from './api/health';
 import { getCachedFullscreenEnabled, isTelegramMobile } from './hooks/useTelegramSDK';
 import { applyTelegramLanguage, i18nReady } from './i18n';
+import { themeColorsQueryOptions } from './api/themeColors';
+import { applyThemeColors } from './hooks/useThemeColors';
+import { readThemeColorsHint } from './utils/themeColorsHint';
+import { UI } from './config/constants';
 import './styles/globals.css';
 
 // Harden the global encoders against lone UTF-16 surrogates (truncated emoji in
@@ -144,13 +148,28 @@ const queryClient = new QueryClient({
   },
 });
 
+// Палитра оператора для самого первого визита: подсказки в localStorage ещё нет,
+// и без ожидания первый кадр ушёл бы в цветах по умолчанию (повторные визиты
+// закрывает инлайн-скрипт index.html). Ответ ставится на :root до рендера и
+// попадает в подсказку. Ждём не дольше таймаута: мёртвый бэкенд не должен
+// держать пустой экран, getColors на ошибке сам отдаёт дефолт.
+const themeColorsReady: Promise<void> = readThemeColorsHint()
+  ? Promise.resolve()
+  : Promise.race([
+      queryClient
+        .fetchQuery(themeColorsQueryOptions())
+        .then((colors) => applyThemeColors(colors))
+        .catch(() => {}),
+      new Promise<void>((resolve) => setTimeout(resolve, UI.THEME_COLORS_FIRST_PAINT_TIMEOUT_MS)),
+    ]);
+
 // Рисуем только после словарей. Локали лежат в отдельных ленивых чанках, а
 // react.useSuspense выключен: без ожидания первая отрисовка на холодном кэше
 // уходила с сырыми ключами (`auth.login`, `auth.email`), а ключи с инлайн-
 // дефолтом — по-английски, отчего форма выглядела наполовину переведённой.
 // i18nReady не реджектится и сам снимается по таймауту, так что не приехавший
 // чанк даёт непереведённый текст, а не белый экран.
-void Promise.all([i18nReady, telegramLanguageReady]).then(() => {
+void Promise.all([i18nReady, telegramLanguageReady, themeColorsReady]).then(() => {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <ErrorBoundary level="app">

--- a/src/pages/GiftSubscription.tsx
+++ b/src/pages/GiftSubscription.tsx
@@ -973,7 +973,8 @@ function CopiedToast({ onDismiss }: { onDismiss: () => void }) {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 20 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
-      className="fixed inset-x-0 bottom-6 z-50 flex justify-center"
+      // На мобильном стоит над нижней панелью: на bottom-6 тост целиком уходил за неё.
+      className="fixed inset-x-0 bottom-[var(--mobile-nav-clearance)] z-50 flex justify-center lg:bottom-6"
     >
       <div className="flex items-center gap-2 rounded-full border border-dark-700/50 bg-dark-900/95 px-5 py-2.5 shadow-2xl shadow-black/40 backdrop-blur-md">
         <CheckIcon className="h-4 w-4 text-success-400" />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -231,11 +231,6 @@ export default function Login() {
   const appLogo = branding?.logo_letter || import.meta.env.VITE_APP_LOGO || 'V';
   const logoUrl = branding ? brandingApi.getLogoUrl(branding) : null;
 
-  // Set document title
-  useEffect(() => {
-    document.title = appName || 'VPN';
-  }, [appName]);
-
   useEffect(() => {
     if (isAuthenticated) {
       navigate(getReturnUrl(), { replace: true });

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -554,6 +554,8 @@ function SummaryCard({
           <div
             className="fixed bottom-0 left-0 right-0 z-50 p-3"
             style={{
+              // Ярлык iOS: под кнопкой ещё индикатор «Домой» (safe-area снизу).
+              paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom, 0px))',
               background:
                 'linear-gradient(to top, rgba(0,0,0,0.9) 0%, rgba(0,0,0,0.6) 70%, transparent 100%)',
             }}

--- a/src/pages/QuickPurchase.tsx
+++ b/src/pages/QuickPurchase.tsx
@@ -7,13 +7,6 @@ import { fireAnalyticsEvent, getYandexCid } from '../hooks/useAnalyticsCounters'
 import { motion, AnimatePresence } from 'framer-motion';
 import DOMPurify from 'dompurify';
 import { landingApi } from '../api/landings';
-import {
-  brandingApi,
-  getCachedBranding,
-  setCachedBranding,
-  preloadLogo,
-  getLogoBlobUrl,
-} from '../api/branding';
 import type {
   LandingConfig,
   LandingTariff,
@@ -32,7 +25,6 @@ import { getApiErrorMessage } from '../utils/api-error';
 import { getPendingCampaignSlug } from '../utils/campaign';
 import { readContactPrefill, stripContactFromUrl } from '../utils/contactPrefill';
 import { formatPrice } from '../utils/format';
-import { setFavicon, letterFaviconDataUri, roundedFaviconDataUri } from '../utils/favicon';
 import { useCurrency } from '../hooks/useCurrency';
 import { safeSession } from '../utils/safeStorage';
 
@@ -785,42 +777,6 @@ export default function QuickPurchase() {
     staleTime: 60_000,
     retry: 1,
   });
-
-  // Public branding — drives the favicon on this standalone landing page.
-  // The cabinet's useBranding hook is auth-gated and AppShell-only, so a public
-  // landing would otherwise keep the empty index.html favicon. The branding
-  // endpoint is public; logo is preloaded as a blob to keep the backend URL out
-  // of the DOM (same pattern as the authenticated app).
-  const { data: branding } = useQuery({
-    queryKey: ['branding'],
-    queryFn: async () => {
-      const data = await brandingApi.getBranding();
-      setCachedBranding(data);
-      await preloadLogo(data);
-      return data;
-    },
-    initialData: getCachedBranding() ?? undefined,
-    initialDataUpdatedAt: 0,
-    staleTime: 60_000,
-    retry: 1,
-  });
-
-  useEffect(() => {
-    if (!branding) return;
-    const logoUrl = branding.has_custom_logo ? getLogoBlobUrl() : null;
-    if (!logoUrl) {
-      setFavicon(letterFaviconDataUri(branding.logo_letter));
-      return;
-    }
-    let cancelled = false;
-    // Round the custom logo like the header tile instead of a hard square.
-    roundedFaviconDataUri(logoUrl).then((rounded) => {
-      if (!cancelled) setFavicon(rounded || logoUrl);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [branding]);
 
   const [discountExpired, setDiscountExpired] = useState(false);
 

--- a/src/providers/ThemeColorsProvider.tsx
+++ b/src/providers/ThemeColorsProvider.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { themeColorsApi } from '../api/themeColors';
+import { themeColorsQueryOptions } from '../api/themeColors';
 import { DEFAULT_THEME_COLORS } from '../types/theme';
 import { applyThemeColors } from '../hooks/useThemeColors';
 import { usePlatform } from '@/platform';
@@ -11,13 +11,7 @@ interface ThemeColorsProviderProps {
 }
 
 export function ThemeColorsProvider({ children }: ThemeColorsProviderProps) {
-  const { data: colors } = useQuery({
-    queryKey: ['theme-colors'],
-    queryFn: themeColorsApi.getColors,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    refetchOnWindowFocus: false,
-    retry: 1,
-  });
+  const { data: colors } = useQuery(themeColorsQueryOptions());
 
   const { theme: platformTheme, capabilities } = usePlatform();
   const { isDark } = useTheme();

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -100,7 +100,13 @@
 
 @layer base {
   :root {
-    --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+    /* Мобильная нижняя панель (MobileBottomNav): отступ от края и место, которое
+       она занимает. Всё, что прижато к низу на мобильном (тосты, бары действий,
+       низ контента), встаёт выше --mobile-nav-clearance — иначе панель это
+       перекрывает. Высота панели — константа дизайна (иконка + подпись). */
+    --mobile-nav-height: 76px;
+    --mobile-nav-offset: max(16px, env(safe-area-inset-bottom, 0px));
+    --mobile-nav-clearance: calc(var(--mobile-nav-height) + var(--mobile-nav-offset) + 12px);
 
     /* Unified Card System */
     --bento-radius: 16px;
@@ -715,39 +721,6 @@ img.twemoji {
     @apply nav-item bg-accent-500/10 text-accent-400;
   }
 
-  .bottom-nav {
-    @apply fixed z-50 bg-dark-900/95;
-    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
-    left: 16px;
-    right: 16px;
-    border-radius: var(--bento-radius);
-    padding: 8px 4px;
-    transform: translateZ(0);
-    box-shadow:
-      0 4px 30px rgba(0, 0, 0, 0.4),
-      0 0 0 1px rgba(255, 255, 255, 0.05) inset;
-  }
-
-  @media (min-width: 1024px) {
-    .bottom-nav {
-      @apply bg-dark-900/80 backdrop-blur-xl;
-    }
-  }
-
-  .bottom-nav-item {
-    @apply flex min-w-[56px] flex-1 shrink-0 flex-col items-center justify-center rounded-2xl px-3 py-2.5 text-dark-500 duration-200;
-    transition-property: color, background-color;
-  }
-
-  .bottom-nav-item:hover {
-    @apply text-dark-300;
-  }
-
-  .bottom-nav-item-active {
-    @apply flex min-w-[56px] flex-1 shrink-0 flex-col items-center justify-center rounded-2xl bg-accent-500/15 px-3 py-2.5 text-accent-400 duration-200;
-    transition-property: color, background-color;
-  }
-
   /* Divider - Dark */
   .divider {
     @apply border-t border-dark-800/50;
@@ -890,43 +863,9 @@ img.twemoji {
     @apply bg-champagne-200/70 text-champagne-800;
   }
 
-  .light .bottom-nav {
-    @apply bg-white/95;
-    box-shadow:
-      0 4px 30px rgba(0, 0, 0, 0.1),
-      0 0 0 1px rgba(0, 0, 0, 0.05);
-  }
-
-  @media (min-width: 1024px) {
-    .light .bottom-nav {
-      @apply bg-white/80 backdrop-blur-xl;
-    }
-  }
-
-  .light .bottom-nav-item {
-    @apply text-champagne-500;
-  }
-
-  .light .bottom-nav-item:hover {
-    @apply text-champagne-700;
-  }
-
-  .light .bottom-nav-item-active {
-    @apply bg-champagne-300/40 text-champagne-800;
-  }
-
   /* Divider - Light */
   .light .divider {
     @apply border-t border-champagne-200;
-  }
-
-  /* Safe area */
-  .safe-area-pb {
-    padding-bottom: calc(0.5rem + var(--safe-area-inset-bottom));
-  }
-
-  .pt-safe {
-    padding-top: env(safe-area-inset-top, 0px);
   }
 
   /* Skeleton loader */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -580,6 +580,19 @@ img.twemoji {
     @apply border border-dark-700/30 bg-dark-900/80;
   }
 
+  /* Ярлык «На экран Домой» (standalone): мобильная шапка продолжается под
+     статус-бар, и стекло на всю эту высоту читается как лишний светлый блок, а
+     полоса цвета страницы над стеклом — как жёсткая граница. Поэтому в этом
+     режиме шапка берёт тон десктопной (bg-dark-950/95, в светлой теме ремап
+     сам): статус-бар и шапка сливаются с фоном, границу даёт только нижняя
+     обводка. В браузере и в Mini App display-mode = browser, тут ничего не
+     меняется. */
+  @media (display-mode: standalone) {
+    .glass.app-mobile-header {
+      @apply border-x-0 border-t-0 bg-dark-950/95;
+    }
+  }
+
   /* Enable backdrop-blur only on desktop where it's performant */
   @media (min-width: 1024px) {
     .glass {
@@ -787,6 +800,16 @@ img.twemoji {
   @media (min-width: 1024px) {
     .light .glass {
       @apply bg-champagne-50/60 backdrop-blur-xl;
+    }
+  }
+
+  /* Ярлык «На экран Домой» в светлой теме — то же, что для тёмной выше: шапка
+     берёт тон страницы (dark-950 здесь ремапится в champagne-200) без верхней
+     и боковых обводок. Правило обязано стоять ПОСЛЕ `.light .glass`: у них
+     одинаковая специфичность, и иначе стекло светлой темы перебивало бы его. */
+  @media (display-mode: standalone) {
+    .light .glass.app-mobile-header {
+      @apply border-x-0 border-t-0 bg-dark-950/95;
     }
   }
 

--- a/src/utils/brandingHtml.test.ts
+++ b/src/utils/brandingHtml.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import htmlSource from '../../index.html?raw';
+import {
+  BRANDING_PLACEHOLDERS,
+  DEFAULT_APP_NAME,
+  renderBrandingHtml,
+} from '../../vite-plugins/brandingHtml';
+import { letterFaviconDataUri } from './favicon';
+
+/**
+ * index.html получает имя и иконку бренда из VITE_APP_NAME / VITE_APP_LOGO на
+ * сборке. До этого в разметке были зашиты «VPN» и монограмма «V», и переменные
+ * до вкладки и ярлыков не доходили.
+ */
+describe('brandingHtml', () => {
+  it('index.html содержит плейсхолдеры имени и иконки', () => {
+    expect(htmlSource).toContain(`<title>${BRANDING_PLACEHOLDERS.name}</title>`);
+    expect(htmlSource).toContain(`content="${BRANDING_PLACEHOLDERS.name}"`);
+    expect(htmlSource).toContain(`href="${BRANDING_PLACEHOLDERS.icon}"`);
+    // Значения из сборки не должны оставаться в разметке буквально.
+    expect(htmlSource).not.toContain('<title>VPN</title>');
+  });
+
+  it('подставляет экранированное имя и монограмму первой буквы', () => {
+    const html = renderBrandingHtml(htmlSource, { name: 'Zero "Ping" & Co', logo: '' });
+    expect(html).not.toContain(BRANDING_PLACEHOLDERS.name);
+    expect(html).not.toContain(BRANDING_PLACEHOLDERS.icon);
+    expect(html).toContain('<title>Zero &quot;Ping&quot; &amp; Co</title>');
+    // Логотип не задан — берётся первая буква имени, тем же генератором, что и в рантайме.
+    expect(html).toContain(`href="${letterFaviconDataUri('Z')}"`);
+  });
+
+  it('пустые переменные дают нейтральный дефолт', () => {
+    const html = renderBrandingHtml(htmlSource, { name: '   ', logo: '' });
+    expect(html).toContain(`<title>${DEFAULT_APP_NAME}</title>`);
+    expect(html).toContain(`href="${letterFaviconDataUri(DEFAULT_APP_NAME)}"`);
+  });
+
+  it('VITE_APP_LOGO задаёт букву монограммы', () => {
+    const html = renderBrandingHtml(htmlSource, { name: 'ZeroPing', logo: 'zp' });
+    expect(html).toContain(`href="${letterFaviconDataUri('Z')}"`);
+  });
+});

--- a/src/utils/documentBranding.test.ts
+++ b/src/utils/documentBranding.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { STORAGE_KEYS } from '@/config/constants';
+import {
+  buildWebManifest,
+  readBrandHint,
+  setAppNameMeta,
+  setAppleTouchIcon,
+  setDocumentTitle,
+  setWebManifest,
+  writeBrandHint,
+} from './documentBranding';
+import { letterFaviconDataUri, setFavicon } from './favicon';
+
+/**
+ * <head> под бренд инсталляции: вкладка, ярлыки Android/iOS, манифест и
+ * подсказка первой отрисовки. Раньше заголовок и фавикон ставились только после
+ * авторизации, а имя приложения для ярлыков не ставилось вовсе — ярлык на
+ * Android получал «VPN» из статического index.html.
+ */
+
+beforeEach(() => {
+  document.head.innerHTML = '<link rel="icon" href="data:image/svg+xml,static" />';
+  document.title = 'VPN';
+  localStorage.clear();
+});
+
+afterEach(() => {
+  document.head.innerHTML = '';
+});
+
+describe('setFavicon', () => {
+  it('заменяет узел <link rel="icon">, а не только href', () => {
+    const before = document.querySelector('link[rel="icon"]');
+    setFavicon('data:image/png;base64,AAAA');
+
+    const links = document.querySelectorAll('link[rel="icon"]');
+    expect(links).toHaveLength(1);
+    expect(links[0]).not.toBe(before);
+    expect(links[0].getAttribute('href')).toBe('data:image/png;base64,AAAA');
+  });
+
+  it('не трогает apple-touch-icon', () => {
+    setAppleTouchIcon('data:image/png;base64,TOUCH');
+    setFavicon('data:image/png;base64,AAAA');
+    expect(document.querySelector('link[rel="apple-touch-icon"]')?.getAttribute('href')).toBe(
+      'data:image/png;base64,TOUCH',
+    );
+  });
+});
+
+describe('letterFaviconDataUri', () => {
+  it('рисует первую букву заглавной и экранирует спецсимволы', () => {
+    const uri = letterFaviconDataUri('zero');
+    expect(uri.startsWith('data:image/svg+xml,')).toBe(true);
+    expect(decodeURIComponent(uri)).toContain('>Z</text>');
+
+    expect(decodeURIComponent(letterFaviconDataUri('<'))).toContain('>&lt;</text>');
+  });
+
+  it('красится в переданные цвета', () => {
+    const svg = decodeURIComponent(
+      letterFaviconDataUri('A', { background: '#123456', foreground: '#ffffff' }),
+    );
+    expect(svg).toContain('fill="#123456"');
+    expect(svg).toContain('fill="#ffffff"');
+  });
+});
+
+describe('заголовок и имя приложения', () => {
+  it('setDocumentTitle не затирает заголовок, переписанный страницей', () => {
+    const applied = setDocumentTitle('ZeroPing', null);
+    expect(document.title).toBe('ZeroPing');
+
+    // Лендинг поставил свой SEO-заголовок — новое имя бренда его не сбивает.
+    document.title = 'Купить VPN за 99 ₽';
+    expect(setDocumentTitle('ZeroPing 2', applied)).toBe(applied);
+    expect(document.title).toBe('Купить VPN за 99 ₽');
+  });
+
+  it('setAppNameMeta создаёт и обновляет метатеги для ярлыков', () => {
+    setAppNameMeta('ZeroPing');
+    setAppNameMeta('ZeroPing VPN');
+    for (const name of ['application-name', 'apple-mobile-web-app-title']) {
+      const metas = document.querySelectorAll(`meta[name="${name}"]`);
+      expect(metas).toHaveLength(1);
+      expect(metas[0].getAttribute('content')).toBe('ZeroPing VPN');
+    }
+  });
+});
+
+describe('веб-манифест', () => {
+  it('строится с абсолютными start_url/scope и данными бренда', () => {
+    const manifest = buildWebManifest({
+      name: 'ZeroPing',
+      icons: [{ src: 'data:image/png;base64,X', sizes: '192x192', type: 'image/png' }],
+      themeColor: '#0a0f1a',
+      backgroundColor: '#0a0f1a',
+    });
+    expect(manifest.name).toBe('ZeroPing');
+    expect(manifest.short_name).toBe('ZeroPing');
+    expect(String(manifest.start_url)).toBe(`${window.location.origin}/`);
+    expect(String(manifest.scope)).toBe(`${window.location.origin}/`);
+    expect(manifest.display).toBe('standalone');
+  });
+
+  it('setWebManifest вешает один <link rel="manifest"> с data: URI', () => {
+    const input = {
+      name: 'ZeroPing',
+      icons: [],
+      themeColor: '#0a0f1a',
+      backgroundColor: '#0a0f1a',
+    };
+    setWebManifest(input);
+    setWebManifest({ ...input, name: 'ZeroPing VPN' });
+
+    const links = document.querySelectorAll('link[rel="manifest"]');
+    expect(links).toHaveLength(1);
+    const href = links[0].getAttribute('href') ?? '';
+    expect(href.startsWith('data:application/manifest+json,')).toBe(true);
+    const parsed = JSON.parse(decodeURIComponent(href.slice(href.indexOf(',') + 1)));
+    expect(parsed.name).toBe('ZeroPing VPN');
+  });
+});
+
+describe('подсказка первой отрисовки', () => {
+  it('пишется под ключом STORAGE_KEYS.BRAND_HINT и читается обратно', () => {
+    writeBrandHint({ name: 'ZeroPing', letter: 'Z', icon: 'data:image/svg+xml,x' });
+    expect(localStorage.getItem(STORAGE_KEYS.BRAND_HINT)).toContain('ZeroPing');
+    expect(readBrandHint()).toEqual({
+      name: 'ZeroPing',
+      letter: 'Z',
+      icon: 'data:image/svg+xml,x',
+    });
+  });
+
+  it('не сохраняет слишком большую иконку и отбрасывает мусор', () => {
+    writeBrandHint({
+      name: 'ZeroPing',
+      letter: 'Z',
+      icon: `data:image/png;base64,${'A'.repeat(20_000)}`,
+    });
+    expect(readBrandHint()).toEqual({ name: 'ZeroPing', letter: 'Z', icon: undefined });
+
+    localStorage.setItem(STORAGE_KEYS.BRAND_HINT, '{"name":42}');
+    expect(readBrandHint()).toBeNull();
+  });
+});

--- a/src/utils/documentBranding.test.ts
+++ b/src/utils/documentBranding.test.ts
@@ -10,7 +10,7 @@ import {
   setWebManifest,
   writeBrandHint,
 } from './documentBranding';
-import { letterFaviconDataUri, setFavicon } from './favicon';
+import { letterFaviconDataUri, setFavicon, squareIconDataUri } from './favicon';
 
 /**
  * <head> под бренд инсталляции: вкладка, ярлыки Android/iOS, манифест и
@@ -64,6 +64,15 @@ describe('letterFaviconDataUri', () => {
     );
     expect(svg).toContain('fill="#123456"');
     expect(svg).toContain('fill="#ffffff"');
+  });
+});
+
+describe('squareIconDataUri', () => {
+  it('без canvas отдаёт null сразу, а не ждёт загрузку картинки', async () => {
+    // jsdom не реализует 2D-контекст: раньше ожидание onload было вечным.
+    await expect(
+      squareIconDataUri('data:image/svg+xml,x', 192, { background: '#0a0f1a' }),
+    ).resolves.toBeNull();
   });
 });
 

--- a/src/utils/documentBranding.ts
+++ b/src/utils/documentBranding.ts
@@ -82,6 +82,8 @@ export interface ManifestIcon {
   src: string;
   sizes: string;
   type: string;
+  /** any — как есть; maskable — лаунчер Android режет по своей форме, содержимое в безопасной зоне. */
+  purpose?: 'any' | 'maskable';
 }
 
 export interface WebManifestInput {

--- a/src/utils/documentBranding.ts
+++ b/src/utils/documentBranding.ts
@@ -1,0 +1,113 @@
+/**
+ * Бренд в <head>: заголовок вкладки, имя приложения для ярлыков (Android читает
+ * манифест и application-name, iOS — apple-mobile-web-app-title), иконки и
+ * веб-манифест. Единственный владелец — useDocumentBranding; страницы, которым
+ * нужен свой заголовок (SEO лендинга), переписывают его сами и восстанавливают.
+ */
+import { STORAGE_KEYS } from '@/config/constants';
+import { safeLocal } from './safeStorage';
+
+/** Подсказка для инлайн-скрипта index.html: что показать до прихода брендинга. */
+export interface BrandHint {
+  name: string;
+  letter: string;
+  /** data URI фавикона; крупные не сохраняем, чтобы не раздувать localStorage. */
+  icon?: string;
+}
+
+const HINT_ICON_MAX_CHARS = 16_000;
+
+export function readBrandHint(): BrandHint | null {
+  const raw = safeLocal.getJson<unknown>(STORAGE_KEYS.BRAND_HINT, null);
+  if (!raw || typeof raw !== 'object') return null;
+  const { name, letter, icon } = raw as Record<string, unknown>;
+  if (typeof name !== 'string' || typeof letter !== 'string') return null;
+  return { name, letter, icon: typeof icon === 'string' ? icon : undefined };
+}
+
+export function writeBrandHint(hint: BrandHint): void {
+  const icon = hint.icon && hint.icon.length <= HINT_ICON_MAX_CHARS ? hint.icon : undefined;
+  safeLocal.setJson(STORAGE_KEYS.BRAND_HINT, {
+    name: hint.name,
+    letter: hint.letter,
+    ...(icon ? { icon } : {}),
+  });
+}
+
+function upsertMeta(name: string, content: string): void {
+  let meta = document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.name = name;
+    document.head.appendChild(meta);
+  }
+  meta.content = content;
+}
+
+function upsertLink(rel: string): HTMLLinkElement {
+  let link = document.head.querySelector<HTMLLinkElement>(`link[rel="${rel}"]`);
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = rel;
+    document.head.appendChild(link);
+  }
+  return link;
+}
+
+/**
+ * Заголовок вкладки. `previous` — что ставили сами в прошлый раз: если страница
+ * с тех пор переписала заголовок под себя, не трогаем его. Возвращает значение,
+ * которое надо передать сюда следующим вызовом.
+ */
+export function setDocumentTitle(name: string, previous: string | null): string {
+  if (previous !== null && document.title !== previous) return previous;
+  document.title = name;
+  return name;
+}
+
+export function setAppNameMeta(name: string): void {
+  upsertMeta('application-name', name);
+  upsertMeta('apple-mobile-web-app-title', name);
+}
+
+export function setAppleTouchIcon(href: string | null): void {
+  if (!href) {
+    document.head.querySelector('link[rel="apple-touch-icon"]')?.remove();
+    return;
+  }
+  upsertLink('apple-touch-icon').href = href;
+}
+
+export interface ManifestIcon {
+  src: string;
+  sizes: string;
+  type: string;
+}
+
+export interface WebManifestInput {
+  name: string;
+  icons: ManifestIcon[];
+  themeColor: string;
+  backgroundColor: string;
+}
+
+export function buildWebManifest(input: WebManifestInput): Record<string, unknown> {
+  // У манифеста в data: URI нет своего адреса, поэтому start_url и scope —
+  // абсолютные, от корня приложения.
+  const base = new URL(import.meta.env.BASE_URL || '/', window.location.origin).href;
+  return {
+    name: input.name,
+    short_name: input.name,
+    start_url: base,
+    scope: base,
+    display: 'standalone',
+    background_color: input.backgroundColor,
+    theme_color: input.themeColor,
+    icons: input.icons,
+  };
+}
+
+export function setWebManifest(input: WebManifestInput): void {
+  const json = JSON.stringify(buildWebManifest(input));
+  upsertLink('manifest').href = `data:application/manifest+json,${encodeURIComponent(json)}`;
+}

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -1,37 +1,40 @@
 /**
  * Favicon helpers.
  *
- * The static fallback in index.html is a neutral monogram so the tab is never
- * left without an icon. Once branding is known we override it with the custom
- * logo (or a brand-letter monogram) via {@link setFavicon}.
+ * Статический фавикон index.html — монограмма из VITE_APP_LOGO; когда брендинг
+ * известен, useDocumentBranding подменяет её логотипом инсталляции (или
+ * монограммой в цвете акцента) через {@link setFavicon}.
  */
+import {
+  DEFAULT_MONOGRAM_COLORS,
+  type MonogramColors,
+  monogramDataUri,
+  monogramLetter,
+} from '../../vite-plugins/brandMonogram';
 
-/** Point the page favicon at `href`, creating the <link> if needed. */
+const IMAGE_LOAD_TIMEOUT_MS = 8000;
+
+/** Поставить фавикон `href`, заменив существующие <link rel="icon">. */
 export function setFavicon(href: string): void {
   if (!href) return;
-  let link = document.querySelector<HTMLLinkElement>("link[rel*='icon']");
-  if (!link) {
-    link = document.createElement('link');
-    link.rel = 'icon';
-    document.head.appendChild(link);
-  }
+  // Именно замена узла: при смене href у существующего <link> Firefox и Safari
+  // не всегда перерисовывают иконку вкладки.
+  const stale = document.querySelectorAll<HTMLLinkElement>(
+    "link[rel='icon'], link[rel='shortcut icon']",
+  );
+  for (const link of stale) link.remove();
+  const link = document.createElement('link');
+  link.rel = 'icon';
   link.href = href;
+  document.head.appendChild(link);
 }
 
-/**
- * Generate a square monogram favicon (SVG data URI) from a brand letter.
- * Used when the deployment has no custom logo, so every page still gets an
- * icon that matches the brand letter instead of the browser's blank default.
- */
-export function letterFaviconDataUri(letter: string): string {
-  const ch = (letter || 'V').trim().charAt(0).toUpperCase() || 'V';
-  const svg =
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">` +
-    `<rect width="64" height="64" rx="14" fill="#0a0f1a"/>` +
-    `<text x="50%" y="50%" font-family="Manrope,Arial,sans-serif" font-size="38" ` +
-    `font-weight="700" fill="#ffffff" text-anchor="middle" dominant-baseline="central">${ch}</text>` +
-    `</svg>`;
-  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+/** Квадратная монограмма (SVG data URI) из буквы бренда. */
+export function letterFaviconDataUri(
+  letter: string,
+  colors: MonogramColors = DEFAULT_MONOGRAM_COLORS,
+): string {
+  return monogramDataUri(monogramLetter(letter), colors);
 }
 
 /**
@@ -40,8 +43,8 @@ export function letterFaviconDataUri(letter: string): string {
  * hard square corners.
  *
  * `radiusRatio` 0.3 mirrors the header tile (rounded-linear-lg = 12px on a 40px
- * tile). Returns null if the image can't be loaded or the canvas is tainted —
- * the caller should fall back to the raw `src`.
+ * tile). Returns null if canvas is unavailable, the image can't be loaded or
+ * the canvas is tainted — the caller should fall back to the raw `src`.
  */
 export async function roundedFaviconDataUri(
   src: string,
@@ -49,14 +52,15 @@ export async function roundedFaviconDataUri(
   radiusRatio = 0.3,
 ): Promise<string | null> {
   if (!src) return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  // Проверяем canvas ДО загрузки картинки: в средах без него (jsdom) onload
+  // не приходит никогда, и вызывающий повис бы на ожидании.
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
   try {
     const img = await loadImage(src);
-    const canvas = document.createElement('canvas');
-    canvas.width = size;
-    canvas.height = size;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return null;
-
     traceRoundedRect(ctx, size, size * radiusRatio);
     ctx.clip();
 
@@ -75,8 +79,18 @@ export async function roundedFaviconDataUri(
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();
-    img.onload = () => resolve(img);
-    img.onerror = reject;
+    const timer = window.setTimeout(
+      () => reject(new Error('image load timeout')),
+      IMAGE_LOAD_TIMEOUT_MS,
+    );
+    img.onload = () => {
+      window.clearTimeout(timer);
+      resolve(img);
+    };
+    img.onerror = () => {
+      window.clearTimeout(timer);
+      reject(new Error('image load failed'));
+    };
     img.src = src;
   });
 }

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -76,6 +76,45 @@ export async function roundedFaviconDataUri(
   }
 }
 
+export interface SquareIconOptions {
+  /** Непрозрачная заливка под содержимым (CSS-цвет). */
+  background: string;
+  /** Доля стороны под содержимое: 1 — во всю плитку, 0.8 — безопасная зона maskable. */
+  contentScale?: number;
+}
+
+/**
+ * Непрозрачная квадратная плитка для иконок ярлыков (apple-touch-icon, манифест).
+ * iOS и Android накладывают на иконку свою маску и рисуют прозрачные пиксели
+ * белым или чёрным — скруглённые углы с прозрачностью превращаются в белые
+ * пятна. Поэтому: заливка на всю плитку, содержимое вписано целиком (contain)
+ * и отцентровано, никакого клипа. Null — без canvas или при ошибке загрузки.
+ */
+export async function squareIconDataUri(
+  src: string,
+  size: number,
+  options: SquareIconOptions,
+): Promise<string | null> {
+  if (!src) return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  try {
+    const img = await loadImage(src);
+    ctx.fillStyle = options.background;
+    ctx.fillRect(0, 0, size, size);
+    const scale = Math.min(size / img.width, size / img.height) * (options.contentScale ?? 1);
+    const dw = img.width * scale;
+    const dh = img.height * scale;
+    ctx.drawImage(img, (size - dw) / 2, (size - dh) / 2, dw, dh);
+    return canvas.toDataURL('image/png');
+  } catch {
+    return null;
+  }
+}
+
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();

--- a/src/utils/themeColorsHint.test.ts
+++ b/src/utils/themeColorsHint.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import htmlSource from '../../index.html?raw';
+import { STORAGE_KEYS } from '@/config/constants';
+import { DEFAULT_THEME_COLORS } from '@/types/theme';
+import { readThemeColorsHint, writeThemeColorsHint } from './themeColorsHint';
+
+/**
+ * Палитра оператора приходит с бэкенда уже после первой отрисовки, и каждая
+ * загрузка сначала показывала цвета по умолчанию (синий акцент, синеватый фон),
+ * а потом прыгала в операторские. Подсказка в localStorage хранит последнюю
+ * применённую палитру, а инлайн-скрипт index.html ставит её на :root до того,
+ * как загрузится приложение.
+ */
+
+const VARS = {
+  '--color-accent-500': '20, 184, 166',
+  '--color-dark-950': '10, 20, 16',
+  '--color-champagne-200': '247, 231, 206',
+  '--color-on-accent': '255, 255, 255',
+  '--color-dark-bg': '#0a1410',
+};
+
+function inlineHintScript(): string {
+  const match = htmlSource.match(/<script data-hint="theme-colors">([\s\S]*?)<\/script>/);
+  if (!match) throw new Error('index.html: нет инлайн-скрипта data-hint="theme-colors"');
+  return match[1];
+}
+
+function runInlineScript(): void {
+  new Function(inlineHintScript())();
+}
+
+function rootVar(name: string): string {
+  return document.documentElement.style.getPropertyValue(name).trim();
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute('style');
+  document.head.innerHTML = '';
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute('style');
+  document.head.innerHTML = '';
+});
+
+describe('themeColorsHint: запись и чтение', () => {
+  it('читает ровно то, что записал', () => {
+    writeThemeColorsHint({ colors: DEFAULT_THEME_COLORS, vars: VARS });
+    expect(readThemeColorsHint()).toEqual({ colors: DEFAULT_THEME_COLORS, vars: VARS });
+  });
+
+  it('без подсказки и на битом JSON возвращает null', () => {
+    expect(readThemeColorsHint()).toBeNull();
+    localStorage.setItem(STORAGE_KEYS.THEME_COLORS_HINT, '{not json');
+    expect(readThemeColorsHint()).toBeNull();
+  });
+
+  it('отбрасывает подсказку с неполными или не-hex цветами', () => {
+    localStorage.setItem(
+      STORAGE_KEYS.THEME_COLORS_HINT,
+      JSON.stringify({ colors: { ...DEFAULT_THEME_COLORS, accent: 'red' }, vars: VARS }),
+    );
+    expect(readThemeColorsHint()).toBeNull();
+    const { accent: _dropped, ...withoutAccent } = DEFAULT_THEME_COLORS;
+    localStorage.setItem(
+      STORAGE_KEYS.THEME_COLORS_HINT,
+      JSON.stringify({ colors: withoutAccent, vars: VARS }),
+    );
+    expect(readThemeColorsHint()).toBeNull();
+  });
+
+  it('отбрасывает переменные с чужими именами или значениями', () => {
+    localStorage.setItem(
+      STORAGE_KEYS.THEME_COLORS_HINT,
+      JSON.stringify({
+        colors: DEFAULT_THEME_COLORS,
+        vars: { ...VARS, '--font-sans': 'serif', '--color-x': 'url(evil)' },
+      }),
+    );
+    expect(readThemeColorsHint()?.vars).toEqual(VARS);
+  });
+});
+
+describe('themeColorsHint: инлайн-скрипт index.html', () => {
+  it('ключ хранилища в скрипте совпадает с STORAGE_KEYS', () => {
+    expect(inlineHintScript()).toContain(`'${STORAGE_KEYS.THEME_COLORS_HINT}'`);
+  });
+
+  it('ставит переменные палитры на :root и фон страницы до загрузки приложения', () => {
+    writeThemeColorsHint({ colors: DEFAULT_THEME_COLORS, vars: VARS });
+    runInlineScript();
+    expect(rootVar('--color-accent-500')).toBe('20, 184, 166');
+    expect(rootVar('--color-dark-950')).toBe('10, 20, 16');
+    expect(rootVar('--color-dark-bg')).toBe('#0a1410');
+    const style = document.head.querySelector('style');
+    expect(style?.textContent).toContain('body');
+    expect(style?.textContent).toContain('rgb(10, 20, 16)');
+    expect(style?.textContent).toContain('rgb(247, 231, 206)');
+  });
+
+  it('без подсказки ничего не трогает', () => {
+    runInlineScript();
+    expect(document.documentElement.getAttribute('style')).toBeNull();
+    expect(document.head.querySelector('style')).toBeNull();
+  });
+
+  it('пропускает чужие имена и значения и не падает на мусоре', () => {
+    localStorage.setItem(
+      STORAGE_KEYS.THEME_COLORS_HINT,
+      JSON.stringify({
+        colors: DEFAULT_THEME_COLORS,
+        vars: { '--color-accent-500': '1, 2, 3', '--font-sans': 'serif', '--color-x': 'url(evil)' },
+      }),
+    );
+    expect(() => runInlineScript()).not.toThrow();
+    expect(rootVar('--color-accent-500')).toBe('1, 2, 3');
+    expect(rootVar('--font-sans')).toBe('');
+    expect(rootVar('--color-x')).toBe('');
+
+    localStorage.setItem(STORAGE_KEYS.THEME_COLORS_HINT, '{not json');
+    expect(() => runInlineScript()).not.toThrow();
+  });
+});

--- a/src/utils/themeColorsHint.ts
+++ b/src/utils/themeColorsHint.ts
@@ -1,0 +1,64 @@
+/**
+ * Подсказка первой отрисовки для палитры оператора.
+ *
+ * Цвета приходят с бэкенда уже после загрузки JS, и каждая загрузка сначала
+ * показывала палитру по умолчанию, а потом прыгала в операторскую. Здесь хранится
+ * последняя применённая палитра: `vars` — готовые CSS-переменные для :root, их
+ * ставит инлайн-скрипт index.html до загрузки приложения; `colors` — цвета, как
+ * их отдал бэкенд, с них стартует react-query до ответа сервера.
+ *
+ * Читаем недоверчиво: localStorage могла записать другая версия приложения.
+ * Принимаются только имена `--color-*` со значением hex или RGB-триплет — те же
+ * проверки повторяет инлайн-скрипт.
+ */
+import { STORAGE_KEYS } from '@/config/constants';
+import { DEFAULT_THEME_COLORS, type ThemeColors } from '@/types/theme';
+import { safeLocal } from './safeStorage';
+
+export interface ThemeColorsHint {
+  colors: ThemeColors;
+  vars: Record<string, string>;
+}
+
+const HEX_COLOR = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+const VAR_NAME = /^--color-[a-z0-9-]+$/;
+const VAR_VALUE = /^(#[0-9a-f]{6}|\d{1,3}, \d{1,3}, \d{1,3})$/i;
+const COLOR_KEYS = Object.keys(DEFAULT_THEME_COLORS) as (keyof ThemeColors)[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseColors(raw: unknown): ThemeColors | null {
+  if (!isRecord(raw)) return null;
+  const entries = COLOR_KEYS.map((key) => [key, raw[key]] as const);
+  if (!entries.every(([, value]) => typeof value === 'string' && HEX_COLOR.test(value))) {
+    return null;
+  }
+  return Object.fromEntries(entries) as unknown as ThemeColors;
+}
+
+function parseVars(raw: unknown): Record<string, string> | null {
+  if (!isRecord(raw)) return null;
+  return Object.fromEntries(
+    Object.entries(raw).filter(
+      (entry): entry is [string, string] =>
+        VAR_NAME.test(entry[0]) && typeof entry[1] === 'string' && VAR_VALUE.test(entry[1]),
+    ),
+  );
+}
+
+export function readThemeColorsHint(): ThemeColorsHint | null {
+  const raw = safeLocal.getJson<unknown>(STORAGE_KEYS.THEME_COLORS_HINT, null);
+  if (!isRecord(raw)) return null;
+  const colors = parseColors(raw.colors);
+  const vars = parseVars(raw.vars);
+  if (!colors || !vars) return null;
+  return { colors, vars };
+}
+
+export function writeThemeColorsHint(hint: ThemeColorsHint): void {
+  // Ответ бэкенда несёт служебные поля (id, updated_at) — в подсказку идут только цвета.
+  const colors = Object.fromEntries(COLOR_KEYS.map((key) => [key, hint.colors[key]]));
+  safeLocal.setJson(STORAGE_KEYS.THEME_COLORS_HINT, { colors, vars: hint.vars });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,5 +8,5 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "vite-plugins/**/*.ts"]
 }

--- a/vite-plugins/brandMonogram.ts
+++ b/vite-plugins/brandMonogram.ts
@@ -1,0 +1,52 @@
+/**
+ * Квадратная монограмма бренда (SVG data URI) из одной буквы.
+ *
+ * Без обращения к DOM: один и тот же код рисует статический фавикон в index.html
+ * на сборке (плагин brandingHtml) и запасной фавикон в рантайме, когда у
+ * инсталляции нет загруженного логотипа. Иначе две копии разъезжаются.
+ */
+
+export interface MonogramColors {
+  background: string;
+  foreground: string;
+}
+
+export const DEFAULT_MONOGRAM_COLORS: MonogramColors = {
+  background: '#0a0f1a',
+  foreground: '#ffffff',
+};
+
+/** Первая буква строки заглавной; при пустой строке — `fallback`. */
+export function monogramLetter(letter: string | null | undefined, fallback = 'V'): string {
+  const ch = (letter ?? '').trim().charAt(0).toUpperCase();
+  return ch || fallback;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function monogramSvg(
+  letter: string,
+  colors: MonogramColors = DEFAULT_MONOGRAM_COLORS,
+): string {
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">` +
+    `<rect width="64" height="64" rx="14" fill="${escapeXml(colors.background)}"/>` +
+    `<text x="50%" y="50%" font-family="Manrope,Arial,sans-serif" font-size="38" ` +
+    `font-weight="700" fill="${escapeXml(colors.foreground)}" text-anchor="middle" ` +
+    `dominant-baseline="central">${escapeXml(monogramLetter(letter))}</text>` +
+    `</svg>`
+  );
+}
+
+export function monogramDataUri(
+  letter: string,
+  colors: MonogramColors = DEFAULT_MONOGRAM_COLORS,
+): string {
+  return `data:image/svg+xml,${encodeURIComponent(monogramSvg(letter, colors))}`;
+}

--- a/vite-plugins/brandingHtml.ts
+++ b/vite-plugins/brandingHtml.ts
@@ -1,0 +1,54 @@
+import type { Plugin } from 'vite';
+import { monogramDataUri, monogramLetter } from './brandMonogram';
+
+/**
+ * Подставляет бренд из переменных сборки в index.html.
+ *
+ * До этого в разметке были зашиты «VPN», «Cabinet» и фавикон «V», и каждая
+ * инсталляция светила ими до прихода настроек с бэкенда (а ярлыки Android/iOS
+ * забирали их навсегда). VITE_APP_NAME / VITE_APP_LOGO существовали, но до
+ * index.html не доходили.
+ */
+
+export interface BrandingHtmlOptions {
+  /** VITE_APP_NAME; пустая строка → «Cabinet». */
+  name: string;
+  /** VITE_APP_LOGO; пустая строка → первая буква имени. */
+  logo: string;
+}
+
+export const BRANDING_PLACEHOLDERS = {
+  name: '__APP_NAME__',
+  icon: '__APP_ICON__',
+} as const;
+
+export const DEFAULT_APP_NAME = 'Cabinet';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function replaceAll(html: string, placeholder: string, value: string): string {
+  return html.split(placeholder).join(value);
+}
+
+export function renderBrandingHtml(html: string, options: BrandingHtmlOptions): string {
+  const name = options.name.trim() || DEFAULT_APP_NAME;
+  const letter = monogramLetter(options.logo, monogramLetter(name));
+  const withName = replaceAll(html, BRANDING_PLACEHOLDERS.name, escapeHtml(name));
+  return replaceAll(withName, BRANDING_PLACEHOLDERS.icon, monogramDataUri(letter));
+}
+
+export function brandingHtml(options: BrandingHtmlOptions): Plugin {
+  return {
+    name: 'bedolaga:branding-html',
+    transformIndexHtml: {
+      order: 'pre',
+      handler: (html) => renderBrandingHtml(html, options),
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,82 +1,92 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import packageJson from './package.json';
+import { brandingHtml } from './vite-plugins/brandingHtml';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  define: {
-    __APP_VERSION__: JSON.stringify(packageJson.version),
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
+export default defineConfig(({ mode }) => {
+  // Переменные из .env и из окружения сборки (Docker передаёт их через ENV);
+  // окружение сильнее файла — как и у самого Vite.
+  const env = { ...loadEnv(mode, __dirname, 'VITE_'), ...process.env };
+  return {
+    plugins: [
+      react(),
+      brandingHtml({ name: env.VITE_APP_NAME ?? '', logo: env.VITE_APP_LOGO ?? '' }),
+    ],
+    define: {
+      __APP_VERSION__: JSON.stringify(packageJson.version),
     },
-  },
-  // Base path - use '/' for standalone Docker deployment
-  // Change to '/cabinet/' if serving from a sub-path
-  base: '/',
-  server: {
-    port: 5173,
-    host: true,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-        // Strip /api prefix: /api/cabinet/auth -> /cabinet/auth
-        rewrite: (path) => path.replace(/^\/api/, ''),
-      },
-      // The backend serves its liveness endpoint at the host root (not under
-      // /api). Proxy it too so the "service unavailable" detection probe hits the
-      // real backend in dev instead of the Vite server (which would mask outages).
-      '/health': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
       },
     },
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: false,
-    chunkSizeWarningLimit: 550,
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (!id.includes('node_modules')) return;
-          if (
-            id.includes('react-dom') ||
-            id.includes('react-router') ||
-            id.includes('node_modules/react/')
-          )
-            return 'vendor-react';
-          if (id.includes('@tanstack/react-query')) return 'vendor-query';
-          if (id.includes('@tanstack/react-table')) return 'vendor-table';
-          if (id.includes('i18next') || id.includes('react-i18next')) return 'vendor-i18n';
-          if (id.includes('framer-motion')) return 'vendor-motion';
-          if (id.includes('@radix-ui/')) return 'vendor-radix';
-          if (id.includes('@dnd-kit/')) return 'vendor-dnd';
-          if (id.includes('@telegram-apps/') || id.includes('/@tma.js/')) return 'vendor-telegram';
-          if (id.includes('/ogl/')) return 'vendor-webgl';
-          if (id.includes('/cmdk/')) return 'vendor-cmdk';
-          if (id.includes('twemoji') || id.includes('@twemoji/')) return 'vendor-twemoji';
-          if (id.includes('/jsencrypt/') || id.includes('@kastov/')) return 'vendor-crypto';
-          if (id.includes('@lottiefiles/')) return 'vendor-lottie';
-          // Heavy admin-only deps — split so they don't bloat the shared
-          // chunks of other lazy admin pages that don't use them.
-          if (id.includes('/recharts/') || id.includes('/d3-')) return 'vendor-recharts';
-          if (id.includes('@tiptap/') || id.includes('/prosemirror-')) return 'vendor-tiptap';
-          if (
-            id.includes('/axios/') ||
-            id.includes('/zustand/') ||
-            id.includes('/clsx/') ||
-            id.includes('/tailwind-merge/') ||
-            id.includes('class-variance-authority') ||
-            id.includes('/dompurify/')
-          )
-            return 'vendor-utils';
+    // Base path - use '/' for standalone Docker deployment
+    // Change to '/cabinet/' if serving from a sub-path
+    base: '/',
+    server: {
+      port: 5173,
+      host: true,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+          // Strip /api prefix: /api/cabinet/auth -> /cabinet/auth
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
+        // The backend serves its liveness endpoint at the host root (not under
+        // /api). Proxy it too so the "service unavailable" detection probe hits the
+        // real backend in dev instead of the Vite server (which would mask outages).
+        '/health': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
         },
       },
     },
-  },
+    build: {
+      outDir: 'dist',
+      sourcemap: false,
+      chunkSizeWarningLimit: 550,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (!id.includes('node_modules')) return;
+            if (
+              id.includes('react-dom') ||
+              id.includes('react-router') ||
+              id.includes('node_modules/react/')
+            )
+              return 'vendor-react';
+            if (id.includes('@tanstack/react-query')) return 'vendor-query';
+            if (id.includes('@tanstack/react-table')) return 'vendor-table';
+            if (id.includes('i18next') || id.includes('react-i18next')) return 'vendor-i18n';
+            if (id.includes('framer-motion')) return 'vendor-motion';
+            if (id.includes('@radix-ui/')) return 'vendor-radix';
+            if (id.includes('@dnd-kit/')) return 'vendor-dnd';
+            if (id.includes('@telegram-apps/') || id.includes('/@tma.js/'))
+              return 'vendor-telegram';
+            if (id.includes('/ogl/')) return 'vendor-webgl';
+            if (id.includes('/cmdk/')) return 'vendor-cmdk';
+            if (id.includes('twemoji') || id.includes('@twemoji/')) return 'vendor-twemoji';
+            if (id.includes('/jsencrypt/') || id.includes('@kastov/')) return 'vendor-crypto';
+            if (id.includes('@lottiefiles/')) return 'vendor-lottie';
+            // Heavy admin-only deps — split so they don't bloat the shared
+            // chunks of other lazy admin pages that don't use them.
+            if (id.includes('/recharts/') || id.includes('/d3-')) return 'vendor-recharts';
+            if (id.includes('@tiptap/') || id.includes('/prosemirror-')) return 'vendor-tiptap';
+            if (
+              id.includes('/axios/') ||
+              id.includes('/zustand/') ||
+              id.includes('/clsx/') ||
+              id.includes('/tailwind-merge/') ||
+              id.includes('class-variance-authority') ||
+              id.includes('/dompurify/')
+            )
+              return 'vendor-utils';
+          },
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Что сделано

По жалобе из «Багов» (бот 4.3.0, кабинет 1.68.0, Docker-установка) и записи экрана со скачком стилей при загрузке.

**Брендирование**
- **Вкладка и фавикон на всех страницах.** Заголовок и фавикон ставил только `useBranding` внутри AppShell, после авторизации, а без сессии его запрос был выключен; страница входа меняла только имя. Теперь единый владелец `<head>` (`useDocumentBranding`) работает везде: заголовок, метатеги имени приложения, фавикон, `apple-touch-icon` и веб-манифест.
- **Фавикон из загруженного логотипа** (скруглённый PNG, как плитка в шапке), иначе монограмма первой буквы в цвете акцента. `setFavicon` заменяет узел `<link>` целиком — Firefox/Safari не всегда перерисовывают вкладку при смене `href`.
- **Ярлыки Android и iOS** получают имя проекта и иконку: манифест (`data:` URI с именем, `start_url`, иконками 192/512 в вариантах `any` и `maskable`) плюс `application-name` и `apple-mobile-web-app-title`. Раньше ярлык брал `<title>` из статического index.html — «VPN». Иконки ярлыков — непрозрачные квадраты на цвете фона темы без скругления: iOS и Android накладывают свою маску и прозрачные углы заливают белым. Скругление осталось только у фавикона вкладки.
- **Без мигания дефолтами.** `VITE_APP_NAME` / `VITE_APP_LOGO` теперь реально подставляются в index.html на сборке (плагин `vite-plugins/brandingHtml`, с экранированием; пустые → «Cabinet» и первая буква имени). Повторные визиты дополнительно берут имя и иконку из подсказки в localStorage до загрузки JS.
- Дублирующая логика заголовка/фавикона в `useBranding`, Login и QuickPurchase убрана. `tsconfig.json` больше не ссылается на `tsconfig.node.json` (ссылка мешала общему модулю монограммы для сборки и рантайма; `tsc -b` никто не запускает).

**Ярлык «На экран Домой» (iOS) и Android**
- **Шапка не срезается статус-баром:** продолжается под него через `padding-top: env(safe-area-inset-top)`; распорка контента и оверлей меню считают ту же высоту (`headerHeightCss`). В режиме `display-mode: standalone` шапка берёт тон страницы (`bg-dark-950/95`, как десктопная) без верхней и боковых обводок — статус-бар и шапка сливаются, границу даёт только нижняя обводка. Правило продублировано для светлой темы после `.light .glass` (одинаковая специфичность, иначе стекло светлой темы его перебивало). В браузере и Mini App `display-mode` = browser, там ничего не меняется; на Android статус-бар системный, шапка получает тот же тон.
- **Нижняя панель** стоит на `max(16px, env(safe-area-inset-bottom))` вместо суммы: над индикатором «Домой» вплотную к безопасной зоне, в браузере прежние 16px.
- **Альбомная ориентация iPhone:** шапка, панель, контент и выезжающее меню отступают от боковых вырезов (`max(1rem, env(safe-area-inset-left/right))`); манифест ориентацию не запрещает.

**Палитра оператора без скачка при загрузке**
- Цвета темы приходят с бэкенда после загрузки JS, и каждая загрузка сначала показывала палитру по умолчанию, потом прыгала в операторскую. `applyThemeColors` пишет применённую палитру в localStorage (`cabinet-theme-colors-hint`: цвета плюс готовые CSS-переменные), инлайн-скрипт index.html ставит переменные на `:root`, фон страницы и `theme-color` до загрузки приложения — по образцу подсказок темы и бренда. Принимаются только `--color-*` с hex или RGB-триплетом, подсказка не может подменить прочие токены.
- react-query стартует с тех же цветов (`themeColorsQueryOptions`: `initialData` + `initialDataUpdatedAt: 0`, запрос на сервер уходит сразу); провайдер и бренд во вкладке делят одни параметры. Самый первый визит ждёт `/branding/colors` перед рендером, но не дольше 1,5 с (мёртвый бэкенд не держит пустой экран). Расчёт переменных вынесен в чистую `computeThemeCssVars`.

**Прижатые к низу элементы против мобильной панели**
- Отступ панели и просвет под ней объявлены один раз (`--mobile-nav-offset`, `--mobile-nav-clearance` в globals.css). От них считают: тосты «скопировано» на странице подарков и в подключении ТВ (на `bottom-6` целиком уходили за панель), бар массовых действий в админке (наезжал на панель на 12px), низ контента (`pb-28` в standalone iOS не хватало на 10px), кнопка оплаты быстрой покупки (индикатор «Домой»).
- При открытом меню шапки панель гасится, как при открытой клавиатуре; меню больше не резервирует под неё место.
- Удалён мёртвый CSS (`.bottom-nav*`, `.safe-area-pb`, `.pt-safe`, `--safe-area-inset-bottom`) — вторая копия стилей панели со старой формулой отступа.

**Проверка.** vitest 543 (тесты: подсказка палитры и её чтение, инлайн-скрипт index.html на jsdom, высота шапки, бренд в `<head>`; ≈480 строк), tsc, biome. Рендер в Chromium с эмуляцией safe-area на семи конфигурациях (Android без вырезов и edge-to-edge, iPhone SE, iPhone 15 Pro в портрете и альбоме, iPad mini, 320px) в обеих темах: отступ шапки равен вырезу, распорка совпадает, тосты и бар на 12px выше панели. `display-mode: standalone` в Chromium не эмулируется — правило проверено статически и принудительным включением; на реальных устройствах не проверялось.

**Замечание для готового Docker-образа:** он собирается с `VITE_APP_NAME=Cabinet`, `VITE_APP_LOGO=V`, поэтому до первого ответа бэкенда покажет «Cabinet»/«C»; со второго визита — подсказку прошлого. Кто хочет свои значения с первого байта — собирает образ со своими переменными.

Только фронт: бот обновлять не требуется.

---

Тестировать не нужно
