### PR TITLE
Релиз: нижняя панель только на экранах кнопок, «Готово» на клавиатуре, причины по устройствам из локали, пометка «Задано в .env», суточная цена с промокодом

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { PermissionRoute } from '@/components/auth/PermissionRoute';
 import { saveReturnUrl } from './utils/token';
 import { useAnalyticsCounters } from './hooks/useAnalyticsCounters';
 import { useSiteVerification } from './hooks/useSiteVerification';
+import { useDoneKey } from './hooks/useDoneKey';
 // Auth pages - load immediately (small)
 import Login from './pages/Login';
 import TelegramCallback from './pages/TelegramCallback';
@@ -267,6 +268,8 @@ function App() {
   // Pulls site-verification tokens (Antilopay apay-tag etc.) from the bot
   // backend and injects matching <meta> tags into document.head.
   useSiteVerification();
+  // Клавиша «Готово» на экранной клавиатуре для всех полей, включая экран входа.
+  useDoneKey();
 
   return (
     <>

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -68,6 +68,8 @@ export interface TicketSettings {
   support_system_mode: string; // tickets, contact, both
   cabinet_user_notifications_enabled: boolean;
   cabinet_admin_notifications_enabled: boolean;
+  /** Поля, закреплённые в .env: из кабинета их не изменить. */
+  env_locked?: string[];
 }
 
 export interface TicketSettingsUpdate {

--- a/src/api/partners.ts
+++ b/src/api/partners.ts
@@ -189,6 +189,8 @@ export interface PartnerSettings {
   withdrawal_requisites_text: string;
   partner_section_visible: boolean;
   referral_program_enabled: boolean;
+  /** Поля, закреплённые в .env: из кабинета их не изменить. */
+  env_locked?: string[];
 }
 
 export interface PartnerSettingsUpdate {

--- a/src/api/subscription.ts
+++ b/src/api/subscription.ts
@@ -198,6 +198,7 @@ export const subscriptionApi = {
   ): Promise<{
     available: boolean;
     reason?: string;
+    reason_code?: string;
     devices?: number;
     price_per_device_kopeks?: number;
     price_per_device_label?: string;
@@ -234,6 +235,7 @@ export const subscriptionApi = {
   ): Promise<{
     available: boolean;
     reason?: string;
+    reason_code?: string;
     current_device_limit: number;
     min_device_limit: number;
     can_reduce: number;

--- a/src/components/admin/EnvLockedBadge.tsx
+++ b/src/components/admin/EnvLockedBadge.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+import { LockIcon } from './icons';
+
+/**
+ * Пометка «Задано в .env»: ключ закреплён в окружении, база его не перекрывает,
+ * из кабинета значение не изменить. Одна на все формы настроек — раньше форма
+ * партнёрки молча принимала правку и «забывала» её после перезагрузки.
+ */
+export function EnvLockedBadge() {
+  const { t } = useTranslation();
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-dark-600/50 px-2 py-0.5 text-xs font-medium text-dark-400"
+      title={t('admin.settings.envLockedHint')}
+    >
+      <LockIcon />
+      {t('admin.settings.envLocked')}
+    </span>
+  );
+}

--- a/src/components/admin/bulkActions/FloatingActionBar.tsx
+++ b/src/components/admin/bulkActions/FloatingActionBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
+import { HIDDEN_UNDER_KEYBOARD, useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 import { TrashIcon } from '@/components/icons';
 import { ChevronDownIcon } from './DropdownSelect';
 import { isSubscriptionLevelAction } from './actionTargets';
@@ -45,6 +46,7 @@ export function FloatingActionBar({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const keyboardOpen = useVirtualKeyboard();
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -158,8 +160,14 @@ export function FloatingActionBar({
 
   return (
     // Снизу — просвет под мобильной панелью (на 5rem бар наезжал на неё на 12px);
-    // на десктопе панели нет, там прежние 5rem.
-    <div className="fixed inset-x-0 bottom-0 z-[9999] flex justify-center px-4 pb-[var(--mobile-nav-clearance)] lg:pb-20">
+    // на десктопе панели нет, там прежние 5rem. Пока открыта экранная клавиатура
+    // (фокус в фильтрах), бар прячется — иначе всплывает над клавиатурой.
+    <div
+      className={cn(
+        'fixed inset-x-0 bottom-0 z-[9999] flex justify-center px-4 pb-[var(--mobile-nav-clearance)] transition-opacity duration-200 lg:pb-20',
+        keyboardOpen && HIDDEN_UNDER_KEYBOARD,
+      )}
+    >
       <div
         ref={menuRef}
         className="relative flex w-full max-w-2xl items-center gap-3 rounded-2xl border border-dark-700/60 bg-dark-800/80 px-5 py-3 shadow-2xl backdrop-blur-xl"

--- a/src/components/admin/reachability/LaunchAside.test.tsx
+++ b/src/components/admin/reachability/LaunchAside.test.tsx
@@ -211,6 +211,28 @@ describe('LaunchBar в браузере', () => {
   });
 });
 
+describe('LaunchBar при открытой клавиатуре', () => {
+  it('прячется, пока фокус в поле ввода, и возвращается после', async () => {
+    const { container } = renderWithProviders(
+      <>
+        <input aria-label="search" />
+        <Panel body={body} bar />
+      </>,
+    );
+    await screen.findByRole('button', { name: 'Проверить 1 цель' });
+    const bar = container.querySelector('.fixed') as HTMLElement;
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(bar.className).not.toContain('opacity-0');
+
+    fireEvent.focusIn(input);
+    expect(bar.className).toContain('opacity-0');
+    expect(bar.className).toContain('pointer-events-none');
+
+    fireEvent.focusOut(input);
+    expect(bar.className).not.toContain('opacity-0');
+  });
+});
+
 describe('LaunchAside в Mini App: родной попап', () => {
   beforeEach(() => {
     dialog.isNative = true;

--- a/src/components/admin/reachability/LaunchAside.tsx
+++ b/src/components/admin/reachability/LaunchAside.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { SkippedUnit } from '@/api/reachability';
 import { ChevronDownIcon } from '@/components/icons';
 import { Button } from '@/components/primitives';
+import { HIDDEN_UNDER_KEYBOARD, useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 import { cn } from '@/lib/utils';
 import { LaunchConfirm } from './LaunchConfirm';
 import type { LaunchState } from './useLaunch';
@@ -165,14 +166,23 @@ export function LaunchAside({ launch, hint }: LaunchProps) {
   );
 }
 
-/** Телефон и Mini App: панель над нижней навигацией, детали раскрываются тапом по итогу. */
+/**
+ * Телефон и Mini App: панель у низа экрана, детали раскрываются тапом по итогу.
+ * Пока открыта экранная клавиатура, прячется — иначе всплывает над клавиатурой.
+ */
 export function LaunchBar({ launch }: LaunchProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const keyboardOpen = useVirtualKeyboard();
   const showDetails = open || launch.confirming;
   const targetsKey = launch.noun === 'servers' ? 'summaryServers' : 'summaryTargets';
   return (
-    <div className="fixed inset-x-0 bottom-[var(--mobile-nav-clearance)] z-40 px-3">
+    <div
+      className={cn(
+        'fixed inset-x-0 bottom-[var(--mobile-nav-clearance)] z-40 px-3 transition-opacity duration-200',
+        keyboardOpen && HIDDEN_UNDER_KEYBOARD,
+      )}
+    >
       <div
         className={cn(
           'mx-auto max-w-2xl rounded-2xl border bg-dark-900 p-3 shadow-2xl transition-colors',

--- a/src/components/admin/reachability/fleet/FleetActionBar.test.tsx
+++ b/src/components/admin/reachability/fleet/FleetActionBar.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resetVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
+import { FleetActionBar } from './FleetActionBar';
+
+/**
+ * Плашка прижата к низу экрана. Когда открыта экранная клавиатура (фокус в поле
+ * поиска по серверам), она всплывала над клавиатурой и закрывала список —
+ * теперь прячется, как нижняя панель навигации, и возвращается после ухода фокуса.
+ */
+afterEach(() => {
+  cleanup();
+  resetVirtualKeyboard();
+});
+
+describe('FleetActionBar', () => {
+  it('прячется при открытой клавиатуре и возвращается после', () => {
+    const { container, getByText } = render(
+      <div>
+        <input aria-label="search" />
+        <FleetActionBar title="1 887 cred" action={<button type="button">Go</button>} />
+      </div>,
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    const bar = getByText('1 887 cred').closest('.fixed') as HTMLElement;
+    expect(bar.className).not.toContain('opacity-0');
+
+    act(() => void input.dispatchEvent(new FocusEvent('focusin', { bubbles: true })));
+    expect(bar.className).toContain('opacity-0');
+    expect(bar.className).toContain('pointer-events-none');
+
+    act(() => void input.dispatchEvent(new FocusEvent('focusout', { bubbles: true })));
+    expect(bar.className).not.toContain('opacity-0');
+  });
+});

--- a/src/components/admin/reachability/fleet/FleetActionBar.tsx
+++ b/src/components/admin/reachability/fleet/FleetActionBar.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react';
+import { HIDDEN_UNDER_KEYBOARD, useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
+import { cn } from '@/lib/utils';
 
 interface FleetActionBarProps {
   title: string;
@@ -7,12 +9,19 @@ interface FleetActionBarProps {
 }
 
 /**
- * Плашка действия на телефоне и в Mini App: над нижней навигацией, как LaunchBar у одиночных
- * проверок. Слева что предлагаем и за сколько, справа одна кнопка.
+ * Плашка действия на телефоне и в Mini App: у низа экрана, как LaunchBar у одиночных
+ * проверок. Слева что предлагаем и за сколько, справа одна кнопка. Пока открыта экранная
+ * клавиатура (фокус в поиске по серверам), прячется — иначе всплывает над клавиатурой.
  */
 export function FleetActionBar({ title, subtitle, action }: FleetActionBarProps) {
+  const keyboardOpen = useVirtualKeyboard();
   return (
-    <div className="fixed inset-x-0 bottom-[var(--mobile-nav-clearance)] z-40 px-3 lg:hidden">
+    <div
+      className={cn(
+        'fixed inset-x-0 bottom-[var(--mobile-nav-clearance)] z-40 px-3 transition-opacity duration-200 lg:hidden',
+        keyboardOpen && HIDDEN_UNDER_KEYBOARD,
+      )}
+    >
       <div className="mx-auto flex max-w-2xl items-center gap-3 rounded-2xl border border-dark-700 bg-dark-900 p-3 shadow-2xl">
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-semibold text-dark-100">{title}</p>

--- a/src/components/layout/AppShell/AppShell.tsx
+++ b/src/components/layout/AppShell/AppShell.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useBranding } from '@/hooks/useBranding';
 import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 import { useScrollRestoration } from '@/hooks/useScrollRestoration';
+import { resetVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 import { themeColorsApi } from '@/api/themeColors';
 import { isLogoPreloaded } from '@/api/branding';
 import { cn } from '@/lib/utils';
@@ -38,6 +39,7 @@ import {
 } from '@/components/icons';
 
 import { MobileBottomNav } from './MobileBottomNav';
+import { isMobileNavScreen, mobileNavItems } from './mobileNavRoutes';
 import { AppHeader } from './AppHeader';
 import { useBackgroundConsumer } from '@/components/backgrounds/BackgroundHost';
 
@@ -76,42 +78,19 @@ export function AppShell({ children }: AppShellProps) {
   const isMobileFullscreen = isFullscreen && isMobile;
 
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
 
-  // Reset keyboard state on route change — prevents bottom nav staying hidden after navigation
+  // Смена экрана закрывает сигнал «клавиатура открыта» (useVirtualKeyboard):
+  // поле с фокусом размонтировано, blur не приходит, и прижатые к низу элементы
+  // иначе остаются спрятанными.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: путь нужен как триггер — сброс на каждой смене экрана
   useEffect(() => {
-    setIsKeyboardOpen(false);
+    resetVirtualKeyboard();
   }, [location.pathname]);
 
-  // Keyboard detection for hiding bottom nav
-  useEffect(() => {
-    const handleFocusIn = (e: FocusEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-        setIsKeyboardOpen(true);
-      }
-    };
-
-    const handleFocusOut = (e: FocusEvent) => {
-      const relatedTarget = e.relatedTarget as HTMLElement | null;
-      if (
-        !relatedTarget ||
-        (relatedTarget.tagName !== 'INPUT' &&
-          relatedTarget.tagName !== 'TEXTAREA' &&
-          !relatedTarget.isContentEditable)
-      ) {
-        setIsKeyboardOpen(false);
-      }
-    };
-
-    document.addEventListener('focusin', handleFocusIn);
-    document.addEventListener('focusout', handleFocusOut);
-
-    return () => {
-      document.removeEventListener('focusin', handleFocusIn);
-      document.removeEventListener('focusout', handleFocusOut);
-    };
-  }, []);
+  // Нижняя панель живёт только на экранах своих кнопок; на остальных её нет и
+  // место под неё не резервируется (data-mobile-nav="off" → --mobile-nav-clearance).
+  const navItems = mobileNavItems({ wheelEnabled, referralEnabled });
+  const showMobileNav = isMobileNavScreen(location.pathname, navItems);
 
   // Desktop navigation — labels always visible (no hover-reveal gimmick)
   const desktopNav = [
@@ -182,7 +161,7 @@ export function AppShell({ children }: AppShellProps) {
   // headerHeight comes from useHeaderHeight() — accounts for TG safe area in fullscreen
 
   return (
-    <div className="min-h-viewport">
+    <div className="min-h-viewport" data-mobile-nav={showMobileNav ? 'on' : 'off'}>
       {/* Global components */}
       <WebSocketNotifications />
       <CampaignBonusNotifier />
@@ -307,13 +286,8 @@ export function AppShell({ children }: AppShellProps) {
         {children}
       </main>
 
-      {/* Mobile Bottom Navigation */}
-      <MobileBottomNav
-        isKeyboardOpen={isKeyboardOpen}
-        isMenuOpen={mobileMenuOpen}
-        referralEnabled={referralEnabled}
-        wheelEnabled={wheelEnabled}
-      />
+      {/* Mobile Bottom Navigation — только на экранах её кнопок */}
+      {showMobileNav && <MobileBottomNav items={navItems} isMenuOpen={mobileMenuOpen} />}
     </div>
   );
 }

--- a/src/components/layout/AppShell/MobileBottomNav.tsx
+++ b/src/components/layout/AppShell/MobileBottomNav.tsx
@@ -4,55 +4,37 @@ import { motion } from 'framer-motion';
 
 import { cn } from '@/lib/utils';
 import { usePlatform } from '@/platform';
+import { HIDDEN_UNDER_KEYBOARD, useVirtualKeyboard } from '@/hooks/useVirtualKeyboard';
 
-// Icons
 import { HomeIcon, SubscriptionIcon, WalletIcon, UsersIcon, ChatIcon, WheelIcon } from './icons';
+import type { MobileNavItem, MobileNavKey } from './mobileNavRoutes';
+
+type NavIcon = React.ComponentType<{ className?: string }>;
+
+const ICONS: Record<MobileNavKey, NavIcon> = {
+  dashboard: HomeIcon,
+  subscription: SubscriptionIcon,
+  balance: WalletIcon,
+  wheel: WheelIcon,
+  referral: UsersIcon,
+  support: ChatIcon,
+};
 
 interface MobileBottomNavProps {
-  isKeyboardOpen: boolean;
+  /** Экраны панели — из mobileNavItems(); AppShell рендерит панель только на них. */
+  items: readonly MobileNavItem[];
   /** Открыто выезжающее меню шапки: у него есть все те же пункты, панель поверх него лишняя. */
   isMenuOpen?: boolean;
-  referralEnabled?: boolean;
-  wheelEnabled?: boolean;
 }
 
-export function MobileBottomNav({
-  isKeyboardOpen,
-  isMenuOpen = false,
-  referralEnabled,
-  wheelEnabled,
-}: MobileBottomNavProps) {
+export function MobileBottomNav({ items, isMenuOpen = false }: MobileBottomNavProps) {
   const { t } = useTranslation();
   const location = useLocation();
   const { haptic } = usePlatform();
+  const isKeyboardOpen = useVirtualKeyboard();
 
   const isActive = (path: string) =>
     path === '/' ? location.pathname === '/' : location.pathname.startsWith(path);
-
-  // Core navigation items for bottom bar.
-  //
-  // Support is ALWAYS present — frustrated paying customers must find help
-  // in the primary nav, not in the hamburger drawer. Previously Wheel
-  // (a brand-moment surface) displaced Support (a critical-path surface)
-  // when the wheel feature flag was on; that trade is hostile to the
-  // support-user persona and was flagged by the /impeccable critique.
-  //
-  // Slot priority when both Wheel and Referral are enabled and only
-  // four slots remain after Dashboard / Subscriptions / Balance / Support:
-  //   - Wheel wins (operator opted in as a deliberate brand moment)
-  //   - Referral falls back to the hamburger drawer
-  // When only one of them is enabled, that one fills the slot.
-  const coreItems = [
-    { path: '/', label: t('nav.dashboard'), icon: HomeIcon },
-    { path: '/subscriptions', label: t('nav.subscription'), icon: SubscriptionIcon },
-    { path: '/balance', label: t('nav.balance'), icon: WalletIcon },
-    ...(wheelEnabled
-      ? [{ path: '/wheel', label: t('nav.wheel'), icon: WheelIcon }]
-      : referralEnabled
-        ? [{ path: '/referral', label: t('nav.referral'), icon: UsersIcon }]
-        : []),
-    { path: '/support', label: t('nav.support'), icon: ChatIcon },
-  ];
 
   const handleNavClick = () => {
     haptic.impact('light');
@@ -64,7 +46,7 @@ export function MobileBottomNav({
         'fixed z-50 transition-all duration-200 lg:hidden',
         'bg-dark-900/95 backdrop-blur-linear',
         'border border-dark-700/30',
-        isKeyboardOpen || isMenuOpen ? 'pointer-events-none opacity-0' : 'opacity-100',
+        isKeyboardOpen || isMenuOpen ? HIDDEN_UNDER_KEYBOARD : 'opacity-100',
       )}
       style={{
         // Отступ снизу и просвет под панелью объявлены в globals.css
@@ -81,27 +63,32 @@ export function MobileBottomNav({
       }}
     >
       <div className="flex justify-around">
-        {coreItems.map((item) => (
-          <Link
-            key={item.path}
-            to={item.path}
-            onClick={handleNavClick}
-            className={cn(
-              'relative flex min-w-[56px] flex-1 shrink-0 flex-col items-center justify-center rounded-2xl px-3 py-2.5 transition-all duration-200',
-              isActive(item.path) ? 'text-accent-400' : 'text-dark-400 hover:text-dark-200',
-            )}
-          >
-            {isActive(item.path) && (
-              <motion.div
-                layoutId="bottom-nav-active"
-                className="absolute inset-0 rounded-2xl bg-accent-500/15"
-                transition={{ type: 'spring', stiffness: 500, damping: 30 }}
-              />
-            )}
-            <item.icon className="relative z-10 h-5 w-5" />
-            <span className="relative z-10 mt-1 whitespace-nowrap text-2xs">{item.label}</span>
-          </Link>
-        ))}
+        {items.map((item) => {
+          const Icon = ICONS[item.key];
+          return (
+            <Link
+              key={item.path}
+              to={item.path}
+              onClick={handleNavClick}
+              className={cn(
+                'relative flex min-w-[56px] flex-1 shrink-0 flex-col items-center justify-center rounded-2xl px-3 py-2.5 transition-all duration-200',
+                isActive(item.path) ? 'text-accent-400' : 'text-dark-400 hover:text-dark-200',
+              )}
+            >
+              {isActive(item.path) && (
+                <motion.div
+                  layoutId="bottom-nav-active"
+                  className="absolute inset-0 rounded-2xl bg-accent-500/15"
+                  transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                />
+              )}
+              <Icon className="relative z-10 h-5 w-5" />
+              <span className="relative z-10 mt-1 whitespace-nowrap text-2xs">
+                {t(`nav.${item.key}`)}
+              </span>
+            </Link>
+          );
+        })}
       </div>
     </nav>
   );

--- a/src/components/layout/AppShell/mobileNavRoutes.test.ts
+++ b/src/components/layout/AppShell/mobileNavRoutes.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { isMobileNavScreen, mobileNavItems } from './mobileNavRoutes';
+
+/**
+ * Нижняя панель на телефоне живёт только на экранах, куда ведут её кнопки:
+ * главная, подписка, баланс, поддержка и один слот под колесо или рефералку.
+ * На вложенных страницах и в админке панель не показывается, а место под ней
+ * не резервируется. Набор экранов и проверка «мы на таком экране» — в одном
+ * месте, чтобы панель и оболочка не разошлись.
+ */
+describe('mobileNavItems', () => {
+  it('без флагов — четыре базовых экрана', () => {
+    expect(mobileNavItems({}).map((item) => item.path)).toEqual([
+      '/',
+      '/subscriptions',
+      '/balance',
+      '/support',
+    ]);
+  });
+
+  it('колесо занимает слот перед поддержкой и вытесняет рефералку', () => {
+    const paths = mobileNavItems({ wheelEnabled: true, referralEnabled: true }).map(
+      (item) => item.path,
+    );
+    expect(paths).toEqual(['/', '/subscriptions', '/balance', '/wheel', '/support']);
+  });
+
+  it('рефералка получает слот, когда колесо выключено', () => {
+    const paths = mobileNavItems({ referralEnabled: true }).map((item) => item.path);
+    expect(paths).toEqual(['/', '/subscriptions', '/balance', '/referral', '/support']);
+  });
+
+  it('ключ пункта совпадает с ключом перевода nav.*', () => {
+    expect(mobileNavItems({ wheelEnabled: true }).map((item) => item.key)).toEqual([
+      'dashboard',
+      'subscription',
+      'balance',
+      'wheel',
+      'support',
+    ]);
+  });
+});
+
+describe('isMobileNavScreen', () => {
+  const items = mobileNavItems({ wheelEnabled: true });
+
+  it('главная и экраны кнопок — да', () => {
+    for (const path of ['/', '/subscriptions', '/balance', '/wheel', '/support']) {
+      expect(isMobileNavScreen(path, items), path).toBe(true);
+    }
+  });
+
+  it('хвостовой слеш не мешает', () => {
+    expect(isMobileNavScreen('/balance/', items)).toBe(true);
+  });
+
+  it('админка и вложенные страницы — нет', () => {
+    for (const path of ['/admin', '/admin/reachability', '/subscriptions/12', '/balance/top-up']) {
+      expect(isMobileNavScreen(path, items), path).toBe(false);
+    }
+  });
+
+  it('экран выключенного слота — нет', () => {
+    expect(isMobileNavScreen('/referral', items)).toBe(false);
+    expect(isMobileNavScreen('/wheel', mobileNavItems({}))).toBe(false);
+  });
+});

--- a/src/components/layout/AppShell/mobileNavRoutes.ts
+++ b/src/components/layout/AppShell/mobileNavRoutes.ts
@@ -1,0 +1,57 @@
+/**
+ * Экраны нижней панели на телефоне. Панель живёт только там, куда ведут её
+ * кнопки: на вложенных страницах и в админке её нет, и место под неё не
+ * резервируется (AppShell ставит data-mobile-nav="off", см. globals.css).
+ */
+export type MobileNavKey =
+  | 'dashboard'
+  | 'subscription'
+  | 'balance'
+  | 'wheel'
+  | 'referral'
+  | 'support';
+
+export interface MobileNavItem {
+  /** Ключ пункта: хвост ключа перевода `nav.*` и ключ иконки в панели. */
+  readonly key: MobileNavKey;
+  readonly path: string;
+}
+
+export interface MobileNavFlags {
+  readonly wheelEnabled?: boolean;
+  readonly referralEnabled?: boolean;
+}
+
+const HEAD: readonly MobileNavItem[] = [
+  { key: 'dashboard', path: '/' },
+  { key: 'subscription', path: '/subscriptions' },
+  { key: 'balance', path: '/balance' },
+];
+const SUPPORT: MobileNavItem = { key: 'support', path: '/support' };
+const WHEEL: MobileNavItem = { key: 'wheel', path: '/wheel' };
+const REFERRAL: MobileNavItem = { key: 'referral', path: '/referral' };
+
+/**
+ * Поддержка есть всегда: платящему клиенту с проблемой помощь нужна в основной
+ * навигации, а не в меню шапки. Под колесо и рефералку остаётся один слот:
+ * колесо (оператор включил его как бренд-момент) важнее, рефералка уходит в шапку.
+ */
+function slotItems({ wheelEnabled, referralEnabled }: MobileNavFlags): readonly MobileNavItem[] {
+  if (wheelEnabled) return [WHEEL];
+  if (referralEnabled) return [REFERRAL];
+  return [];
+}
+
+export function mobileNavItems(flags: MobileNavFlags): readonly MobileNavItem[] {
+  return [...HEAD, ...slotItems(flags), SUPPORT];
+}
+
+function withoutTrailingSlash(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+}
+
+/** Точное совпадение с экраном кнопки: детали подписки или пополнение — уже не экран панели. */
+export function isMobileNavScreen(pathname: string, items: readonly MobileNavItem[]): boolean {
+  const path = withoutTrailingSlash(pathname);
+  return items.some((item) => item.path === path);
+}

--- a/src/components/subscription/deviceReasons.test.ts
+++ b/src/components/subscription/deviceReasons.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { deviceUnavailableText } from './deviceReasons';
+
+/**
+ * Причина «докупить/уменьшить устройства нельзя» приходит с сервера. Раньше это был
+ * готовый текст на языке автора кода — в «Уменьшить лимит устройств» человек видел
+ * «Already at minimum device limit» посреди русского интерфейса. Теперь сервер шлёт
+ * машинный код, а текст берётся из локали; старый текст остаётся запасным для
+ * кода, которого кабинет ещё не знает.
+ */
+const t = ((key: string, params?: Record<string, unknown>) =>
+  params ? `${key}:${JSON.stringify(params)}` : key) as Parameters<typeof deviceUnavailableText>[0];
+
+const FALLBACK = 'subscription.additionalOptions.reduceUnavailable';
+
+describe('deviceUnavailableText', () => {
+  it('минимум тарифа — из локали, а не сырой английский', () => {
+    const text = deviceUnavailableText(
+      t,
+      {
+        available: false,
+        reason: 'Already at minimum device limit',
+        reason_code: 'at_minimum',
+        min_device_limit: 1,
+      },
+      FALLBACK,
+    );
+    expect(text).toBe('subscription.additionalOptions.alreadyAtMinDeviceLimit');
+  });
+
+  it('коды с числом подставляют число', () => {
+    expect(
+      deviceUnavailableText(
+        t,
+        { reason_code: 'max_devices_reached', max_device_limit: 5 },
+        FALLBACK,
+      ),
+    ).toBe('subscription.additionalOptions.reasons.maxDevicesReached:{"count":5}');
+    expect(deviceUnavailableText(t, { reason_code: 'can_add_limited', can_add: 2 }, FALLBACK)).toBe(
+      'subscription.additionalOptions.reasons.canAddLimited:{"count":2}',
+    );
+  });
+
+  it('остальные коды — свои ключи', () => {
+    expect(deviceUnavailableText(t, { reason_code: 'no_subscription' }, FALLBACK)).toBe(
+      'subscription.additionalOptions.reasons.noSubscription',
+    );
+    expect(deviceUnavailableText(t, { reason_code: 'no_active_subscription' }, FALLBACK)).toBe(
+      'subscription.additionalOptions.reasons.noActiveSubscription',
+    );
+    expect(deviceUnavailableText(t, { reason_code: 'trial' }, FALLBACK)).toBe(
+      'subscription.additionalOptions.reasons.trialNotAllowed',
+    );
+    expect(deviceUnavailableText(t, { reason_code: 'devices_unavailable' }, FALLBACK)).toBe(
+      'subscription.additionalOptions.devicesUnavailable',
+    );
+  });
+
+  it('незнакомый код — текст сервера, без текста — запасной ключ', () => {
+    expect(
+      deviceUnavailableText(t, { reason_code: 'brand_new', reason: 'Server says' }, FALLBACK),
+    ).toBe('Server says');
+    expect(deviceUnavailableText(t, { reason_code: 'brand_new' }, FALLBACK)).toBe(FALLBACK);
+    expect(deviceUnavailableText(t, undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('старый сервер без кода — его текст как раньше', () => {
+    expect(deviceUnavailableText(t, { reason: 'Докупка устройств недоступна' }, FALLBACK)).toBe(
+      'Докупка устройств недоступна',
+    );
+  });
+});

--- a/src/components/subscription/deviceReasons.ts
+++ b/src/components/subscription/deviceReasons.ts
@@ -1,0 +1,45 @@
+import type { TFunction } from 'i18next';
+
+/**
+ * Почему докупить или уменьшить устройства нельзя.
+ *
+ * Сервер шлёт машинный `reason_code`, текст берётся из локали. Поле `reason` —
+ * готовая фраза на языке автора кода — остаётся запасным вариантом для кода,
+ * которого этот кабинет ещё не знает, и для старого сервера, где кода нет вовсе.
+ */
+export interface DeviceReasonInfo {
+  available?: boolean;
+  reason?: string | null;
+  reason_code?: string | null;
+  max_device_limit?: number | null;
+  can_add?: number | null;
+  min_device_limit?: number | null;
+}
+
+const OPTIONS = 'subscription.additionalOptions';
+
+const REASON_KEYS: Record<string, (info: DeviceReasonInfo) => [string, Record<string, number>?]> = {
+  no_subscription: () => [`${OPTIONS}.reasons.noSubscription`],
+  no_active_subscription: () => [`${OPTIONS}.reasons.noActiveSubscription`],
+  devices_unavailable: () => [`${OPTIONS}.devicesUnavailable`],
+  max_devices_reached: (info) => [
+    `${OPTIONS}.reasons.maxDevicesReached`,
+    { count: info.max_device_limit ?? 0 },
+  ],
+  can_add_limited: (info) => [`${OPTIONS}.reasons.canAddLimited`, { count: info.can_add ?? 0 }],
+  trial: () => [`${OPTIONS}.reasons.trialNotAllowed`],
+  at_minimum: () => [`${OPTIONS}.alreadyAtMinDeviceLimit`],
+};
+
+export function deviceUnavailableText(
+  t: TFunction,
+  info: DeviceReasonInfo | undefined,
+  fallbackKey: string,
+): string {
+  const resolve = info?.reason_code ? REASON_KEYS[info.reason_code] : undefined;
+  if (resolve) {
+    const [key, params] = resolve(info as DeviceReasonInfo);
+    return params ? t(key, params) : t(key);
+  }
+  return info?.reason || t(fallbackKey);
+}

--- a/src/components/subscription/purchase/TariffPickerGrid.tsx
+++ b/src/components/subscription/purchase/TariffPickerGrid.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { useTheme } from '../../../hooks/useTheme';
 import { useCurrency } from '../../../hooks/useCurrency';
 import { usePromoDiscount } from '../../../hooks/usePromoDiscount';
+import { dailyPriceQuote } from './dailyPrice';
 import { getGlassColors } from '../../../utils/glassTheme';
 import { ArrowDownIcon, DevicesIcon, RestartIcon } from '@/components/icons';
 import type { Tariff, Subscription, PurchaseOptions } from '../../../types';
@@ -201,14 +202,8 @@ export function TariffPickerGrid({
                 {/* Price info */}
                 <div className="mt-3 border-t border-dark-700/50 pt-3 text-sm text-dark-400">
                   {(() => {
-                    const dailyPrice =
-                      tariff.daily_price_kopeks ?? tariff.price_per_day_kopeks ?? 0;
-                    const originalDailyPrice = tariff.original_daily_price_kopeks || 0;
-                    if (dailyPrice > 0 || originalDailyPrice > 0) {
-                      const promoDaily = applyPromoDiscount(
-                        dailyPrice,
-                        originalDailyPrice > dailyPrice ? originalDailyPrice : undefined,
-                      );
+                    const promoDaily = dailyPriceQuote(tariff, applyPromoDiscount);
+                    if (promoDaily) {
                       return (
                         <span className="flex items-center gap-2">
                           <span className="font-medium text-accent-400">

--- a/src/components/subscription/purchase/TariffPurchaseForm.tsx
+++ b/src/components/subscription/purchase/TariffPurchaseForm.tsx
@@ -6,6 +6,7 @@ import { subscriptionApi } from '../../../api/subscription';
 import { getErrorMessage, getInsufficientBalanceError } from '../../../utils/subscriptionHelpers';
 import { useCurrency } from '../../../hooks/useCurrency';
 import { usePromoDiscount } from '../../../hooks/usePromoDiscount';
+import { dailyPriceQuote } from './dailyPrice';
 import { usePlatform } from '../../../platform';
 import { openPaymentUrl } from '../../../utils/openPaymentUrl';
 import { getMonthlyPriceKopeks } from '../../../utils/pricing';
@@ -54,6 +55,8 @@ export function TariffPurchaseForm({
   const queryClient = useQueryClient();
   const { formatAmount, currencySymbol } = useCurrency();
   const { applyPromoDiscount } = usePromoDiscount();
+  // Та же котировка, что на карточке тарифа: серверная цена + промокод один раз.
+  const dailyQuote = dailyPriceQuote(tariff, applyPromoDiscount);
   const { openLink, platform } = usePlatform();
   const ref = useRef<HTMLDivElement>(null);
 
@@ -235,8 +238,26 @@ export function TariffPurchaseForm({
               {t('subscription.dailyPurchase.costPerDay')}
             </div>
             <div className="text-3xl font-bold text-accent-400">
-              {formatPrice(tariff.daily_price_kopeks || 0)}
+              {formatPrice(dailyQuote?.price ?? 0)}
             </div>
+            {dailyQuote?.original && dailyQuote.original > dailyQuote.price && (
+              <div className="mt-1 flex items-center justify-center gap-2 text-sm">
+                <span className="text-dark-500 line-through">
+                  {formatPrice(dailyQuote.original)}
+                </span>
+                {dailyQuote.percent && dailyQuote.percent > 0 && (
+                  <span
+                    className={`rounded px-1.5 py-0.5 text-xs ${
+                      dailyQuote.isPromoGroup
+                        ? 'bg-success-500/20 text-success-400'
+                        : 'bg-warning-500/20 text-warning-400'
+                    }`}
+                  >
+                    -{dailyQuote.percent}%
+                  </span>
+                )}
+              </div>
+            )}
           </div>
           <div className="space-y-2 text-sm text-dark-400">
             <div className="flex items-start gap-2">
@@ -254,7 +275,7 @@ export function TariffPurchaseForm({
           </div>
 
           {(() => {
-            const dailyPrice = tariff.daily_price_kopeks || 0;
+            const dailyPrice = dailyQuote?.price ?? 0;
             const hasEnoughBalance = balanceKopeks !== undefined && dailyPrice <= balanceKopeks;
 
             return (

--- a/src/components/subscription/purchase/dailyPrice.test.ts
+++ b/src/components/subscription/purchase/dailyPrice.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { combinePromoDiscount } from '@/hooks/usePromoDiscount';
+import { dailyPriceQuote } from './dailyPrice';
+
+/**
+ * Скидка промокода накладывается на цену ровно один раз — на клиенте, поверх
+ * серверной цены с групповой скидкой. Для суточного тарифа сервер раньше уже
+ * вкладывал промокод в daily_price_kopeks, а карточка накладывала его ещё раз:
+ * при промокоде на 20 % человек видел −36 % (9,60 ₽ из 15 ₽), а экран активации —
+ * честные 12 ₽. Теперь и карточка, и экран активации считают одной функцией.
+ */
+describe('combinePromoDiscount', () => {
+  it('без скидок — цена как есть', () => {
+    expect(combinePromoDiscount(1500, undefined, 0)).toEqual({
+      price: 1500,
+      original: null,
+      percent: null,
+      isPromoGroup: false,
+    });
+  });
+
+  it('только промокод — процент промокода, зачёркнута исходная', () => {
+    expect(combinePromoDiscount(1500, undefined, 20)).toEqual({
+      price: 1200,
+      original: 1500,
+      percent: 20,
+      isPromoGroup: false,
+    });
+  });
+
+  it('группа и промокод — суммарный процент от исходной цены', () => {
+    expect(combinePromoDiscount(1200, 1500, 20)).toEqual({
+      price: 960,
+      original: 1500,
+      percent: 36,
+      isPromoGroup: true,
+    });
+  });
+
+  it('только группа — процент группы', () => {
+    expect(combinePromoDiscount(1200, 1500, 0)).toEqual({
+      price: 1200,
+      original: 1500,
+      percent: 20,
+      isPromoGroup: true,
+    });
+  });
+});
+
+describe('dailyPriceQuote', () => {
+  const apply = (price: number, original?: number | null) =>
+    combinePromoDiscount(price, original, 20);
+
+  it('суточный тариф с промокодом: 15 ₽ → 12 ₽, −20 %, один раз', () => {
+    const quote = dailyPriceQuote({ daily_price_kopeks: 1500 }, apply);
+    expect(quote).toEqual({ price: 1200, original: 1500, percent: 20, isPromoGroup: false });
+  });
+
+  it('серверная групповая скидка + промокод: 12 ₽ → 9,60 ₽, −36 % от 15 ₽', () => {
+    const quote = dailyPriceQuote(
+      { daily_price_kopeks: 1200, original_daily_price_kopeks: 1500 },
+      apply,
+    );
+    expect(quote).toEqual({ price: 960, original: 1500, percent: 36, isPromoGroup: true });
+  });
+
+  it('нет суточной цены — null; запасной вариант — цена за день из кастомных дней', () => {
+    expect(dailyPriceQuote({ daily_price_kopeks: 0 }, apply)).toBeNull();
+    expect(dailyPriceQuote({ price_per_day_kopeks: 500 }, apply)?.price).toBe(400);
+  });
+});

--- a/src/components/subscription/purchase/dailyPrice.ts
+++ b/src/components/subscription/purchase/dailyPrice.ts
@@ -1,0 +1,25 @@
+import type { ApplyPromoDiscount, PromoDiscountResult } from '@/hooks/usePromoDiscount';
+
+/**
+ * Котировка суточной цены для показа: серверная цена (уже со скидкой группы) плюс
+ * активный промокод — один раз. Одна функция на карточку тарифа и экран активации,
+ * чтобы они не расходились (было: −36 % на карточке и −20 % на активации).
+ */
+export interface DailyPricedTariff {
+  daily_price_kopeks?: number | null;
+  original_daily_price_kopeks?: number | null;
+  price_per_day_kopeks?: number | null;
+}
+
+export function dailyPriceQuote(
+  tariff: DailyPricedTariff,
+  applyPromoDiscount: ApplyPromoDiscount,
+): PromoDiscountResult | null {
+  const dailyPrice = tariff.daily_price_kopeks ?? tariff.price_per_day_kopeks ?? 0;
+  const originalDailyPrice = tariff.original_daily_price_kopeks ?? 0;
+  if (dailyPrice <= 0 && originalDailyPrice <= 0) return null;
+  return applyPromoDiscount(
+    dailyPrice,
+    originalDailyPrice > dailyPrice ? originalDailyPrice : undefined,
+  );
+}

--- a/src/components/subscription/sheets/DeviceReductionSheet.tsx
+++ b/src/components/subscription/sheets/DeviceReductionSheet.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { deviceUnavailableText } from '../deviceReasons';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { subscriptionApi } from '../../../api/subscription';
@@ -109,7 +110,11 @@ export function DeviceReductionSheet({
 
       {deviceReductionInfo?.available === false ? (
         <div className="py-4 text-center text-sm text-dark-400">
-          {deviceReductionInfo.reason || t('subscription.additionalOptions.reduceUnavailable')}
+          {deviceUnavailableText(
+            t,
+            deviceReductionInfo,
+            'subscription.additionalOptions.reduceUnavailable',
+          )}
         </div>
       ) : deviceReductionInfo ? (
         <div className="space-y-4">

--- a/src/components/subscription/sheets/DeviceTopupSheet.tsx
+++ b/src/components/subscription/sheets/DeviceTopupSheet.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { deviceUnavailableText } from '../deviceReasons';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { subscriptionApi } from '../../../api/subscription';
 import { getErrorMessage } from '../../../utils/subscriptionHelpers';
@@ -105,7 +106,11 @@ export function DeviceTopupSheet({
 
       {devicePriceData?.available === false ? (
         <div className="py-4 text-center text-sm text-dark-400">
-          {devicePriceData.reason || t('subscription.additionalOptions.devicesUnavailable')}
+          {deviceUnavailableText(
+            t,
+            devicePriceData,
+            'subscription.additionalOptions.devicesUnavailable',
+          )}
         </div>
       ) : (
         <div className="space-y-4">

--- a/src/components/subscription/sheets/SwitchTariffSheet.tsx
+++ b/src/components/subscription/sheets/SwitchTariffSheet.tsx
@@ -6,6 +6,8 @@ import { AxiosError } from 'axios';
 import { subscriptionApi } from '../../../api/subscription';
 import { getErrorMessage } from '../../../utils/subscriptionHelpers';
 import { useCurrency } from '../../../hooks/useCurrency';
+import { usePromoDiscount } from '../../../hooks/usePromoDiscount';
+import { dailyPriceQuote } from '../purchase/dailyPrice';
 import InsufficientBalancePrompt from '../../InsufficientBalancePrompt';
 import type { Tariff } from '../../../types';
 import { Skeleton, SkeletonGroup } from '../../ui/skeleton';
@@ -71,6 +73,7 @@ export function SwitchTariffSheet({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { formatAmount, currencySymbol } = useCurrency();
+  const { applyPromoDiscount } = usePromoDiscount();
   const ref = useRef<HTMLDivElement>(null);
 
   const formatPrice = (kopeks: number) =>
@@ -140,8 +143,11 @@ export function SwitchTariffSheet({
         switchPreview &&
         (() => {
           const targetTariff = tariffs.find((tariff) => tariff.id === tariffId);
-          const dailyPrice =
-            targetTariff?.daily_price_kopeks ?? targetTariff?.price_per_day_kopeks ?? 0;
+          // Та же котировка, что на карточке и экране активации: промокод один раз.
+          const dailyQuote = targetTariff
+            ? dailyPriceQuote(targetTariff, applyPromoDiscount)
+            : null;
+          const dailyPrice = dailyQuote?.price ?? 0;
           const isDailyTariff = dailyPrice > 0;
 
           return (

--- a/src/hooks/useDoneKey.ts
+++ b/src/hooks/useDoneKey.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { usePlatform } from '@/platform';
+import { installDoneKey, isTouchOnly } from '@/utils/doneKey';
+
+/**
+ * Клавиша «Готово» на экранной клавиатуре для всех однострочных полей
+ * (см. utils/doneKey). Включается только на устройствах без мыши: на десктопе
+ * Enter в поле должен работать как раньше.
+ */
+export function useDoneKey(): void {
+  const { hideKeyboard } = usePlatform();
+  useEffect(() => {
+    const matchMedia =
+      typeof window.matchMedia === 'function' ? window.matchMedia.bind(window) : undefined;
+    if (!isTouchOnly(matchMedia)) return;
+    return installDoneKey({ hideKeyboard });
+  }, [hideKeyboard]);
+}

--- a/src/hooks/usePromoDiscount.ts
+++ b/src/hooks/usePromoDiscount.ts
@@ -26,6 +26,44 @@ export interface PromoDiscountResult {
   isPromoGroup: boolean;
 }
 
+/**
+ * Наложить активную скидку промокода на серверную цену (уже со скидкой группы).
+ * Чистая часть хука: сервер промокод в цену НЕ вкладывает, клиент накладывает
+ * его ровно один раз — здесь. `existingOriginalPrice` — цена до групповой скидки,
+ * от неё считается суммарный процент.
+ */
+export function combinePromoDiscount(
+  priceKopeks: number,
+  existingOriginalPrice: number | null | undefined,
+  activePercent: number,
+): PromoDiscountResult {
+  const hasExisting = (existingOriginalPrice ?? 0) > priceKopeks;
+  const hasPromo = activePercent > 0;
+
+  if (!hasExisting && !hasPromo) {
+    return { price: priceKopeks, original: null, percent: null, isPromoGroup: false };
+  }
+
+  const finalPrice = hasPromo ? Math.round(priceKopeks * (1 - activePercent / 100)) : priceKopeks;
+
+  if (hasExisting) {
+    const original = existingOriginalPrice as number;
+    return {
+      price: finalPrice,
+      original,
+      percent: Math.round((1 - finalPrice / original) * 100),
+      isPromoGroup: true,
+    };
+  }
+
+  return { price: finalPrice, original: priceKopeks, percent: activePercent, isPromoGroup: false };
+}
+
+export type ApplyPromoDiscount = (
+  priceKopeks: number,
+  existingOriginalPrice?: number | null,
+) => PromoDiscountResult;
+
 export function usePromoDiscount() {
   const { data: activeDiscount } = useQuery({
     queryKey: ['active-discount'],
@@ -33,40 +71,12 @@ export function usePromoDiscount() {
     staleTime: 30000,
   });
 
-  const applyPromoDiscount = useCallback(
-    (priceKopeks: number, existingOriginalPrice?: number | null): PromoDiscountResult => {
-      const hasExisting = (existingOriginalPrice ?? 0) > priceKopeks;
-      const hasPromo = !!activeDiscount?.is_active && !!activeDiscount.discount_percent;
+  const activePercent = activeDiscount?.is_active ? (activeDiscount.discount_percent ?? 0) : 0;
 
-      if (!hasExisting && !hasPromo) {
-        return { price: priceKopeks, original: null, percent: null, isPromoGroup: false };
-      }
-
-      let finalPrice = priceKopeks;
-      if (hasPromo) {
-        finalPrice = Math.round(priceKopeks * (1 - activeDiscount!.discount_percent! / 100));
-      }
-
-      if (hasExisting) {
-        const combinedPercent = hasPromo
-          ? Math.round((1 - finalPrice / existingOriginalPrice!) * 100)
-          : Math.round((1 - priceKopeks / existingOriginalPrice!) * 100);
-        return {
-          price: finalPrice,
-          original: existingOriginalPrice!,
-          percent: combinedPercent,
-          isPromoGroup: true,
-        };
-      }
-
-      return {
-        price: finalPrice,
-        original: priceKopeks,
-        percent: activeDiscount!.discount_percent!,
-        isPromoGroup: false,
-      };
-    },
-    [activeDiscount],
+  const applyPromoDiscount = useCallback<ApplyPromoDiscount>(
+    (priceKopeks, existingOriginalPrice) =>
+      combinePromoDiscount(priceKopeks, existingOriginalPrice, activePercent),
+    [activePercent],
   );
 
   return { activeDiscount, applyPromoDiscount };

--- a/src/hooks/useVirtualKeyboard.test.tsx
+++ b/src/hooks/useVirtualKeyboard.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { isTextEntry, resetVirtualKeyboard, useVirtualKeyboard } from './useVirtualKeyboard';
+
+/**
+ * На телефоне фокус в поле ввода поднимает экранную клавиатуру, и всё, что
+ * прижато к низу экрана (панель навигации, плашки запуска и массовых действий),
+ * всплывает над ней. Один общий сигнал «клавиатура открыта» — по фокусу в
+ * текстовом поле — и все прижатые элементы прячутся по нему одинаково.
+ */
+const focusIn = (el: Element) => el.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+const focusOut = (el: Element, relatedTarget: Element | null) =>
+  el.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget }));
+
+afterEach(() => {
+  cleanup();
+  resetVirtualKeyboard();
+  document.body.innerHTML = '';
+});
+
+describe('isTextEntry', () => {
+  it('поля ввода и редактируемый текст — да', () => {
+    const editable = document.createElement('div');
+    editable.contentEditable = 'true';
+    Object.defineProperty(editable, 'isContentEditable', { value: true });
+    expect(isTextEntry(document.createElement('input'))).toBe(true);
+    expect(isTextEntry(document.createElement('textarea'))).toBe(true);
+    expect(isTextEntry(editable)).toBe(true);
+  });
+
+  it('кнопки, документ и пустая цель — нет', () => {
+    expect(isTextEntry(document.createElement('button'))).toBe(false);
+    expect(isTextEntry(document)).toBe(false);
+    expect(isTextEntry(null)).toBe(false);
+  });
+});
+
+describe('useVirtualKeyboard', () => {
+  it('открыта, пока фокус в поле ввода; закрыта после ухода фокуса на кнопку', () => {
+    const input = document.createElement('input');
+    const button = document.createElement('button');
+    document.body.append(input, button);
+    const { result } = renderHook(() => useVirtualKeyboard());
+    expect(result.current).toBe(false);
+
+    act(() => void focusIn(input));
+    expect(result.current).toBe(true);
+
+    act(() => void focusOut(input, button));
+    expect(result.current).toBe(false);
+  });
+
+  it('переход фокуса между полями клавиатуру не закрывает', () => {
+    const first = document.createElement('input');
+    const second = document.createElement('textarea');
+    document.body.append(first, second);
+    const { result } = renderHook(() => useVirtualKeyboard());
+
+    act(() => void focusIn(first));
+    act(() => void focusOut(first, second));
+    expect(result.current).toBe(true);
+  });
+
+  it('сброс при смене экрана закрывает клавиатуру, даже если blur не пришёл', () => {
+    const input = document.createElement('input');
+    document.body.append(input);
+    const { result } = renderHook(() => useVirtualKeyboard());
+
+    act(() => void focusIn(input));
+    expect(result.current).toBe(true);
+    act(() => resetVirtualKeyboard());
+    expect(result.current).toBe(false);
+  });
+
+  it('несколько подписчиков видят одно состояние', () => {
+    const input = document.createElement('input');
+    document.body.append(input);
+    const a = renderHook(() => useVirtualKeyboard());
+    const b = renderHook(() => useVirtualKeyboard());
+
+    act(() => void focusIn(input));
+    expect(a.result.current).toBe(true);
+    expect(b.result.current).toBe(true);
+  });
+});

--- a/src/hooks/useVirtualKeyboard.ts
+++ b/src/hooks/useVirtualKeyboard.ts
@@ -1,0 +1,68 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Экранная клавиатура на телефоне: открыта, пока фокус стоит в текстовом поле.
+ * Всё, что прижато к низу экрана (панель навигации, плашки запуска проверок и
+ * массовых действий), иначе всплывает над клавиатурой и закрывает контент —
+ * по этому сигналу оно прячется. Один источник на всё приложение: слушатели
+ * ставятся при первом подписчике и снимаются с последним.
+ */
+type Listener = () => void;
+
+/** Классы для прижатого к низу элемента, пока клавиатура открыта. */
+export const HIDDEN_UNDER_KEYBOARD = 'pointer-events-none opacity-0';
+
+let open = false;
+let listeners: readonly Listener[] = [];
+
+export function isTextEntry(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable === true
+  );
+}
+
+function setOpen(next: boolean): void {
+  if (next === open) return;
+  open = next;
+  for (const listener of listeners) listener();
+}
+
+function onFocusIn(event: FocusEvent): void {
+  if (isTextEntry(event.target)) setOpen(true);
+}
+
+/** Переход фокуса из поля в поле клавиатуру не закрывает. */
+function onFocusOut(event: FocusEvent): void {
+  if (!isTextEntry(event.relatedTarget)) setOpen(false);
+}
+
+function subscribe(listener: Listener): () => void {
+  if (listeners.length === 0) {
+    document.addEventListener('focusin', onFocusIn);
+    document.addEventListener('focusout', onFocusOut);
+  }
+  listeners = [...listeners, listener];
+  return () => {
+    listeners = listeners.filter((known) => known !== listener);
+    if (listeners.length === 0) {
+      document.removeEventListener('focusin', onFocusIn);
+      document.removeEventListener('focusout', onFocusOut);
+    }
+  };
+}
+
+const getSnapshot = (): boolean => open;
+const getServerSnapshot = (): boolean => false;
+
+export function useVirtualKeyboard(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+/**
+ * Смена экрана: поле с фокусом размонтировано и blur не приходит — без сброса
+ * панель после перехода оставалась спрятанной (см. историю: страница оплаты).
+ */
+export function resetVirtualKeyboard(): void {
+  setOpen(false);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -602,6 +602,14 @@
       "disconnectDevicesFirst_other": "Disconnect devices first to reduce the limit below {{count}} devices",
       "reduceUnavailable": "Device reduction is not available",
       "alreadyAtMinDeviceLimit": "Already at minimum device limit for your tariff",
+      "reasons": {
+        "noSubscription": "Subscription not found",
+        "noActiveSubscription": "No active subscription",
+        "maxDevicesReached": "Device limit reached ({{count}})",
+        "canAddLimited_one": "You can add at most {{count}} device",
+        "canAddLimited_other": "You can add at most {{count}} devices",
+        "trialNotAllowed": "Device reduction is not available for trial subscriptions"
+      },
       "reduce": "Reduce",
       "reducing": "Reducing...",
       "newDeviceLimit_one": "New limit: {{count}} device",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -468,6 +468,14 @@
       "reduceDevicesDescription": "می‌توانید تعداد دستگاه‌ها را تا حداقل مجاز در تعرفه کاهش دهید",
       "reduceDevicesTitle": "کاهش تعداد دستگاه‌ها",
       "reduceUnavailable": "در حال حاضر کاهش تعداد دستگاه‌ها امکان‌پذیر نیست",
+      "alreadyAtMinDeviceLimit": "حداقل تعداد دستگاه برای تعرفه شما از قبل اعمال شده است",
+      "reasons": {
+        "noSubscription": "اشتراکی یافت نشد",
+        "noActiveSubscription": "اشتراک فعالی وجود ندارد",
+        "maxDevicesReached": "به حداکثر تعداد دستگاه رسیده‌اید ({{count}})",
+        "canAddLimited": "حداکثر {{count}} دستگاه می‌توانید اضافه کنید",
+        "trialNotAllowed": "کاهش تعداد دستگاه برای اشتراک آزمایشی در دسترس نیست"
+      },
       "reducing": "در حال کاهش…"
     },
     "serverManagement": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -620,6 +620,15 @@
       "disconnectDevicesFirst_many": "Сначала отключите устройства, чтобы уменьшить лимит ниже {{count}} устройств",
       "reduceUnavailable": "Уменьшение устройств недоступно",
       "alreadyAtMinDeviceLimit": "Уже достигнут минимальный лимит устройств для вашего тарифа",
+      "reasons": {
+        "noSubscription": "Подписка не найдена",
+        "noActiveSubscription": "Нет активной подписки",
+        "maxDevicesReached": "Достигнут максимум устройств ({{count}})",
+        "canAddLimited_one": "Можно добавить максимум {{count}} устройство",
+        "canAddLimited_few": "Можно добавить максимум {{count}} устройства",
+        "canAddLimited_many": "Можно добавить максимум {{count}} устройств",
+        "trialNotAllowed": "Для пробной подписки уменьшение лимита недоступно"
+      },
       "reduce": "Уменьшить",
       "reducing": "Уменьшение...",
       "newDeviceLimit_one": "Новый лимит: {{count}} устройство",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -468,6 +468,14 @@
       "reduceDevicesDescription": "您可以将设备数量减少至套餐的最低限制",
       "reduceDevicesTitle": "减少设备数量",
       "reduceUnavailable": "当前无法减少设备数量",
+      "alreadyAtMinDeviceLimit": "已是您套餐的最低设备数",
+      "reasons": {
+        "noSubscription": "未找到订阅",
+        "noActiveSubscription": "没有有效的订阅",
+        "maxDevicesReached": "已达到设备上限（{{count}}）",
+        "canAddLimited": "最多还能添加 {{count}} 台设备",
+        "trialNotAllowed": "试用订阅不支持减少设备数"
+      },
       "reducing": "正在减少…"
     },
     "serverManagement": {

--- a/src/pages/AdminPartnerSettings.tsx
+++ b/src/pages/AdminPartnerSettings.tsx
@@ -7,6 +7,7 @@ import { AdminBackButton } from '../components/admin';
 import { toNumber } from '../utils/inputHelpers';
 import { SettingsIcon } from '@/components/icons';
 import { PageSkeleton, Skeleton } from '@/components/ui/skeleton';
+import { EnvLockedBadge } from '@/components/admin/EnvLockedBadge';
 
 type NumberOrEmpty = number | '';
 
@@ -23,6 +24,8 @@ export default function AdminPartnerSettings() {
     queryKey: ['partner-settings'],
     queryFn: partnerApi.getPartnerSettings,
   });
+  // Поля, закреплённые в .env: сервер их не применит — переключатель отключаем и помечаем.
+  const envLocked = new Set(settings?.env_locked ?? []);
 
   const [formData, setFormData] = useState<{
     referral_program_enabled: boolean;
@@ -154,14 +157,16 @@ export default function AdminPartnerSettings() {
               <input
                 type="checkbox"
                 checked={formData.referral_program_enabled}
+                disabled={envLocked.has('referral_program_enabled')}
                 onChange={(e) =>
                   setFormData({ ...formData, referral_program_enabled: e.target.checked })
                 }
                 className="h-5 w-5 rounded border-dark-700 bg-dark-800 text-accent-500 focus:ring-2 focus:ring-accent-500 focus:ring-offset-0"
               />
               <div>
-                <div className="font-medium text-dark-100">
+                <div className="flex items-center gap-2 font-medium text-dark-100">
                   {t('admin.partners.settingsFields.programEnabled')}
+                  {envLocked.has('referral_program_enabled') && <EnvLockedBadge />}
                 </div>
                 <div className="text-sm text-dark-500">
                   {t('admin.partners.settingsFields.programEnabledDesc')}
@@ -176,14 +181,16 @@ export default function AdminPartnerSettings() {
               <input
                 type="checkbox"
                 checked={formData.partner_section_visible}
+                disabled={envLocked.has('partner_section_visible')}
                 onChange={(e) =>
                   setFormData({ ...formData, partner_section_visible: e.target.checked })
                 }
                 className="h-5 w-5 rounded border-dark-700 bg-dark-800 text-accent-500 focus:ring-2 focus:ring-accent-500 focus:ring-offset-0"
               />
               <div>
-                <div className="font-medium text-dark-100">
+                <div className="flex items-center gap-2 font-medium text-dark-100">
                   {t('admin.partners.settingsFields.partnerVisible')}
+                  {envLocked.has('partner_section_visible') && <EnvLockedBadge />}
                 </div>
                 <div className="text-sm text-dark-500">
                   {t('admin.partners.settingsFields.partnerVisibleDesc')}
@@ -205,12 +212,14 @@ export default function AdminPartnerSettings() {
               <input
                 type="checkbox"
                 checked={formData.withdrawal_enabled}
+                disabled={envLocked.has('withdrawal_enabled')}
                 onChange={(e) => setFormData({ ...formData, withdrawal_enabled: e.target.checked })}
                 className="h-5 w-5 rounded border-dark-700 bg-dark-800 text-accent-500 focus:ring-2 focus:ring-accent-500 focus:ring-offset-0"
               />
               <div>
-                <div className="font-medium text-dark-100">
+                <div className="flex items-center gap-2 font-medium text-dark-100">
                   {t('admin.partners.settingsFields.withdrawalEnabled')}
+                  {envLocked.has('withdrawal_enabled') && <EnvLockedBadge />}
                 </div>
                 <div className="text-sm text-dark-500">
                   {t('admin.partners.settingsFields.withdrawalEnabledDesc')}
@@ -221,8 +230,9 @@ export default function AdminPartnerSettings() {
 
           {/* Min Amount */}
           <div className="mb-4">
-            <label className="mb-2 block text-sm font-medium text-dark-300">
+            <label className="mb-2 flex items-center gap-2 text-sm font-medium text-dark-300">
               {t('admin.partners.settingsFields.minAmount')}
+              {envLocked.has('withdrawal_min_amount_kopeks') && <EnvLockedBadge />}
             </label>
             <input
               type="number"
@@ -237,7 +247,9 @@ export default function AdminPartnerSettings() {
                 if (!isNaN(num)) setFormData({ ...formData, withdrawal_min_amount_kopeks: num });
               }}
               className="input"
-              disabled={!formData.withdrawal_enabled}
+              disabled={
+                !formData.withdrawal_enabled || envLocked.has('withdrawal_min_amount_kopeks')
+              }
             />
             <p className="mt-1 text-xs text-dark-500">
               {t('admin.partners.settingsFields.minAmountDesc')}
@@ -246,8 +258,9 @@ export default function AdminPartnerSettings() {
 
           {/* Cooldown Days */}
           <div className="mb-4">
-            <label className="mb-2 block text-sm font-medium text-dark-300">
+            <label className="mb-2 flex items-center gap-2 text-sm font-medium text-dark-300">
               {t('admin.partners.settingsFields.cooldownDays')}
+              {envLocked.has('withdrawal_cooldown_days') && <EnvLockedBadge />}
             </label>
             <input
               type="number"
@@ -261,7 +274,7 @@ export default function AdminPartnerSettings() {
                 if (!isNaN(num)) setFormData({ ...formData, withdrawal_cooldown_days: num });
               }}
               className="input"
-              disabled={!formData.withdrawal_enabled}
+              disabled={!formData.withdrawal_enabled || envLocked.has('withdrawal_cooldown_days')}
             />
             <p className="mt-1 text-xs text-dark-500">
               {t('admin.partners.settingsFields.cooldownDaysDesc')}
@@ -270,8 +283,9 @@ export default function AdminPartnerSettings() {
 
           {/* Requisites Text */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-dark-300">
+            <label className="mb-2 flex items-center gap-2 text-sm font-medium text-dark-300">
               {t('admin.partners.settingsFields.requisitesText')}
+              {envLocked.has('withdrawal_requisites_text') && <EnvLockedBadge />}
             </label>
             <textarea
               value={formData.withdrawal_requisites_text}
@@ -280,7 +294,7 @@ export default function AdminPartnerSettings() {
               }
               className="input min-h-[80px] w-full"
               maxLength={2000}
-              disabled={!formData.withdrawal_enabled}
+              disabled={!formData.withdrawal_enabled || envLocked.has('withdrawal_requisites_text')}
               placeholder={t('admin.partners.settingsFields.requisitesTextPlaceholder')}
             />
             <p className="mt-1 text-xs text-dark-500">

--- a/src/pages/AdminTicketSettings.tsx
+++ b/src/pages/AdminTicketSettings.tsx
@@ -7,6 +7,7 @@ import { AdminBackButton } from '../components/admin';
 import { SettingsIcon } from '@/components/icons';
 import { toNumber } from '../utils/inputHelpers';
 import { PageSkeleton, Skeleton } from '@/components/ui/skeleton';
+import { EnvLockedBadge } from '@/components/admin/EnvLockedBadge';
 
 type NumberOrEmpty = number | '';
 
@@ -23,6 +24,8 @@ export default function AdminTicketSettings() {
     queryKey: ['ticket-settings'],
     queryFn: adminApi.getTicketSettings,
   });
+  // Поля, закреплённые в .env: сервер их не применит — переключатель отключаем и помечаем.
+  const envLocked = new Set(settings?.env_locked ?? []);
 
   const [formData, setFormData] = useState<{
     sla_enabled: boolean;
@@ -218,11 +221,15 @@ export default function AdminTicketSettings() {
               <input
                 type="checkbox"
                 checked={formData.sla_enabled}
+                disabled={envLocked.has('sla_enabled')}
                 onChange={(e) => setFormData({ ...formData, sla_enabled: e.target.checked })}
                 className="h-5 w-5 rounded border-dark-700 bg-dark-800 text-accent-500 focus:ring-2 focus:ring-accent-500 focus:ring-offset-0"
               />
               <div>
-                <div className="font-medium text-dark-100">{t('admin.tickets.slaEnabled')}</div>
+                <div className="flex items-center gap-2 font-medium text-dark-100">
+                  {t('admin.tickets.slaEnabled')}
+                  {envLocked.has('sla_enabled') && <EnvLockedBadge />}
+                </div>
                 <div className="text-sm text-dark-500">{t('admin.tickets.slaEnabledDesc')}</div>
               </div>
             </label>
@@ -230,8 +237,9 @@ export default function AdminTicketSettings() {
 
           {/* SLA Minutes */}
           <div className="mb-4">
-            <label className="mb-2 block text-sm font-medium text-dark-300">
+            <label className="mb-2 flex items-center gap-2 text-sm font-medium text-dark-300">
               {t('admin.tickets.slaMinutes')}
+              {envLocked.has('sla_minutes') && <EnvLockedBadge />}
             </label>
             <input
               type="number"
@@ -245,7 +253,7 @@ export default function AdminTicketSettings() {
                 if (!isNaN(num)) setFormData({ ...formData, sla_minutes: num });
               }}
               className={`input ${formData.sla_enabled && !isSlaMinutesValid && formData.sla_minutes !== '' ? 'border-error-500/50' : ''}`}
-              disabled={!formData.sla_enabled}
+              disabled={!formData.sla_enabled || envLocked.has('sla_minutes')}
             />
             {formData.sla_enabled && formData.sla_minutes !== '' && !isSlaMinutesValid && (
               <p className="mt-1 text-xs text-error-400">
@@ -257,8 +265,9 @@ export default function AdminTicketSettings() {
 
           {/* Check Interval */}
           <div className="mb-4">
-            <label className="mb-2 block text-sm font-medium text-dark-300">
+            <label className="mb-2 flex items-center gap-2 text-sm font-medium text-dark-300">
               {t('admin.tickets.checkInterval')}
+              {envLocked.has('sla_check_interval_seconds') && <EnvLockedBadge />}
             </label>
             <input
               type="number"
@@ -272,7 +281,7 @@ export default function AdminTicketSettings() {
                 if (!isNaN(num)) setFormData({ ...formData, sla_check_interval_seconds: num });
               }}
               className={`input ${formData.sla_enabled && !isCheckIntervalValid && formData.sla_check_interval_seconds !== '' ? 'border-error-500/50' : ''}`}
-              disabled={!formData.sla_enabled}
+              disabled={!formData.sla_enabled || envLocked.has('sla_check_interval_seconds')}
             />
             {formData.sla_enabled &&
               formData.sla_check_interval_seconds !== '' &&
@@ -286,8 +295,9 @@ export default function AdminTicketSettings() {
 
           {/* Reminder Cooldown */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-dark-300">
+            <label className="mb-2 flex items-center gap-2 text-sm font-medium text-dark-300">
               {t('admin.tickets.reminderCooldown')}
+              {envLocked.has('sla_reminder_cooldown_minutes') && <EnvLockedBadge />}
             </label>
             <input
               type="number"
@@ -302,7 +312,7 @@ export default function AdminTicketSettings() {
                 if (!isNaN(num)) setFormData({ ...formData, sla_reminder_cooldown_minutes: num });
               }}
               className={`input ${formData.sla_enabled && !isReminderCooldownValid && formData.sla_reminder_cooldown_minutes !== '' ? 'border-error-500/50' : ''}`}
-              disabled={!formData.sla_enabled}
+              disabled={!formData.sla_enabled || envLocked.has('sla_reminder_cooldown_minutes')}
             />
             {formData.sla_enabled &&
               formData.sla_reminder_cooldown_minutes !== '' &&

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -145,7 +145,8 @@ const CountdownTimer = memo(function CountdownTimer({
           {t('subscription.expired')}
         </div>
       ) : (
-        <div className="flex items-baseline justify-between">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+          {/* На телефоне дата уходит на свою строку: рядом с таймером ей не хватало места, и она ломалась посреди «23 сент. / 2026 г.» */}
           <div className="flex items-baseline gap-1 font-mono tabular-nums">
             {countdown.days > 0 && (
               <>

--- a/src/pages/adminPartnerSettings.test.tsx
+++ b/src/pages/adminPartnerSettings.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlatformProvider } from '@/platform/PlatformProvider';
+import type { PartnerSettings } from '@/api/partners';
+
+/**
+ * Настройка, закреплённая в .env, из кабинета не меняется: сервер пишет её в базу,
+ * но в память не применяет, и после перезагрузки всё возвращается. Раньше форма
+ * молча принимала такую правку. Теперь сервер отдаёт такие поля в env_locked, а
+ * форма показывает пометку и отключает переключатель.
+ */
+
+import ruLocale from '@/locales/ru.json';
+
+function resolveRu(key: string): string | undefined {
+  const value = key
+    .split('.')
+    .reduce<unknown>((node, part) => (node as Record<string, unknown>)?.[part], ruLocale);
+  return typeof value === 'string' ? value : undefined;
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      (resolveRu(key) ?? key).replace(/{{(\w+)}}/g, (_m, name) => String(options?.[name] ?? '')),
+    i18n: { language: 'ru', changeLanguage: () => Promise.resolve() },
+  }),
+  Trans: ({ children }: { children?: unknown }) => children ?? null,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+const state: { payload: PartnerSettings } = {
+  payload: {
+    withdrawal_enabled: true,
+    withdrawal_min_amount_kopeks: 100000,
+    withdrawal_cooldown_days: 30,
+    withdrawal_requisites_text: '',
+    partner_section_visible: true,
+    referral_program_enabled: true,
+    env_locked: [],
+  },
+};
+
+vi.mock('@/api/partners', () => ({
+  partnerApi: {
+    getPartnerSettings: () => Promise.resolve(state.payload),
+    updatePartnerSettings: () => Promise.resolve(state.payload),
+  },
+}));
+
+if (!window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+(globalThis as Record<string, unknown>).__APP_VERSION__ ??= '0.0.0-test';
+
+afterEach(() => {
+  cleanup();
+  state.payload = { ...state.payload, env_locked: [] };
+});
+
+async function renderPage() {
+  const Page = (await import('./AdminPartnerSettings')).default;
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <PlatformProvider>
+        <MemoryRouter initialEntries={['/admin/partners/settings']}>
+          <Page />
+        </MemoryRouter>
+      </PlatformProvider>
+    </QueryClientProvider>,
+  );
+  await screen.findByLabelText(/Раздел партнёрки виден в кабинете/);
+}
+
+describe('поля, закреплённые в .env', () => {
+  it('переключатель отключён и помечен «Задано в .env»', async () => {
+    state.payload = { ...state.payload, env_locked: ['partner_section_visible'] };
+    await renderPage();
+
+    const visible = screen.getByLabelText(/Раздел партнёрки виден в кабинете/) as HTMLInputElement;
+    expect(visible.disabled).toBe(true);
+    expect(screen.getAllByText('Задано в .env')).toHaveLength(1);
+
+    const program = screen.getByLabelText(/Реферальная программа включена/) as HTMLInputElement;
+    expect(program.disabled).toBe(false);
+  });
+
+  it('без env_locked ничего не отключено и пометок нет', async () => {
+    await renderPage();
+    expect(
+      (screen.getByLabelText(/Раздел партнёрки виден в кабинете/) as HTMLInputElement).disabled,
+    ).toBe(false);
+    expect(screen.queryByText('Задано в .env')).toBeNull();
+  });
+});

--- a/src/platform/adapters/TelegramAdapter.ts
+++ b/src/platform/adapters/TelegramAdapter.ts
@@ -22,6 +22,7 @@ import {
   shareURL,
   enableClosingConfirmation,
   disableClosingConfirmation,
+  hideKeyboard,
 } from '@telegram-apps/sdk-react';
 import type {
   PlatformContext,
@@ -328,6 +329,14 @@ export function createTelegramAdapter(): PlatformContext {
           disableClosingConfirmation();
         }
       } catch {}
+    },
+
+    hideKeyboard() {
+      try {
+        if (hideKeyboard.isAvailable()) hideKeyboard();
+      } catch {
+        // Старый клиент: клавиатуру закрывает потеря фокуса полем.
+      }
     },
   };
 }

--- a/src/platform/adapters/WebAdapter.ts
+++ b/src/platform/adapters/WebAdapter.ts
@@ -239,5 +239,9 @@ export function createWebAdapter(): PlatformContext {
         window.onbeforeunload = null;
       }
     },
+
+    hideKeyboard() {
+      // В браузере клавиатуру закрывает потеря фокуса полем.
+    },
   };
 }

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -110,4 +110,8 @@ export interface PlatformContext {
 
   // Closing confirmation
   setClosingConfirmation: (enabled: boolean) => void;
+
+  // Экранная клавиатура: спрятать средствами платформы (Telegram — Bot API 9.1+).
+  // В браузере достаточно потери фокуса полем, там это no-op.
+  hideKeyboard: () => void;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -107,7 +107,15 @@
     --mobile-nav-height: 76px;
     --mobile-nav-offset: max(16px, env(safe-area-inset-bottom, 0px));
     --mobile-nav-clearance: calc(var(--mobile-nav-height) + var(--mobile-nav-offset) + 12px);
+  }
 
+  /* Экраны без панели (вложенные страницы, админка): AppShell ставит
+     data-mobile-nav="off", и прижатым к низу элементам остаётся только отступ от края. */
+  [data-mobile-nav="off"] {
+    --mobile-nav-clearance: var(--mobile-nav-offset);
+  }
+
+  :root {
     /* Unified Card System */
     --bento-radius: 16px;
     --bento-radius-lg: 20px;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -839,6 +839,8 @@ export interface TicketSettings {
   support_system_mode: string;
   cabinet_user_notifications_enabled: boolean;
   cabinet_admin_notifications_enabled: boolean;
+  /** Поля, закреплённые в .env: из кабинета их не изменить. */
+  env_locked?: string[];
 }
 
 // Payment method config types (admin)

--- a/src/utils/doneKey.test.ts
+++ b/src/utils/doneKey.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { installDoneKey, isSingleLineTextEntry, isTouchOnly, stampEnterKeyHint } from './doneKey';
+
+/**
+ * На телефоне у экранной клавиатуры нет своей кнопки «скрыть» (в Mini App
+ * Telegram нет и родной панели iOS с «Готово»). Поэтому клавиша ввода на всех
+ * однострочных полях подписывается «Готово» и закрывает клавиатуру: поле теряет
+ * фокус, а в Telegram дополнительно вызывается hideKeyboard(). Многострочные
+ * поля не трогаем — там Enter переносит строку.
+ */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+const pressEnter = (el: Element, init: KeyboardEventInit = {}) =>
+  el.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true, ...init }),
+  );
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('isSingleLineTextEntry', () => {
+  it('текстовые input — да, textarea и кнопки-инпуты — нет', () => {
+    const text = document.createElement('input');
+    const search = document.createElement('input');
+    search.type = 'search';
+    const number = document.createElement('input');
+    number.type = 'number';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    const submit = document.createElement('input');
+    submit.type = 'submit';
+    expect(isSingleLineTextEntry(text)).toBe(true);
+    expect(isSingleLineTextEntry(search)).toBe(true);
+    expect(isSingleLineTextEntry(number)).toBe(true);
+    expect(isSingleLineTextEntry(checkbox)).toBe(false);
+    expect(isSingleLineTextEntry(submit)).toBe(false);
+    expect(isSingleLineTextEntry(document.createElement('textarea'))).toBe(false);
+    expect(isSingleLineTextEntry(null)).toBe(false);
+  });
+});
+
+describe('stampEnterKeyHint', () => {
+  it('ставит «Готово» текстовым полям без своей подсказки, чужую подсказку не трогает', () => {
+    document.body.innerHTML = `
+      <input id="plain" />
+      <input id="own" enterkeyhint="go" />
+      <input id="check" type="checkbox" />
+      <textarea id="multi"></textarea>
+      <div><input id="nested" type="search" /></div>`;
+    stampEnterKeyHint(document.body);
+    expect(document.getElementById('plain')?.getAttribute('enterkeyhint')).toBe('done');
+    expect(document.getElementById('nested')?.getAttribute('enterkeyhint')).toBe('done');
+    expect(document.getElementById('own')?.getAttribute('enterkeyhint')).toBe('go');
+    expect(document.getElementById('check')?.hasAttribute('enterkeyhint')).toBe(false);
+    expect(document.getElementById('multi')?.hasAttribute('enterkeyhint')).toBe(false);
+  });
+
+  it('принимает и сам input, а не только контейнер', () => {
+    const input = document.createElement('input');
+    stampEnterKeyHint(input);
+    expect(input.getAttribute('enterkeyhint')).toBe('done');
+  });
+});
+
+describe('installDoneKey', () => {
+  it('поле, появившееся позже, тоже получает «Готово»', async () => {
+    const stop = installDoneKey({ hideKeyboard: vi.fn() });
+    const input = document.createElement('input');
+    document.body.append(input);
+    await tick();
+    expect(input.getAttribute('enterkeyhint')).toBe('done');
+    stop();
+  });
+
+  it('Enter в однострочном поле снимает фокус и прячет клавиатуру Telegram', () => {
+    const hideKeyboard = vi.fn();
+    const stop = installDoneKey({ hideKeyboard });
+    const input = document.createElement('input');
+    document.body.append(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    pressEnter(input);
+    expect(document.activeElement).not.toBe(input);
+    expect(hideKeyboard).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('Enter, который уже обработало поле (preventDefault), клавиатуру не закрывает', () => {
+    const hideKeyboard = vi.fn();
+    const stop = installDoneKey({ hideKeyboard });
+    const input = document.createElement('input');
+    input.addEventListener('keydown', (event) => event.preventDefault());
+    document.body.append(input);
+    input.focus();
+
+    pressEnter(input);
+    expect(document.activeElement).toBe(input);
+    expect(hideKeyboard).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('Enter в textarea и во время набора через IME ничего не делает', () => {
+    const hideKeyboard = vi.fn();
+    const stop = installDoneKey({ hideKeyboard });
+    const area = document.createElement('textarea');
+    const input = document.createElement('input');
+    document.body.append(area, input);
+
+    area.focus();
+    pressEnter(area);
+    expect(document.activeElement).toBe(area);
+
+    input.focus();
+    pressEnter(input, { isComposing: true });
+    expect(document.activeElement).toBe(input);
+    expect(hideKeyboard).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('другие клавиши фокус не снимают', () => {
+    const hideKeyboard = vi.fn();
+    const stop = installDoneKey({ hideKeyboard });
+    const input = document.createElement('input');
+    document.body.append(input);
+    input.focus();
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    expect(document.activeElement).toBe(input);
+    expect(hideKeyboard).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('после остановки больше не вмешивается', () => {
+    const hideKeyboard = vi.fn();
+    const stop = installDoneKey({ hideKeyboard });
+    stop();
+    const input = document.createElement('input');
+    document.body.append(input);
+    input.focus();
+    pressEnter(input);
+    expect(document.activeElement).toBe(input);
+    expect(hideKeyboard).not.toHaveBeenCalled();
+  });
+});
+
+describe('isTouchOnly', () => {
+  it('телефон и планшет — да, ноутбук с мышью — нет, без matchMedia — нет', () => {
+    const phone = (query: string) => ({ matches: query === '(hover: none) and (pointer: coarse)' });
+    const laptop = () => ({ matches: false });
+    expect(isTouchOnly(phone)).toBe(true);
+    expect(isTouchOnly(laptop)).toBe(false);
+    expect(isTouchOnly(undefined)).toBe(false);
+  });
+});

--- a/src/utils/doneKey.ts
+++ b/src/utils/doneKey.ts
@@ -1,0 +1,97 @@
+/**
+ * Клавиша «Готово» на экранной клавиатуре.
+ *
+ * У экранной клавиатуры на телефоне нет своей кнопки «скрыть», а в Mini App
+ * Telegram нет и родной панели iOS с «Готово» над клавиатурой — её показывает
+ * не страница, а WebView. Поэтому на всех однострочных полях клавиша ввода
+ * подписывается «Готово» (enterkeyhint) и закрывает клавиатуру: поле теряет
+ * фокус, а платформа получает шанс спрятать клавиатуру сама (Telegram —
+ * hideKeyboard(), Bot API 9.1+). Многострочные поля не трогаем: там Enter
+ * переносит строку. Поле, которое само обработало Enter (preventDefault —
+ * «добавить ещё один», «отправить»), клавиатуру не теряет.
+ */
+export const DONE_HINT = 'done';
+
+/** Устройства без указателя-мыши: только там есть экранная клавиатура. */
+export const TOUCH_ONLY_QUERY = '(hover: none) and (pointer: coarse)';
+
+const NON_TEXT_INPUT_TYPES: ReadonlySet<string> = new Set([
+  'button',
+  'submit',
+  'reset',
+  'checkbox',
+  'radio',
+  'file',
+  'range',
+  'color',
+  'hidden',
+  'image',
+]);
+
+export function isSingleLineTextEntry(target: EventTarget | null): target is HTMLInputElement {
+  return target instanceof HTMLInputElement && !NON_TEXT_INPUT_TYPES.has(target.type);
+}
+
+function stamp(input: HTMLInputElement): void {
+  if (!isSingleLineTextEntry(input) || input.hasAttribute('enterkeyhint')) return;
+  input.setAttribute('enterkeyhint', DONE_HINT);
+}
+
+/** Подписать «Готово» полям внутри узла (или самому полю), у которых нет своей подсказки. */
+export function stampEnterKeyHint(root: Node): void {
+  if (root instanceof HTMLInputElement) {
+    stamp(root);
+    return;
+  }
+  if (root instanceof Element || root instanceof Document || root instanceof DocumentFragment) {
+    root.querySelectorAll('input').forEach(stamp);
+  }
+}
+
+export function shouldDismissOnEnter(event: KeyboardEvent): boolean {
+  return (
+    event.key === 'Enter' &&
+    !event.isComposing &&
+    !event.defaultPrevented &&
+    isSingleLineTextEntry(event.target)
+  );
+}
+
+type MatchMedia = (query: string) => { matches: boolean };
+
+export function isTouchOnly(matchMedia: MatchMedia | undefined): boolean {
+  return matchMedia?.(TOUCH_ONLY_QUERY).matches ?? false;
+}
+
+export interface DoneKeyOptions {
+  /** Спрятать клавиатуру средствами платформы; в браузере достаточно потери фокуса. */
+  hideKeyboard: () => void;
+  root?: Document;
+}
+
+/**
+ * Включить «Готово» на всей странице: подписать уже существующие поля, следить
+ * за новыми и закрывать клавиатуру по Enter. Возвращает функцию отключения.
+ */
+export function installDoneKey({ hideKeyboard, root = document }: DoneKeyOptions): () => void {
+  stampEnterKeyHint(root);
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      record.addedNodes.forEach(stampEnterKeyHint);
+    }
+  });
+  observer.observe(root.documentElement, { childList: true, subtree: true });
+
+  const onKeyDown = (event: KeyboardEvent): void => {
+    const field = event.target;
+    if (!isSingleLineTextEntry(field) || !shouldDismissOnEnter(event)) return;
+    field.blur();
+    hideKeyboard();
+  };
+  root.addEventListener('keydown', onKeyDown);
+
+  return () => {
+    observer.disconnect();
+    root.removeEventListener('keydown', onKeyDown);
+  };
+}


### PR DESCRIPTION
## Что сделано

**Нижняя панель только на экранах своих кнопок, плашки не всплывают над клавиатурой.** Панель навигации показывается на `/`, `/subscriptions`, `/balance`, `/support` и в слоте `/wheel` | `/referral` (`src/components/layout/AppShell/mobileNavRoutes.ts`); AppShell ставит `data-mobile-nav="on|off"`, при `off` просвет под контентом снимается (`--mobile-nav-clearance`). Сигнал экранной клавиатуры вынесен в `useVirtualKeyboard` (useSyncExternalStore, сброс на смене маршрута); по нему прячутся MobileBottomNav, LaunchBar, FleetActionBar и FloatingActionBar — после `contain: style` на `<main>` в 1.70.0 плашки BSCHEKER всплывали над клавиатурой в Mini App.

**Клавиша «Готово» на экранной клавиатуре.** На тач-устройствах все однострочные поля получают `enterkeyhint="done"` (`src/utils/doneKey.ts`, MutationObserver подхватывает новые поля); Enter снимает фокус и прячет клавиатуру через новый `platform.hideKeyboard()` (Telegram — SDK `hideKeyboard`, Bot API 9.1+; веб — no-op). Textarea и поля со своим обработчиком Enter не трогаются.

**Причины отказа по устройствам из локали, срок действия на своей строке.** «Already at minimum device limit» и другие фразы бота заменены кодами `reason_code` → `src/components/subscription/deviceReasons.ts` и ключи `subscription.additionalOptions.reasons.*` в четырёх локалях. Дата «Действует до» под таймером на телефоне переносится на свою строку (`flex-col gap-1 sm:flex-row`).

**Пометка «Задано в .env» в настройках партнёрки и тикетов.** Бот отдаёт `env_locked`; `EnvLockedBadge` помечает такие поля, AdminPartnerSettings и AdminTicketSettings их отключают — галочка больше не «возвращается» молча. Если ключ стоит в .env, кабинет честно говорит об этом вместо ложного сохранения.

**Суточная цена с промокодом считается одной функцией.** Сервер теперь отдаёт цену только со скидкой группы; `combinePromoDiscount` (чистая часть `usePromoDiscount`) и `dailyPriceQuote` дают одну цифру на карточке тарифа, экране активации и в шторке смены — промокод 20 % больше не показывался как −36 %.

**Проверка:** CI на `dev` зелёный (tsc, biome, vitest 848 в 129 файлах на Node 24 и 26; Security Audit, CodeQL). Рендер в WebKit пробами на рабочем дереве: панель и просвет по маршрутам, «Готово» тач/десктоп, дата под таймером 390/820, карточка и активация суточного тарифа с промокодом 20 %. Требует бот с `reason_code`, `env_locked` и суточной ценой без промокода — BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#3222.

---

Тестировать не нужно
