### PR TITLE
Хотфикс: нижняя панель остаётся на карточке подписки

### DIFF
--- a/src/components/layout/AppShell/mobileNavRoutes.test.ts
+++ b/src/components/layout/AppShell/mobileNavRoutes.test.ts
@@ -55,9 +55,22 @@ describe('isMobileNavScreen', () => {
   });
 
   it('админка и вложенные страницы — нет', () => {
-    for (const path of ['/admin', '/admin/reachability', '/subscriptions/12', '/balance/top-up']) {
+    for (const path of ['/admin', '/admin/reachability', '/balance/top-up']) {
       expect(isMobileNavScreen(path, items), path).toBe(false);
     }
+  });
+
+  it('карточка подписки — да: кнопка «Подписка» приводит именно сюда', () => {
+    // Список с единственной подпиской сам открывает её карточку, так что человек
+    // нажимает кнопку панели и оказывается здесь. Пропадающая панель на этом
+    // экране и была багом.
+    expect(isMobileNavScreen('/subscriptions/12', items)).toBe(true);
+    expect(isMobileNavScreen('/subscriptions/12/', items)).toBe(true);
+  });
+
+  it('но продление изнутри карточки — уже нет', () => {
+    expect(isMobileNavScreen('/subscriptions/12/renew', items)).toBe(false);
+    expect(isMobileNavScreen('/subscription/purchase', items)).toBe(false);
   });
 
   it('экран выключенного слота — нет', () => {

--- a/src/components/layout/AppShell/mobileNavRoutes.ts
+++ b/src/components/layout/AppShell/mobileNavRoutes.ts
@@ -50,8 +50,19 @@ function withoutTrailingSlash(pathname: string): string {
   return pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
 }
 
-/** Точное совпадение с экраном кнопки: детали подписки или пополнение — уже не экран панели. */
+/**
+ * Экраны, куда кнопка панели приводит не напрямую.
+ *
+ * «Подписка» ведёт на список, а список с единственной подпиской сам открывает её
+ * карточку (Subscriptions.tsx). Для клиента это и есть экран кнопки: он нажал
+ * «Подписка» и оказался здесь — панель пропадать не должна. Продление и покупка
+ * сюда не попадают: туда уходят уже изнутри карточки.
+ */
+const NAV_SCREEN_PATTERNS: readonly RegExp[] = [/^\/subscriptions\/\d+$/];
+
+/** Экран кнопки: сам путь пункта или то, во что он разворачивается. */
 export function isMobileNavScreen(pathname: string, items: readonly MobileNavItem[]): boolean {
   const path = withoutTrailingSlash(pathname);
-  return items.some((item) => item.path === path);
+  if (items.some((item) => item.path === path)) return true;
+  return NAV_SCREEN_PATTERNS.some((pattern) => pattern.test(path));
 }


### PR DESCRIPTION
Хотфикс `dev` → `main`. Тестировать не нужно.

## Нижняя панель пропадала на карточке подписки

Из отчёта: нажимаешь «Подписка» в нижней панели или заходишь в управление подпиской — и панель исчезает прямо под пальцем.

В прошлом релизе появилось правило «панель живёт только на экранах, куда ведут её кнопки». Правило сравнивало адрес точно, а кнопка «Подписка» ведёт на список, который при единственной подписке сам открывает её карточку. Карточка под правило не подходила, и панель пропадала на экране, куда сама же и привела.

Экран кнопки теперь определяется не только её собственным адресом, но и тем, во что этот адрес разворачивается. Продление и покупка остаются вложенными: туда уходят уже изнутри карточки, и там панели по-прежнему нет.

Остальные пункты панели проверены — никуда не перебрасывают, случай единственный.

Проверено рендером в WebKit: нажатие «Подписка» → карточка, панель на месте и просвет под неё зарезервирован; на экране продления панели нет.

---

Бот: BEDOLAGA-DEV/remnawave-bedolaga-telegram-bot#3225
